### PR TITLE
fix(nix): add HLS wrapper scripts for GHC 9.6.6 compatibility

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -185,6 +185,15 @@
             plcMusl
             pirMusl
             plutusMusl
+
+            # HLS wrapper scripts for GHC 9.6.6 compatibility
+            (writeShellScriptBin "haskell-language-server-wrapper" ''
+              exec ${pkgs.haskell.packages.ghc966.haskell-language-server}/bin/haskell-language-server "$@"
+            '')
+
+            (writeShellScriptBin "haskell-language-server-9.6.6" ''
+              exec ${pkgs.haskell.packages.ghc966.haskell-language-server}/bin/haskell-language-server "$@"
+            '')
           ];
 
           shellHook = ''


### PR DESCRIPTION
## Summary

- Add `haskell-language-server-wrapper` pointing to GHC 9.6.6 HLS version
- Add explicit `haskell-language-server-9.6.6` wrapper as alternative
- Fixes HLS compatibility issues in nix development shell

## Problem

The existing HLS setup was looking for `haskell-language-server-9.6.6` but only had access to a different version, causing LSP failures in editors.

## Solution

Created wrapper scripts that explicitly reference the GHC 9.6.6-compatible HLS binary from the nix packages, ensuring both the generic wrapper and version-specific wrapper work correctly.

🤖 Generated with [Claude Code](https://claude.ai/code)