### PR TITLE
fix(ci): install pnpm before Node.js setup in slides workflow

### DIFF
--- a/.github/workflows/deploy-slides.yml
+++ b/.github/workflows/deploy-slides.yml
@@ -30,17 +30,17 @@ jobs:
         with:
           ref: ${{ inputs.branch || 'main' }}
 
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: latest
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: "20"
           cache: "pnpm"
           cache-dependency-path: doc/slides/pnpm-lock.yaml
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: latest
 
       - name: Install dependencies
         working-directory: doc/slides


### PR DESCRIPTION
## Context

The slides deployment workflow is failing because the step order is incorrect.

## Problem

The workflow fails with:
```
Error: Unable to locate executable file: pnpm
```

This happens because:
1. `Setup Node.js` step tries to use `cache: pnpm`
2. But pnpm hasn't been installed yet
3. Result: Error finding pnpm executable

Failed run: https://github.com/IntersectMBO/UPLC-CAPE/actions/runs/18817176786/job/53687159913

## Solution

Reordered the steps to install pnpm **before** setting up Node.js:

```yaml
1. Checkout
2. Install pnpm          ← Moved up
3. Setup Node.js         ← Now pnpm is available for caching
4. Install dependencies
5. Build
6. Deploy
```

## Testing

After merge, retry the "Deploy Slides to GitHub Pages" workflow to verify it succeeds.