### PR TITLE
fix(slides): remove extra blank lines in YAML frontmatter

### DIFF
--- a/doc/slides/slides.md
+++ b/doc/slides/slides.md
@@ -261,7 +261,6 @@ Optimization isn't micro-optimization—choosing the right toolchain and optimiz
 -->
 
 ---
-
 layout: center
 class: attention
 ---
@@ -279,7 +278,6 @@ class: attention
 -->
 
 ---
-
 layout: center
 class: attention
 ---


### PR DESCRIPTION
## Context

Minor formatting fix for Slidev YAML frontmatter to ensure proper parsing.

## Problem

Extra blank lines between slide separators and YAML frontmatter can interfere with proper parsing of layout and class attributes in Slidev.

## Solution

Removed extraneous blank lines in two places where YAML frontmatter appeared after `---` separators.

## Changes

- Removed blank line before `layout: center` / `class: attention` blocks
- Ensures clean YAML frontmatter parsing

## Testing

Slides render correctly with proper layout and class attributes applied.