### PR TITLE
Remove .gitkeep from non-empty submission source directories

### DIFF
--- a/submissions/factorial_naive_recursion/Plinth_1.45.0.0_Unisay/source/.gitkeep
+++ b/submissions/factorial_naive_recursion/Plinth_1.45.0.0_Unisay/source/.gitkeep
@@ -1,1 +1,0 @@
-# Optional: Place your source code files here

--- a/submissions/fibonacci/Aiken_1.1.19_KtorZ_prepacked/source/.gitkeep
+++ b/submissions/fibonacci/Aiken_1.1.19_KtorZ_prepacked/source/.gitkeep
@@ -1,1 +1,0 @@
-# Optional: Place your source code files here

--- a/submissions/fibonacci/Aiken_1.1.19_KtorZ_tailrec/source/.gitkeep
+++ b/submissions/fibonacci/Aiken_1.1.19_KtorZ_tailrec/source/.gitkeep
@@ -1,1 +1,0 @@
-# Optional: Place your source code files here

--- a/submissions/fibonacci/Plutarch_1.11.0_SeungheonOh_prepacked/source/.gitkeep
+++ b/submissions/fibonacci/Plutarch_1.11.0_SeungheonOh_prepacked/source/.gitkeep
@@ -1,1 +1,0 @@
-# Optional: Place your source code files here

--- a/submissions/fibonacci_naive_recursion/Aiken_1.1.17_KtorZ/source/.gitkeep
+++ b/submissions/fibonacci_naive_recursion/Aiken_1.1.17_KtorZ/source/.gitkeep
@@ -1,1 +1,0 @@
-# Optional: Place your source code files here

--- a/submissions/fibonacci_naive_recursion/Plinth_1.45.0.0_Unisay/source/.gitkeep
+++ b/submissions/fibonacci_naive_recursion/Plinth_1.45.0.0_Unisay/source/.gitkeep
@@ -1,1 +1,0 @@
-# Optional: Place your source code files here


### PR DESCRIPTION
## Summary
Remove `.gitkeep` placeholder files from submission source directories that now contain actual source files. These files were originally added to ensure directories were tracked by git, but are no longer needed once the directories contain real content.

## Changes
Removed `.gitkeep` from the following non-empty source directories:
- `submissions/fibonacci/Aiken_1.1.19_KtorZ_prepacked/source/`
- `submissions/fibonacci/Aiken_1.1.19_KtorZ_tailrec/source/`
- `submissions/fibonacci/Plutarch_1.11.0_SeungheonOh_prepacked/source/`
- `submissions/fibonacci_naive_recursion/Aiken_1.1.17_KtorZ/source/`
- `submissions/fibonacci_naive_recursion/Plinth_1.45.0.0_Unisay/source/`
- `submissions/factorial_naive_recursion/Plinth_1.45.0.0_Unisay/source/`

## Rationale
The `.gitkeep` convention is used to track empty directories in git, but becomes redundant once directories contain actual files. Removing these files reduces clutter and follows standard git practices.