### PR TITLE
docs(README): update benchmark scenarios table

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,9 +112,11 @@ Latest benchmark reports: [UPLC-CAPE Reports](https://intersectmbo.github.io/UPL
 
 | Benchmark | Type | Description | Status |
 | --- | --- | --- | --- |
-| [Fibonacci](scenarios/fibonacci.md) | Synthetic | Recursive algorithm performance | Ready |
-| [Factorial](scenarios/factorial.md) | Synthetic | Recursive algorithm performance | Ready |
-| [Two-Party Escrow](scenarios/two-party-escrow.md) | Real-world | Smart contract escrow validator | Ready |
+| [Fibonacci](scenarios/fibonacci/fibonacci.md) | Synthetic | Recursive algorithm performance | Ready |
+| [Fibonacci (Naive Recursion)](scenarios/fibonacci_naive_recursion/fibonacci_naive_recursion.md) | Synthetic | Prescribed naive recursive algorithm for compiler optimization comparison | Ready |
+| [Factorial](scenarios/factorial/factorial.md) | Synthetic | Recursive algorithm performance | Ready |
+| [Factorial (Naive Recursion)](scenarios/factorial_naive_recursion/factorial_naive_recursion.md) | Synthetic | Prescribed naive recursive algorithm for compiler optimization comparison | Ready |
+| [Two-Party Escrow](scenarios/two-party-escrow/two-party-escrow.md) | Real-world | Smart contract escrow validator | Ready |
 | Streaming Payments | Real-world | Payment channel implementation | Planned |
 | Simple DAO Voting | Real-world | Governance mechanism | Planned |
 | Time-locked Staking | Real-world | Staking protocol | Planned |


### PR DESCRIPTION
## Summary

- Add missing Fibonacci (Naive Recursion) and Factorial (Naive Recursion) benchmarks to the table
- Fix all scenario file path links to point to correct directory structure
- Update descriptions to clarify the purpose of naive recursion benchmarks

## Problem

The README's benchmark scenarios table had two issues:

1. **Missing benchmarks**: The table only listed 3 ready benchmarks, but there are actually 5:
   - Fibonacci
   - **Fibonacci (Naive Recursion)** ← Missing
   - Factorial
   - **Factorial (Naive Recursion)** ← Missing
   - Two-Party Escrow

2. **Broken links**: All scenario links were pointing to non-existent paths:
   - ❌ `scenarios/fibonacci.md`
   - ✅ `scenarios/fibonacci/fibonacci.md`

## Changes

### Added Missing Benchmarks
- Added `Fibonacci (Naive Recursion)` with link to `scenarios/fibonacci_naive_recursion/fibonacci_naive_recursion.md`
- Added `Factorial (Naive Recursion)` with link to `scenarios/factorial_naive_recursion/factorial_naive_recursion.md`
- Updated descriptions to clarify these are "Prescribed naive recursive algorithm for compiler optimization comparison"

### Fixed File Paths
Updated all scenario links to include the correct directory structure:
- `scenarios/fibonacci.md` → `scenarios/fibonacci/fibonacci.md`
- `scenarios/factorial.md` → `scenarios/factorial/factorial.md`
- `scenarios/two-party-escrow.md` → `scenarios/two-party-escrow/two-party-escrow.md`

## Verification

```bash
# Verify all scenarios exist
cape benchmark list
# Output: fibonacci, fibonacci_naive_recursion, factorial, factorial_naive_recursion, two-party-escrow

# Verify links work
ls scenarios/fibonacci/fibonacci.md
ls scenarios/fibonacci_naive_recursion/fibonacci_naive_recursion.md
ls scenarios/factorial/factorial.md
ls scenarios/factorial_naive_recursion/factorial_naive_recursion.md
ls scenarios/two-party-escrow/two-party-escrow.md
```

## Test Plan

- [x] Verify all benchmark links in the table work correctly
- [x] Run `treefmt` to ensure proper formatting
- [x] Verify the table renders correctly in the README