### PR TITLE
docs(readme): update available benchmark scenarios and links

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A standardized benchmarking framework for measuring and comparing the on-chain p
   - [Setup](#setup)
   - [Your first benchmark](#your-first-benchmark)
 - [Live Performance Reports](#live-performance-reports)
-- [Available Benchmarks](#available-benchmarks)
+- [Available benchmark scenarios](#available-benchmark-scenarios)
 - [Usage (CLI)](#usage-cli)
   - [Core commands](#core-commands)
   - [Interactive prompts](#interactive-prompts)
@@ -96,11 +96,12 @@ Latest benchmark reports: [UPLC-CAPE Reports](https://intersectmbo.github.io/UPL
 
 ---
 
-## Available Benchmarks
+## Available benchmark scenarios
 
 | Benchmark | Type | Description | Status |
 | --- | --- | --- | --- |
 | [Fibonacci](scenarios/fibonacci.md) | Synthetic | Recursive algorithm performance | Ready |
+| [Factorial](scenarios/factorial.md) | Synthetic | Recursive algorithm performance | Ready |
 | Two-Party Escrow | Real-world | Smart contract scenario | Planned |
 | Streaming Payments | Real-world | Payment channel implementation | Planned |
 | Simple DAO Voting | Real-world | Governance mechanism | Planned |
@@ -110,7 +111,7 @@ Latest benchmark reports: [UPLC-CAPE Reports](https://intersectmbo.github.io/UPL
 
 ## Usage (CLI)
 
-For the full and up-to-date command reference, see USAGE.md at the project root.
+For the full and up-to-date command reference, see [USAGE.md](USAGE.md).
 
 ### Core commands
 


### PR DESCRIPTION
## Summary
Update README to reflect current scenarios and improve intra-repo links.

## Changes
- Rename “Available Benchmarks” to “Available benchmark scenarios” (and update TOC link)
- Add Factorial scenario row linking to `scenarios/factorial.md`
- Convert plain `USAGE.md` mention to a proper Markdown link

## Rationale
Keeps documentation accurate as new scenarios are added and ensures links render properly on GitHub Pages and in the repository.

## Affected files
- README.md

## Verification
- Rendered README locally to confirm anchors and links:
  - [scenarios/fibonacci.md](scenarios/fibonacci.md)
  - [scenarios/factorial.md](scenarios/factorial.md)
  - [USAGE.md](USAGE.md)
  - [CONTRIBUTING.md](CONTRIBUTING.md)
  - [LICENSE](LICENSE)

## Checklist
- [x] Docs updated
- [x] Links verified
- [x] No code changes

---
No functional changes; documentation only.