### PR TITLE
submission: fibonacci/Aiken_1.1.17_KtorZ

### DIFF
--- a/submissions/fibonacci/Aiken_1.1.17_KtorZ/README.md
+++ b/submissions/fibonacci/Aiken_1.1.17_KtorZ/README.md
@@ -1,0 +1,29 @@
+# Benchmark Implementation Notes
+
+**Scenario**: `fibonacci`
+**Submission ID**: `Aiken_1.1.17_KtorZ`
+
+## Implementation Details
+
+- **Compiler**: `Aiken v1.1.17`
+- **Implementation Approach**: `recursive`
+- **Compilation Flags**: N/A
+
+## Performance Results
+
+- CPU Units: `155308959218`
+- Memory Units: `559619722`
+- Script Size (bytes): `87`
+- Term Size: `81`
+
+## Reproducibility
+
+- **Source Available**: `true`
+- **Source Repository**: `https://github.com/cardano-scaling/UPLC-CAPE`
+- **Compilation Config**: None
+
+## Notes
+
+Most simple / idiomatic implementation I could think of; no particular attempt at optimizing anything.
+
+Use `aiken export` to obtain the raw UPLC for the function; however, I ended up manually removing the Data wrapping / unwrapping which the `export` command adds by default; since Data is used as the primary interface.

--- a/submissions/fibonacci/Aiken_1.1.17_KtorZ/config.json
+++ b/submissions/fibonacci/Aiken_1.1.17_KtorZ/config.json
@@ -1,0 +1,6 @@
+{
+  "comment": "Optional: Include compilation parameters that affect UPLC output",
+  "optimization_flags": [],
+  "compiler_settings": {},
+  "build_environment": {}
+}

--- a/submissions/fibonacci/Aiken_1.1.17_KtorZ/fibonacci.uplc
+++ b/submissions/fibonacci/Aiken_1.1.17_KtorZ/fibonacci.uplc
@@ -1,0 +1,103 @@
+(program
+  1.1.0
+  [
+    (lam
+      i_0
+      [
+        [
+          (lam
+            i_1
+            (lam
+              i_2
+              (force
+                (case
+                  (constr
+                    0
+                    [ [ (builtin lessThanEqualsInteger) i_2 ] (con integer 1) ]
+                    (delay i_2)
+                    (delay
+                      [
+                        (lam
+                          i_3
+                          [
+                            (lam
+                              i_4
+                              [
+                                [
+                                  (builtin addInteger)
+                                  [
+                                    i_4
+                                    [
+                                      [ (builtin addInteger) i_2 ]
+                                      (con integer -1)
+                                    ]
+                                  ]
+                                ]
+                                [
+                                  i_4
+                                  [
+                                    [ (builtin addInteger) i_2 ]
+                                    (con integer -2)
+                                  ]
+                                ]
+                              ]
+                            )
+                            [ i_3 i_3 ]
+                          ]
+                        )
+                        (lam
+                          i_5
+                          (lam
+                            i_6
+                            (force
+                              (case
+                                (constr
+                                  0
+                                  [
+                                    [ (builtin lessThanEqualsInteger) i_6 ]
+                                    (con integer 1)
+                                  ]
+                                  (delay i_6)
+                                  (delay
+                                    [
+                                      [
+                                        (builtin addInteger)
+                                        [
+                                          [ i_5 i_5 ]
+                                          [
+                                            [ (builtin addInteger) i_6 ]
+                                            (con integer -1)
+                                          ]
+                                        ]
+                                      ]
+                                      [
+                                        [ i_5 i_5 ]
+                                        [
+                                          [ (builtin addInteger) i_6 ]
+                                          (con integer -2)
+                                        ]
+                                      ]
+                                    ]
+                                  )
+                                )
+                                i_1
+                              )
+                            )
+                          )
+                        )
+                      ]
+                    )
+                  )
+                  i_1
+                )
+              )
+            )
+          )
+          (force (builtin ifThenElse))
+        ]
+	i_0
+      ]
+    )
+    (con integer 25)
+  ]
+)

--- a/submissions/fibonacci/Aiken_1.1.17_KtorZ/metadata.json
+++ b/submissions/fibonacci/Aiken_1.1.17_KtorZ/metadata.json
@@ -1,0 +1,25 @@
+{
+  "compiler": {
+    "name": "Aiken",
+    "version": "1.1.17",
+    "commit_hash": "c3a7fba28232341dd5b3e60854c99a6f2c2a6c77"
+  },
+  "compilation_config": {
+    "optimization_level": "N/A",
+    "target": "uplc",
+    "flags": [],
+    "environment": {
+      "dependencies": {}
+    }
+  },
+  "contributor": {
+    "name": "KtorZ",
+    "organization": "Cardano Foundation"
+  },
+  "submission": {
+    "date": "2025-07-24T19:35:38.551Z",
+    "source_available": true,
+    "source_repository": "https://github.com/cardano-scaling/UPLC-CAPE",
+    "implementation_notes": "Most simple / idiomatic implementation I could think of; no particular attempt at optimizing anything.\n\nUse `aiken export` to obtain the raw UPLC for the function; however, I ended up manually removing the Data wrapping / unwrapping which the `export` command adds by default; since Data is used as the primary interface."
+  }
+}

--- a/submissions/fibonacci/Aiken_1.1.17_KtorZ/metrics.json
+++ b/submissions/fibonacci/Aiken_1.1.17_KtorZ/metrics.json
@@ -1,0 +1,16 @@
+{
+  "scenario": "fibonacci",
+  "version": "1.0.0",
+  "measurements": {
+    "cpu_units": 155308959218,
+    "memory_units": 559619722,
+    "script_size_bytes": 87,
+    "term_size": 81
+  },
+  "execution_environment": {
+    "evaluator": "Aiken",
+    "protocol_version": "plutus-core-1.1.0"
+  },
+  "timestamp": "2025-07-24T19:35:38.551Z",
+  "notes": "The 'term_size' is only a best-effort in the sense that I do not know how this is typically calculated within the Plinthe codebase."
+}

--- a/submissions/fibonacci/Aiken_1.1.17_KtorZ/source/.gitkeep
+++ b/submissions/fibonacci/Aiken_1.1.17_KtorZ/source/.gitkeep
@@ -1,0 +1,1 @@
+# Optional: Place your source code files here

--- a/submissions/fibonacci/Aiken_1.1.17_KtorZ/source/fib.ak
+++ b/submissions/fibonacci/Aiken_1.1.17_KtorZ/source/fib.ak
@@ -1,0 +1,7 @@
+pub fn fibonacci(n: Int) -> Int {
+  if n <= 1 {
+    n
+  } else {
+    fibonacci(n - 1) + fibonacci(n - 2)
+  }
+}


### PR DESCRIPTION
Small additional notes:

- It's unclear how the _term size_ is expected to be calculated; I've tried looking up the implementation in the Plutus codebase but I simply cannot make sense of how this is computed. So as a best-effort, I've added a function within Aiken that counts the term's nodes in _what I assume is the expected way_. 

- Having the metadata both in the README and the metadata.json / metrics.json feels somewhat redundant. It would be nice to generate the README from the structured ones; as a github workflow for example, when those are changing. 

- Nice work on the setup, instructions and validation tools; I hope I got this right :) 
