### PR TITLE
Fix broken navigation links in benchmark reports

### DIFF
--- a/report/benchmarks/factorial.html
+++ b/report/benchmarks/factorial.html
@@ -165,17 +165,17 @@
     </div>
 
     <div class="breadcrumb">
-        <a href="index.html">Home</a>
+        <a href="../index.html">Home</a>
         <span class="breadcrumb-separator">→</span>
         <span>factorial</span>
     </div>
 
     <div class="nav">
-        <a href="index.html">← Back to All Benchmarks</a>
+        <a href="../index.html">← Back to All Benchmarks</a>
     </div>
 
     <div class="timestamp">
-        Generated on: 2025-10-17 16:00:13 CEST
+        Generated on: 2025-10-17 16:23:27 CEST
     </div>
     
     <div class="benchmark-section">

--- a/report/benchmarks/factorial_naive_recursion.html
+++ b/report/benchmarks/factorial_naive_recursion.html
@@ -165,17 +165,17 @@
     </div>
 
     <div class="breadcrumb">
-        <a href="index.html">Home</a>
+        <a href="../index.html">Home</a>
         <span class="breadcrumb-separator">→</span>
         <span>factorial_naive_recursion</span>
     </div>
 
     <div class="nav">
-        <a href="index.html">← Back to All Benchmarks</a>
+        <a href="../index.html">← Back to All Benchmarks</a>
     </div>
 
     <div class="timestamp">
-        Generated on: 2025-10-17 16:00:17 CEST
+        Generated on: 2025-10-17 16:23:31 CEST
     </div>
     
     <div class="benchmark-section">

--- a/report/benchmarks/fibonacci.html
+++ b/report/benchmarks/fibonacci.html
@@ -165,17 +165,17 @@
     </div>
 
     <div class="breadcrumb">
-        <a href="index.html">Home</a>
+        <a href="../index.html">Home</a>
         <span class="breadcrumb-separator">→</span>
         <span>fibonacci</span>
     </div>
 
     <div class="nav">
-        <a href="index.html">← Back to All Benchmarks</a>
+        <a href="../index.html">← Back to All Benchmarks</a>
     </div>
 
     <div class="timestamp">
-        Generated on: 2025-10-17 16:00:23 CEST
+        Generated on: 2025-10-17 16:23:35 CEST
     </div>
     
     <div class="benchmark-section">

--- a/report/benchmarks/fibonacci_naive_recursion.html
+++ b/report/benchmarks/fibonacci_naive_recursion.html
@@ -165,17 +165,17 @@
     </div>
 
     <div class="breadcrumb">
-        <a href="index.html">Home</a>
+        <a href="../index.html">Home</a>
         <span class="breadcrumb-separator">→</span>
         <span>fibonacci_naive_recursion</span>
     </div>
 
     <div class="nav">
-        <a href="index.html">← Back to All Benchmarks</a>
+        <a href="../index.html">← Back to All Benchmarks</a>
     </div>
 
     <div class="timestamp">
-        Generated on: 2025-10-17 16:00:28 CEST
+        Generated on: 2025-10-17 16:23:38 CEST
     </div>
     
     <div class="benchmark-section">

--- a/report/benchmarks/two-party-escrow.html
+++ b/report/benchmarks/two-party-escrow.html
@@ -165,17 +165,17 @@
     </div>
 
     <div class="breadcrumb">
-        <a href="index.html">Home</a>
+        <a href="../index.html">Home</a>
         <span class="breadcrumb-separator">→</span>
         <span>two-party-escrow</span>
     </div>
 
     <div class="nav">
-        <a href="index.html">← Back to All Benchmarks</a>
+        <a href="../index.html">← Back to All Benchmarks</a>
     </div>
 
     <div class="timestamp">
-        Generated on: 2025-10-17 16:00:33 CEST
+        Generated on: 2025-10-17 16:23:41 CEST
     </div>
     
     <div class="benchmark-section">

--- a/report/index.html
+++ b/report/index.html
@@ -232,7 +232,7 @@
     </div>
 
     <div class="timestamp">
-        Generated on: 2025-10-17 16:00:36 CEST
+        Generated on: 2025-10-17 16:23:43 CEST
     </div>
     
     <!-- Benchmark Summary Table -->

--- a/scripts/cape-subcommands/submission/benchmark.html.tmpl
+++ b/scripts/cape-subcommands/submission/benchmark.html.tmpl
@@ -165,13 +165,13 @@
     </div>
 
     <div class="breadcrumb">
-        <a href="index.html">Home</a>
+        <a href="../index.html">Home</a>
         <span class="breadcrumb-separator">→</span>
         <span>{{.benchmark}}</span>
     </div>
 
     <div class="nav">
-        <a href="index.html">← Back to All Benchmarks</a>
+        <a href="../index.html">← Back to All Benchmarks</a>
     </div>
 
     <div class="timestamp">


### PR DESCRIPTION
## Summary
Fixes broken "Home" and "Back to All Benchmarks" navigation links in benchmark report pages that were causing 404 errors on GitHub Pages.

## Changes
- Updated `scripts/cape-subcommands/submission/benchmark.html.tmpl` to use correct relative paths
- Changed `href="index.html"` to `href="../index.html"` (lines 168 & 174)
- Regenerated all benchmark reports with corrected navigation links

## Technical Details
Benchmark pages are generated in `report/benchmarks/` subdirectory while `index.html` is in the `report/` parent directory. The links needed to use `../` relative path to correctly navigate up one directory level.

## Testing
- Verified links in all generated benchmark HTML files point to `../index.html`
- Confirmed navigation works correctly in local report files

Closes #88