### PR TITLE
docs(README): fix version numbers to match actual dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,14 +382,14 @@ UPLC-CAPE/
 ## Version and Tooling Requirements
 
 - Development environment: Nix shell (`nix develop`) with optional direnv (`direnv allow`).
-- GHC: 9.6.6 (provided in Nix shell).
+- GHC: 9.6.7 (provided in Nix shell).
 - Plutus Core target: 1.1.0.
   - Use `plcVersion110` (for Haskell/PlutusTx code).
 - Package baselines (CHaP):
-  - plutus-core >= 1.52.0.0
-  - plutus-tx >= 1.52.0.0
-  - plutus-ledger-api >= 1.52.0.0
-  - plutus-tx-plugin >= 1.52.0.0
+  - plutus-core >= 1.45.0.0
+  - plutus-tx >= 1.45.0.0
+  - plutus-ledger-api >= 1.45.0.0
+  - plutus-tx-plugin >= 1.45.0.0
 
 ---
 


### PR DESCRIPTION
## Summary

- Update GHC version from 9.6.6 to 9.6.7
- Update Plutus package versions from 1.52.0.0 to 1.45.0.0

## Problem

The README's "Version and Tooling Requirements" section contained incorrect version numbers that didn't match the actual project configuration.

### GHC Version Mismatch
- **README stated**: 9.6.6
- **Actual version**: 9.6.7
- **Verification**: Running `ghc --version` in the nix shell shows 9.6.7

### Plutus Package Version Mismatch
- **README stated**: >= 1.52.0.0
- **Actual versions**: >= 1.45.0.0
- **Evidence**:
  - `cape.cabal:23-26` uses `^>=1.45` constraints for all plutus packages
  - `cabal.project:16` comment explicitly states "Latest index with Plutus 1.45"
  - `flake.nix:28` pins to Plutus commit `ba16ec68d3ba1a53594585deed81cdb3e720e4a3` which is "Release 1.45.0.0"

## Changes

### Updated Lines in README.md (lines 383-392)

**Before:**
```markdown
- GHC: 9.6.6 (provided in Nix shell).
- Package baselines (CHaP):
  - plutus-core >= 1.52.0.0
  - plutus-tx >= 1.52.0.0
  - plutus-ledger-api >= 1.52.0.0
  - plutus-tx-plugin >= 1.52.0.0
```

**After:**
```markdown
- GHC: 9.6.7 (provided in Nix shell).
- Package baselines (CHaP):
  - plutus-core >= 1.45.0.0
  - plutus-tx >= 1.45.0.0
  - plutus-ledger-api >= 1.45.0.0
  - plutus-tx-plugin >= 1.45.0.0
```

## Verification

```bash
# Verify GHC version
ghc --version
# Output: The Glorious Glasgow Haskell Compilation System, version 9.6.7

# Verify Plutus versions in cabal file
grep "plutus-" cape.cabal | head -4
# Output shows ^>=1.45 constraints

# Verify Plutus commit in flake
grep -A 2 'plutus =' flake.nix
# Output shows ba16ec68d3ba1a53594585deed81cdb3e720e4a3 (Release 1.45.0.0)
```

## Impact

- **Documentation accuracy**: Ensures developers and contributors see correct version requirements
- **No functional changes**: This is purely a documentation fix
- **Consistency**: Aligns README with actual project configuration

## Test Plan

- [x] Verify GHC version matches `ghc --version` output
- [x] Verify Plutus versions match `cape.cabal` constraints
- [x] Verify Plutus versions match `flake.nix` pinned commit
- [x] Run `treefmt` to ensure proper formatting