### PR TITLE
fix(reports): properly filter base/open mode submissions in HTML index pages

### DIFF
--- a/report/base/benchmarks/factorial.html
+++ b/report/base/benchmarks/factorial.html
@@ -206,7 +206,7 @@
     </div>
 
     <div class="timestamp">
-        Generated on: 2025-10-07 15:44:35 CEST
+        Generated on: 2025-10-07 17:51:03 CEST
     </div>
     
     <div class="benchmark-section">

--- a/report/base/benchmarks/fibonacci.html
+++ b/report/base/benchmarks/fibonacci.html
@@ -206,7 +206,7 @@
     </div>
 
     <div class="timestamp">
-        Generated on: 2025-10-07 15:44:40 CEST
+        Generated on: 2025-10-07 17:51:07 CEST
     </div>
     
     <div class="benchmark-section">

--- a/report/base/index.html
+++ b/report/base/index.html
@@ -294,7 +294,7 @@
     
 
     <div class="timestamp">
-        Generated on: 2025-10-07 15:44:42 CEST
+        Generated on: 2025-10-07 17:51:09 CEST
     </div>
     
     <!-- Benchmark Summary Table -->
@@ -315,7 +315,7 @@
                     </div>
                     <div class="count">
                         
-                            (4 submissions)
+                            (2 submissions)
                         
                     </div>
                 </div>
@@ -343,39 +343,18 @@
                                 <td>2025-09-12</td>
                                 <td class="numeric">
                                     <span class="tooltip">
-                                        <span class="cpu-value best-value">28.02M</span>
+                                        <span class="cpu-value">28.02M</span>
                                         <span class="tooltiptext">28019280</span>
                                     </span>
                                 </td>
                                 <td class="numeric">
                                     <span class="tooltip">
-                                        <span class="memory-value best-value">107.23K</span>
+                                        <span class="memory-value">107.23K</span>
                                         <span class="tooltiptext">107235</span>
                                     </span>
                                 </td>
-                                <td class="numeric script-value best-value">34</td>
-                                <td class="numeric term-value best-value">27</td>
-                            </tr>
-                            
-                            <tr data-cpu="37481975" data-memory="140290" data-script="40" data-term="33">
-                                <td>plutarch</td>
-                                <td>1.11.1</td>
-                                <td>SeungheonOh</td>
-                                <td>2025-09-12</td>
-                                <td class="numeric">
-                                    <span class="tooltip">
-                                        <span class="cpu-value">37.48M</span>
-                                        <span class="tooltiptext">37481975</span>
-                                    </span>
-                                </td>
-                                <td class="numeric">
-                                    <span class="tooltip">
-                                        <span class="memory-value">140.29K</span>
-                                        <span class="tooltiptext">140290</span>
-                                    </span>
-                                </td>
-                                <td class="numeric script-value">40</td>
-                                <td class="numeric term-value">33</td>
+                                <td class="numeric script-value">34</td>
+                                <td class="numeric term-value">27</td>
                             </tr>
                             
                             <tr data-cpu="44601975" data-memory="184790" data-script="58" data-term="57">
@@ -399,27 +378,6 @@
                                 <td class="numeric term-value">57</td>
                             </tr>
                             
-                            <tr data-cpu="50249063" data-memory="214106" data-script="81" data-term="82">
-                                <td>Scalus</td>
-                                <td>0.12.0</td>
-                                <td>Unisay</td>
-                                <td>2025-10-07</td>
-                                <td class="numeric">
-                                    <span class="tooltip">
-                                        <span class="cpu-value">50.25M</span>
-                                        <span class="tooltiptext">50249063</span>
-                                    </span>
-                                </td>
-                                <td class="numeric">
-                                    <span class="tooltip">
-                                        <span class="memory-value">214.11K</span>
-                                        <span class="tooltiptext">214106</span>
-                                    </span>
-                                </td>
-                                <td class="numeric script-value">81</td>
-                                <td class="numeric term-value">82</td>
-                            </tr>
-                            
                         </tbody>
                     </table>
                     
@@ -434,7 +392,7 @@
                     </div>
                     <div class="count">
                         
-                            (5 submissions)
+                            (4 submissions)
                         
                     </div>
                 </div>
@@ -493,8 +451,8 @@
                                         <span class="tooltiptext">481520743</span>
                                     </span>
                                 </td>
-                                <td class="numeric script-value best-value">43</td>
-                                <td class="numeric term-value best-value">36</td>
+                                <td class="numeric script-value">43</td>
+                                <td class="numeric term-value">36</td>
                             </tr>
                             
                             <tr data-cpu="175016233630" data-memory="641939062" data-script="47" data-term="41">
@@ -537,83 +495,6 @@
                                 </td>
                                 <td class="numeric script-value">77</td>
                                 <td class="numeric term-value">77</td>
-                            </tr>
-                            
-                            <tr data-cpu="81367848" data-memory="345184" data-script="98" data-term="101">
-                                <td>Scalus</td>
-                                <td>0.12.0</td>
-                                <td>Unisay</td>
-                                <td>2025-10-07</td>
-                                <td class="numeric">
-                                    <span class="tooltip">
-                                        <span class="cpu-value best-value">81.37M</span>
-                                        <span class="tooltiptext">81367848</span>
-                                    </span>
-                                </td>
-                                <td class="numeric">
-                                    <span class="tooltip">
-                                        <span class="memory-value best-value">345.18K</span>
-                                        <span class="tooltiptext">345184</span>
-                                    </span>
-                                </td>
-                                <td class="numeric script-value">98</td>
-                                <td class="numeric term-value">101</td>
-                            </tr>
-                            
-                        </tbody>
-                    </table>
-                    
-                </div>
-            </div>
-            
-            <div class="benchmark-section">
-                <div class="benchmark-header" onclick="toggleBenchmark('two-party-escrow')">
-                    <div class="name">
-                        <span class="toggle" id="toggle-two-party-escrow">▶</span>
-                        <a href="benchmarks/two-party-escrow.html" onclick="event.stopPropagation()">two-party-escrow</a>
-                    </div>
-                    <div class="count">
-                        
-                            (1 submission)
-                        
-                    </div>
-                </div>
-                <div class="benchmark-content" id="content-two-party-escrow">
-                    
-                    <table class="submission-table" id="table-two-party-escrow">
-                        <thead>
-                            <tr>
-                                <th onclick="sortTable('two-party-escrow', 0)">Compiler</th>
-                                <th onclick="sortTable('two-party-escrow', 1)">Version</th>
-                                <th onclick="sortTable('two-party-escrow', 2)">Author</th>
-                                <th onclick="sortTable('two-party-escrow', 3)">Date</th>
-                                <th class="numeric" onclick="sortTable('two-party-escrow', 4)">CPU Units</th>
-                                <th class="numeric" onclick="sortTable('two-party-escrow', 5)">Memory Units</th>
-                                <th class="numeric" onclick="sortTable('two-party-escrow', 6)">Script Size</th>
-                                <th class="numeric" onclick="sortTable('two-party-escrow', 7)">Term Size</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            
-                            <tr data-cpu="1494176868" data-memory="6372891" data-script="3233" data-term="3232">
-                                <td>Plinth</td>
-                                <td>1.53.0.0</td>
-                                <td>Unisay</td>
-                                <td>2025-09-12</td>
-                                <td class="numeric">
-                                    <span class="tooltip">
-                                        <span class="cpu-value best-value">1.49B</span>
-                                        <span class="tooltiptext">1494176868</span>
-                                    </span>
-                                </td>
-                                <td class="numeric">
-                                    <span class="tooltip">
-                                        <span class="memory-value best-value">6.37M</span>
-                                        <span class="tooltiptext">6372891</span>
-                                    </span>
-                                </td>
-                                <td class="numeric script-value best-value">3233</td>
-                                <td class="numeric term-value best-value">3232</td>
                             </tr>
                             
                         </tbody>

--- a/report/index.html
+++ b/report/index.html
@@ -221,7 +221,7 @@
     </div>
 
     <div class="timestamp">
-        Generated on: 2025-10-07 15:44:57 CEST
+        Generated on: 2025-10-07 17:51:17 CEST
     </div>
 
     <div class="mode-section">

--- a/report/open/benchmarks/factorial.html
+++ b/report/open/benchmarks/factorial.html
@@ -206,7 +206,7 @@
     </div>
 
     <div class="timestamp">
-        Generated on: 2025-10-07 15:44:46 CEST
+        Generated on: 2025-10-07 17:51:11 CEST
     </div>
     
     <div class="benchmark-section">

--- a/report/open/benchmarks/fibonacci.html
+++ b/report/open/benchmarks/fibonacci.html
@@ -206,7 +206,7 @@
     </div>
 
     <div class="timestamp">
-        Generated on: 2025-10-07 15:44:50 CEST
+        Generated on: 2025-10-07 17:51:13 CEST
     </div>
     
     <div class="benchmark-section">

--- a/report/open/benchmarks/two-party-escrow.html
+++ b/report/open/benchmarks/two-party-escrow.html
@@ -206,7 +206,7 @@
     </div>
 
     <div class="timestamp">
-        Generated on: 2025-10-07 15:44:55 CEST
+        Generated on: 2025-10-07 17:51:15 CEST
     </div>
     
     <div class="benchmark-section">

--- a/report/open/index.html
+++ b/report/open/index.html
@@ -294,7 +294,7 @@
     
 
     <div class="timestamp">
-        Generated on: 2025-10-07 15:44:56 CEST
+        Generated on: 2025-10-07 17:51:17 CEST
     </div>
     
     <!-- Benchmark Summary Table -->
@@ -315,7 +315,7 @@
                     </div>
                     <div class="count">
                         
-                            (4 submissions)
+                            (2 submissions)
                         
                     </div>
                 </div>
@@ -336,27 +336,6 @@
                         </thead>
                         <tbody>
                             
-                            <tr data-cpu="28019280" data-memory="107235" data-script="34" data-term="27">
-                                <td>Plinth</td>
-                                <td>1.53.0.0</td>
-                                <td>Unisay</td>
-                                <td>2025-09-12</td>
-                                <td class="numeric">
-                                    <span class="tooltip">
-                                        <span class="cpu-value best-value">28.02M</span>
-                                        <span class="tooltiptext">28019280</span>
-                                    </span>
-                                </td>
-                                <td class="numeric">
-                                    <span class="tooltip">
-                                        <span class="memory-value best-value">107.23K</span>
-                                        <span class="tooltiptext">107235</span>
-                                    </span>
-                                </td>
-                                <td class="numeric script-value best-value">34</td>
-                                <td class="numeric term-value best-value">27</td>
-                            </tr>
-                            
                             <tr data-cpu="37481975" data-memory="140290" data-script="40" data-term="33">
                                 <td>plutarch</td>
                                 <td>1.11.1</td>
@@ -376,27 +355,6 @@
                                 </td>
                                 <td class="numeric script-value">40</td>
                                 <td class="numeric term-value">33</td>
-                            </tr>
-                            
-                            <tr data-cpu="44601975" data-memory="184790" data-script="58" data-term="57">
-                                <td>Scalus</td>
-                                <td>0.12.0</td>
-                                <td>Unisay</td>
-                                <td>2025-10-07</td>
-                                <td class="numeric">
-                                    <span class="tooltip">
-                                        <span class="cpu-value">44.60M</span>
-                                        <span class="tooltiptext">44601975</span>
-                                    </span>
-                                </td>
-                                <td class="numeric">
-                                    <span class="tooltip">
-                                        <span class="memory-value">184.79K</span>
-                                        <span class="tooltiptext">184790</span>
-                                    </span>
-                                </td>
-                                <td class="numeric script-value">58</td>
-                                <td class="numeric term-value">57</td>
                             </tr>
                             
                             <tr data-cpu="50249063" data-memory="214106" data-script="81" data-term="82">
@@ -434,7 +392,7 @@
                     </div>
                     <div class="count">
                         
-                            (5 submissions)
+                            (1 submission)
                         
                     </div>
                 </div>
@@ -455,90 +413,6 @@
                         </thead>
                         <tbody>
                             
-                            <tr data-cpu="170746089630" data-memory="615250662" data-script="86" data-term="79">
-                                <td>Aiken</td>
-                                <td>1.1.17</td>
-                                <td>KtorZ</td>
-                                <td>2025-09-12</td>
-                                <td class="numeric">
-                                    <span class="tooltip">
-                                        <span class="cpu-value">170.75B</span>
-                                        <span class="tooltiptext">170746089630</span>
-                                    </span>
-                                </td>
-                                <td class="numeric">
-                                    <span class="tooltip">
-                                        <span class="memory-value">615.25M</span>
-                                        <span class="tooltiptext">615250662</span>
-                                    </span>
-                                </td>
-                                <td class="numeric script-value">86</td>
-                                <td class="numeric term-value">79</td>
-                            </tr>
-                            
-                            <tr data-cpu="129093086599" data-memory="481520743" data-script="43" data-term="36">
-                                <td>Plinth</td>
-                                <td>1.53.0.0</td>
-                                <td>Unisay</td>
-                                <td>2025-09-12</td>
-                                <td class="numeric">
-                                    <span class="tooltip">
-                                        <span class="cpu-value">129.09B</span>
-                                        <span class="tooltiptext">129093086599</span>
-                                    </span>
-                                </td>
-                                <td class="numeric">
-                                    <span class="tooltip">
-                                        <span class="memory-value">481.52M</span>
-                                        <span class="tooltiptext">481520743</span>
-                                    </span>
-                                </td>
-                                <td class="numeric script-value best-value">43</td>
-                                <td class="numeric term-value best-value">36</td>
-                            </tr>
-                            
-                            <tr data-cpu="175016233630" data-memory="641939062" data-script="47" data-term="41">
-                                <td>Plutarch</td>
-                                <td>1.11.1</td>
-                                <td>Seungheon Oh</td>
-                                <td>2025-09-12</td>
-                                <td class="numeric">
-                                    <span class="tooltip">
-                                        <span class="cpu-value">175.02B</span>
-                                        <span class="tooltiptext">175016233630</span>
-                                    </span>
-                                </td>
-                                <td class="numeric">
-                                    <span class="tooltip">
-                                        <span class="memory-value">641.94M</span>
-                                        <span class="tooltiptext">641939062</span>
-                                    </span>
-                                </td>
-                                <td class="numeric script-value">47</td>
-                                <td class="numeric term-value">41</td>
-                            </tr>
-                            
-                            <tr data-cpu="171532323770" data-memory="685972690" data-script="77" data-term="77">
-                                <td>Scalus</td>
-                                <td>0.12.0</td>
-                                <td>Unisay</td>
-                                <td>2025-10-07</td>
-                                <td class="numeric">
-                                    <span class="tooltip">
-                                        <span class="cpu-value">171.53B</span>
-                                        <span class="tooltiptext">171532323770</span>
-                                    </span>
-                                </td>
-                                <td class="numeric">
-                                    <span class="tooltip">
-                                        <span class="memory-value">685.97M</span>
-                                        <span class="tooltiptext">685972690</span>
-                                    </span>
-                                </td>
-                                <td class="numeric script-value">77</td>
-                                <td class="numeric term-value">77</td>
-                            </tr>
-                            
                             <tr data-cpu="81367848" data-memory="345184" data-script="98" data-term="101">
                                 <td>Scalus</td>
                                 <td>0.12.0</td>
@@ -546,13 +420,13 @@
                                 <td>2025-10-07</td>
                                 <td class="numeric">
                                     <span class="tooltip">
-                                        <span class="cpu-value best-value">81.37M</span>
+                                        <span class="cpu-value">81.37M</span>
                                         <span class="tooltiptext">81367848</span>
                                     </span>
                                 </td>
                                 <td class="numeric">
                                     <span class="tooltip">
-                                        <span class="memory-value best-value">345.18K</span>
+                                        <span class="memory-value">345.18K</span>
                                         <span class="tooltiptext">345184</span>
                                     </span>
                                 </td>
@@ -602,18 +476,18 @@
                                 <td>2025-09-12</td>
                                 <td class="numeric">
                                     <span class="tooltip">
-                                        <span class="cpu-value best-value">1.49B</span>
+                                        <span class="cpu-value">1.49B</span>
                                         <span class="tooltiptext">1494176868</span>
                                     </span>
                                 </td>
                                 <td class="numeric">
                                     <span class="tooltip">
-                                        <span class="memory-value best-value">6.37M</span>
+                                        <span class="memory-value">6.37M</span>
                                         <span class="tooltiptext">6372891</span>
                                     </span>
                                 </td>
-                                <td class="numeric script-value best-value">3233</td>
-                                <td class="numeric term-value best-value">3232</td>
+                                <td class="numeric script-value">3233</td>
+                                <td class="numeric term-value">3232</td>
                             </tr>
                             
                         </tbody>

--- a/scripts/cape-subcommands/submission/aggregate.sh
+++ b/scripts/cape-subcommands/submission/aggregate.sh
@@ -15,13 +15,43 @@ if [[ -z "${PROJECT_ROOT:-}" ]]; then
 fi
 
 # Cape Submission Aggregate - Generates CSV report of all benchmark submissions
-# Usage: cape submission aggregate
+# Usage: cape submission aggregate [--mode <base|open>]
+#
+# Options:
+#   --mode <base|open>  Filter submissions by mode (base or open)
+#
+# Output:
+#   CSV with mode column as 2nd field: benchmark,mode,timestamp,language,...
 
 # Early help
 if cape_help_requested "$@"; then
   cape_render_help "${BASH_SOURCE[0]}"
   exit 0
 fi
+
+# Parse arguments
+MODE_FILTER=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --mode)
+      MODE_FILTER="$2"
+      if [ "$MODE_FILTER" != "base" ] && [ "$MODE_FILTER" != "open" ]; then
+        echo "Error: --mode must be 'base' or 'open'" >&2
+        exit 1
+      fi
+      shift 2
+      ;;
+    -h | --help | help)
+      cape_render_help "${BASH_SOURCE[0]}"
+      exit 0
+      ;;
+    *)
+      echo "Error: Unknown argument '$1'" >&2
+      echo "Usage: cape submission aggregate [--mode <base|open>]" >&2
+      exit 1
+      ;;
+  esac
+done
 
 # Verify repo structure
 if [ ! -d "$PROJECT_ROOT/submissions" ]; then
@@ -30,8 +60,22 @@ if [ ! -d "$PROJECT_ROOT/submissions" ]; then
   exit 1
 fi
 
-# Output CSV header
-echo "benchmark,timestamp,language,version,user,cpu_units,memory_units,script_size_bytes,term_size,submission_dir"
+# Function to determine submission mode from directory name
+get_submission_mode() {
+  local dir_name="$1"
+
+  if [[ "$dir_name" =~ _base$ ]]; then
+    echo "base"
+  elif [[ "$dir_name" =~ _open($|_) ]]; then
+    echo "open"
+  else
+    # Legacy submissions without suffix are treated as open mode
+    echo "open"
+  fi
+}
+
+# Output CSV header with mode as 2nd column
+echo "benchmark,mode,timestamp,language,version,user,cpu_units,memory_units,script_size_bytes,term_size,submission_dir"
 
 # Process all submissions (NUL-delimited for filename safety)
 while IFS= read -r -d '' metadata_file; do
@@ -51,6 +95,14 @@ while IFS= read -r -d '' metadata_file; do
   # Extract actual submission directory name
   actual_submission_dir="$(basename "$submission_dir")"
 
+  # Determine submission mode from directory name
+  submission_mode=$(get_submission_mode "$actual_submission_dir")
+
+  # Apply mode filter if specified
+  if [ -n "$MODE_FILTER" ] && [ "$submission_mode" != "$MODE_FILTER" ]; then
+    continue
+  fi
+
   # Extract data from metadata.json using basic JSON parsing (be tolerant to missing fields)
   compiler_name=$(grep -o '"name"[[:space:]]*:[[:space:]]*"[^"]*"' "$metadata_file" | head -1 | cut -d '"' -f4 || true)
   compiler_version=$(grep -o '"version"[[:space:]]*:[[:space:]]*"[^"]*"' "$metadata_file" | head -1 | cut -d '"' -f4 || true)
@@ -69,7 +121,7 @@ while IFS= read -r -d '' metadata_file; do
   script_size_bytes=$(jq -r '.measurements.script_size_bytes // 0' "$metrics_file" 2> /dev/null || true)
   term_size=$(jq -r '.measurements.term_size // 0' "$metrics_file" 2> /dev/null || true)
 
-  # Escape any commas in string fields and output CSV row
+  # Escape any commas in string fields and output CSV row with mode as 2nd column
   benchmark=$(echo "$benchmark" | sed 's/,/\\,/g')
   timestamp=$(echo "$timestamp" | sed 's/,/\\,/g')
   compiler_name=$(echo "$compiler_name" | sed 's/,/\\,/g')
@@ -77,5 +129,5 @@ while IFS= read -r -d '' metadata_file; do
   contributor_name=$(echo "$contributor_name" | sed 's/,/\\,/g')
   actual_submission_dir=$(echo "$actual_submission_dir" | sed 's/,/\\,/g')
 
-  echo "$benchmark,$timestamp,$compiler_name,$compiler_version,$contributor_name,$cpu_units,$memory_units,$script_size_bytes,$term_size,$actual_submission_dir"
+  echo "$benchmark,$submission_mode,$timestamp,$compiler_name,$compiler_version,$contributor_name,$cpu_units,$memory_units,$script_size_bytes,$term_size,$actual_submission_dir"
 done < <(find "$PROJECT_ROOT/submissions" -name "metadata.json" -path "*/[!T]*/*" -print0 | sort -z)


### PR DESCRIPTION
## Problem
HTML report index pages were showing ALL submissions regardless of mode. For example, the base mode index showed 5 fibonacci submissions (4 base + 1 open) instead of 4.

## Root Cause  
The `generate_index_report()` function used `cape benchmark stats` which returns all submissions without mode filtering.

## Solution
1. **Enhanced `cape submission aggregate`**: Added `--mode` flag and mode column in CSV
2. **Updated report.sh**: Use filtered aggregate data for index pages, removed obsolete filtering
3. **Fixed index generation**: Created `build_filtered_stats()` to build stats from filtered CSV

## Verification
- ✅ Base fibonacci index: 4 submissions (was 5)
- ✅ Open fibonacci index: 1 submission
- ✅ All 61 integration tests pass
- ✅ All 183 Haskell unit tests pass  
- ✅ Builds cleanly with -Werror

## Testing
```bash
cape submission aggregate --mode base | grep fibonacci  # Shows 4 base submissions
cape submission aggregate --mode open | grep fibonacci  # Shows 1 open submission
cape test  # All 61 tests pass
```