### PR TITLE
Add support for multiple input arguments in test framework

### DIFF
--- a/cape.cabal
+++ b/cape.cabal
@@ -60,6 +60,7 @@ common common-language
     NumericUnderscores
     OverloadedStrings
     PatternSynonyms
+    QuasiQuotes
     ScopedTypeVariables
     Strict
     TemplateHaskell
@@ -169,6 +170,7 @@ test-suite cape-tests
     , plutus-ledger-api
     , plutus-tx
     , plutus-tx:plutus-tx-testlib
+    , string-interpolate
     , vector
 
   hs-source-dirs:     test

--- a/lib/Cape/Tests.hs
+++ b/lib/Cape/Tests.hs
@@ -15,7 +15,7 @@ Example usage:
 
 @
 suite <- loadTestSuite "scenarios/fibonacci/cape-tests.json"
-input <- resolveTestInput baseDir suite (tcInput testCase)
+inputs <- mapM (resolveTestInput baseDir suite) (tcInputs testCase)
 @
 -}
 module Cape.Tests (
@@ -143,18 +143,21 @@ data TestCase = TestCase
   -- ^ Whether test is marked pending
   --
   --     JSON: @"pending": true@
-  , tcInput :: Maybe TestInput
-  -- ^ Input specification (optional for error-only tests)
+  , tcInputs :: [TestInput]
+  -- ^ List of inputs to be applied sequentially (empty for error-only tests)
   --
   --     JSON example:
   --     @
-  --     "input": {
-  --       "type": "script_context",
-  --       "script_context": {
-  --         "baseline": "@successful_deposit",
-  --         "patches": []
+  --     "inputs": [
+  --       {
+  --         "type": "uplc",
+  --         "value": "(con integer 48)"
+  --       },
+  --       {
+  --         "type": "uplc",
+  --         "value": "(con integer 18)"
   --       }
-  --     }
+  --     ]
   --     @
   , tcExpected :: ExpectedResult
   -- ^ Expected result specification
@@ -223,7 +226,7 @@ data InputType
     --
     --     JSON: @"type": "script_context"@
     ScriptContext
-  deriving stock (Show)
+  deriving stock (Show, Eq)
 
 -- | Specification for ScriptContext baseline.
 data BaselineSpec
@@ -458,7 +461,7 @@ instance FromJSON TestCase where
       <$> o .: "name"
       <*> o .:? "description"
       <*> o .:? "pending"
-      <*> o .:? "input"
+      <*> o .: "inputs"
       <*> o .: "expected"
 
 instance FromJSON TestInput where

--- a/plinth-submissions-app/Main.hs
+++ b/plinth-submissions-app/Main.hs
@@ -14,13 +14,13 @@ import UntypedPlutusCore.DeBruijn (unDeBruijnTerm)
 main :: IO ()
 main = do
   writeCodeToFile
-    "submissions/fibonacci/Plinth_1.45.0.0_Unisay_base/fibonacci.uplc"
+    "submissions/fibonacci_naive_recursion/Plinth_1.45.0.0_Unisay/fibonacci.uplc"
     fibonacciCode
   writeCodeToFile
-    "submissions/factorial/Plinth_1.45.0.0_Unisay_base/factorial.uplc"
+    "submissions/factorial_naive_recursion/Plinth_1.45.0.0_Unisay/factorial.uplc"
     factorialCode
   writeCodeToFile
-    "submissions/two-party-escrow/Plinth_1.45.0.0_Unisay_open/two-party-escrow.uplc"
+    "submissions/two-party-escrow/Plinth_1.45.0.0_Unisay/two-party-escrow.uplc"
     twoPartyEscrowValidatorCode
 
 writeCodeToFile :: FilePath -> CompiledCode a -> IO ()

--- a/scenarios/factorial/cape-tests.json
+++ b/scenarios/factorial/cape-tests.json
@@ -5,122 +5,142 @@
     {
       "name": "factorial_0",
       "description": "Factorial of 0 should return 1 (mathematical definition)",
-      "input": {
-        "type": "uplc",
-        "value": "(con integer 0)"
-      },
       "expected": {
         "type": "value",
         "content": "(con integer 1)"
-      }
+      },
+      "inputs": [
+        {
+          "type": "uplc",
+          "value": "(con integer 0)"
+        }
+      ]
     },
     {
       "name": "factorial_1",
       "description": "Factorial of 1 should return 1",
-      "input": {
-        "type": "uplc",
-        "value": "(con integer 1)"
-      },
       "expected": {
         "type": "value",
         "content": "(con integer 1)"
-      }
+      },
+      "inputs": [
+        {
+          "type": "uplc",
+          "value": "(con integer 1)"
+        }
+      ]
     },
     {
       "name": "factorial_2",
       "description": "Factorial of 2 should return 2",
-      "input": {
-        "type": "uplc",
-        "value": "(con integer 2)"
-      },
       "expected": {
         "type": "value",
         "content": "(con integer 2)"
-      }
+      },
+      "inputs": [
+        {
+          "type": "uplc",
+          "value": "(con integer 2)"
+        }
+      ]
     },
     {
       "name": "factorial_3",
       "description": "Factorial of 3 should return 6",
-      "input": {
-        "type": "uplc",
-        "value": "(con integer 3)"
-      },
       "expected": {
         "type": "value",
         "content": "(con integer 6)"
-      }
+      },
+      "inputs": [
+        {
+          "type": "uplc",
+          "value": "(con integer 3)"
+        }
+      ]
     },
     {
       "name": "factorial_4",
       "description": "Factorial of 4 should return 24",
-      "input": {
-        "type": "uplc",
-        "value": "(con integer 4)"
-      },
       "expected": {
         "type": "value",
         "content": "(con integer 24)"
-      }
+      },
+      "inputs": [
+        {
+          "type": "uplc",
+          "value": "(con integer 4)"
+        }
+      ]
     },
     {
       "name": "factorial_5",
       "description": "Factorial of 5 should return 120",
-      "input": {
-        "type": "uplc",
-        "value": "(con integer 5)"
-      },
       "expected": {
         "type": "value",
         "content": "(con integer 120)"
-      }
+      },
+      "inputs": [
+        {
+          "type": "uplc",
+          "value": "(con integer 5)"
+        }
+      ]
     },
     {
       "name": "factorial_8",
       "description": "Factorial of 8 should return 40320",
-      "input": {
-        "type": "uplc",
-        "value": "(con integer 8)"
-      },
       "expected": {
         "type": "value",
         "content": "(con integer 40320)"
-      }
+      },
+      "inputs": [
+        {
+          "type": "uplc",
+          "value": "(con integer 8)"
+        }
+      ]
     },
     {
       "name": "factorial_10",
       "description": "Factorial of 10 should return 3628800 (original benchmark target)",
-      "input": {
-        "type": "uplc",
-        "value": "(con integer 10)"
-      },
       "expected": {
         "type": "value",
         "content": "(con integer 3628800)"
-      }
+      },
+      "inputs": [
+        {
+          "type": "uplc",
+          "value": "(con integer 10)"
+        }
+      ]
     },
     {
       "name": "factorial_12",
       "description": "Factorial of 12 should return 479001600",
-      "input": {
-        "type": "uplc",
-        "value": "(con integer 12)"
-      },
       "expected": {
         "type": "value",
         "content": "(con integer 479001600)"
-      }
+      },
+      "inputs": [
+        {
+          "type": "uplc",
+          "value": "(con integer 12)"
+        }
+      ]
     },
     {
       "name": "factorial_negative",
       "description": "Factorial of negative number should return 1 based on current implementation (n <= 0 case)",
-      "input": {
-        "type": "uplc",
-        "value": "(con integer -5)"
-      },
       "expected": {
         "type": "value",
         "content": "(con integer 1)"
-      }
+      },
+      "inputs": [
+        {
+          "type": "uplc",
+          "value": "(con integer -5)"
+        }
+      ]
     }
   ]
 }

--- a/scenarios/factorial_naive_recursion/cape-tests.json
+++ b/scenarios/factorial_naive_recursion/cape-tests.json
@@ -5,10 +5,12 @@
     {
       "name": "factorial_0",
       "description": "Factorial of 0 should return 1 (mathematical definition)",
-      "input": {
-        "type": "uplc",
-        "value": "(con integer 0)"
-      },
+      "inputs": [
+        {
+          "type": "uplc",
+          "value": "(con integer 0)"
+        }
+      ],
       "expected": {
         "type": "value",
         "content": "(con integer 1)"
@@ -17,10 +19,12 @@
     {
       "name": "factorial_1",
       "description": "Factorial of 1 should return 1",
-      "input": {
-        "type": "uplc",
-        "value": "(con integer 1)"
-      },
+      "inputs": [
+        {
+          "type": "uplc",
+          "value": "(con integer 1)"
+        }
+      ],
       "expected": {
         "type": "value",
         "content": "(con integer 1)"
@@ -29,10 +33,12 @@
     {
       "name": "factorial_2",
       "description": "Factorial of 2 should return 2",
-      "input": {
-        "type": "uplc",
-        "value": "(con integer 2)"
-      },
+      "inputs": [
+        {
+          "type": "uplc",
+          "value": "(con integer 2)"
+        }
+      ],
       "expected": {
         "type": "value",
         "content": "(con integer 2)"
@@ -41,10 +47,12 @@
     {
       "name": "factorial_3",
       "description": "Factorial of 3 should return 6",
-      "input": {
-        "type": "uplc",
-        "value": "(con integer 3)"
-      },
+      "inputs": [
+        {
+          "type": "uplc",
+          "value": "(con integer 3)"
+        }
+      ],
       "expected": {
         "type": "value",
         "content": "(con integer 6)"
@@ -53,10 +61,12 @@
     {
       "name": "factorial_4",
       "description": "Factorial of 4 should return 24",
-      "input": {
-        "type": "uplc",
-        "value": "(con integer 4)"
-      },
+      "inputs": [
+        {
+          "type": "uplc",
+          "value": "(con integer 4)"
+        }
+      ],
       "expected": {
         "type": "value",
         "content": "(con integer 24)"
@@ -65,10 +75,12 @@
     {
       "name": "factorial_5",
       "description": "Factorial of 5 should return 120",
-      "input": {
-        "type": "uplc",
-        "value": "(con integer 5)"
-      },
+      "inputs": [
+        {
+          "type": "uplc",
+          "value": "(con integer 5)"
+        }
+      ],
       "expected": {
         "type": "value",
         "content": "(con integer 120)"
@@ -77,10 +89,12 @@
     {
       "name": "factorial_8",
       "description": "Factorial of 8 should return 40320",
-      "input": {
-        "type": "uplc",
-        "value": "(con integer 8)"
-      },
+      "inputs": [
+        {
+          "type": "uplc",
+          "value": "(con integer 8)"
+        }
+      ],
       "expected": {
         "type": "value",
         "content": "(con integer 40320)"
@@ -89,10 +103,12 @@
     {
       "name": "factorial_10",
       "description": "Factorial of 10 should return 3628800 (original benchmark target)",
-      "input": {
-        "type": "uplc",
-        "value": "(con integer 10)"
-      },
+      "inputs": [
+        {
+          "type": "uplc",
+          "value": "(con integer 10)"
+        }
+      ],
       "expected": {
         "type": "value",
         "content": "(con integer 3628800)"
@@ -101,10 +117,12 @@
     {
       "name": "factorial_12",
       "description": "Factorial of 12 should return 479001600",
-      "input": {
-        "type": "uplc",
-        "value": "(con integer 12)"
-      },
+      "inputs": [
+        {
+          "type": "uplc",
+          "value": "(con integer 12)"
+        }
+      ],
       "expected": {
         "type": "value",
         "content": "(con integer 479001600)"
@@ -113,10 +131,12 @@
     {
       "name": "factorial_negative",
       "description": "Factorial of negative number should return 1 based on current implementation (n <= 0 case)",
-      "input": {
-        "type": "uplc",
-        "value": "(con integer -5)"
-      },
+      "inputs": [
+        {
+          "type": "uplc",
+          "value": "(con integer -5)"
+        }
+      ],
       "expected": {
         "type": "value",
         "content": "(con integer 1)"

--- a/scenarios/fibonacci/cape-tests.json
+++ b/scenarios/fibonacci/cape-tests.json
@@ -5,10 +5,12 @@
     {
       "name": "fibonacci_0",
       "description": "Fibonacci of 0 should return 0",
-      "input": {
-        "type": "uplc",
-        "value": "(con integer 0)"
-      },
+      "inputs": [
+        {
+          "type": "uplc",
+          "value": "(con integer 0)"
+        }
+      ],
       "expected": {
         "type": "value",
         "content": "(con integer 0)"
@@ -17,10 +19,12 @@
     {
       "name": "fibonacci_1",
       "description": "Fibonacci of 1 should return 1",
-      "input": {
-        "type": "uplc",
-        "value": "(con integer 1)"
-      },
+      "inputs": [
+        {
+          "type": "uplc",
+          "value": "(con integer 1)"
+        }
+      ],
       "expected": {
         "type": "value",
         "content": "(con integer 1)"
@@ -29,10 +33,12 @@
     {
       "name": "fibonacci_2",
       "description": "Fibonacci of 2 should return 1",
-      "input": {
-        "type": "uplc",
-        "value": "(con integer 2)"
-      },
+      "inputs": [
+        {
+          "type": "uplc",
+          "value": "(con integer 2)"
+        }
+      ],
       "expected": {
         "type": "value",
         "content": "(con integer 1)"
@@ -41,10 +47,12 @@
     {
       "name": "fibonacci_3",
       "description": "Fibonacci of 3 should return 2",
-      "input": {
-        "type": "uplc",
-        "value": "(con integer 3)"
-      },
+      "inputs": [
+        {
+          "type": "uplc",
+          "value": "(con integer 3)"
+        }
+      ],
       "expected": {
         "type": "value",
         "content": "(con integer 2)"
@@ -53,10 +61,12 @@
     {
       "name": "fibonacci_5",
       "description": "Fibonacci of 5 should return 5",
-      "input": {
-        "type": "uplc",
-        "value": "(con integer 5)"
-      },
+      "inputs": [
+        {
+          "type": "uplc",
+          "value": "(con integer 5)"
+        }
+      ],
       "expected": {
         "type": "value",
         "content": "(con integer 5)"
@@ -65,10 +75,12 @@
     {
       "name": "fibonacci_8",
       "description": "Fibonacci of 8 should return 21",
-      "input": {
-        "type": "uplc",
-        "value": "(con integer 8)"
-      },
+      "inputs": [
+        {
+          "type": "uplc",
+          "value": "(con integer 8)"
+        }
+      ],
       "expected": {
         "type": "value",
         "content": "(con integer 21)"
@@ -77,10 +89,12 @@
     {
       "name": "fibonacci_10",
       "description": "Fibonacci of 10 should return 55",
-      "input": {
-        "type": "uplc",
-        "value": "(con integer 10)"
-      },
+      "inputs": [
+        {
+          "type": "uplc",
+          "value": "(con integer 10)"
+        }
+      ],
       "expected": {
         "type": "value",
         "content": "(con integer 55)"
@@ -89,10 +103,12 @@
     {
       "name": "fibonacci_15",
       "description": "Fibonacci of 15 should return 610",
-      "input": {
-        "type": "uplc",
-        "value": "(con integer 15)"
-      },
+      "inputs": [
+        {
+          "type": "uplc",
+          "value": "(con integer 15)"
+        }
+      ],
       "expected": {
         "type": "value",
         "content": "(con integer 610)"
@@ -101,10 +117,12 @@
     {
       "name": "fibonacci_20",
       "description": "Fibonacci of 20 should return 6765",
-      "input": {
-        "type": "uplc",
-        "value": "(con integer 20)"
-      },
+      "inputs": [
+        {
+          "type": "uplc",
+          "value": "(con integer 20)"
+        }
+      ],
       "expected": {
         "type": "value",
         "content": "(con integer 6765)"
@@ -113,10 +131,12 @@
     {
       "name": "fibonacci_25",
       "description": "Fibonacci of 25 should return 75025 (original benchmark target)",
-      "input": {
-        "type": "uplc",
-        "value": "(con integer 25)"
-      },
+      "inputs": [
+        {
+          "type": "uplc",
+          "value": "(con integer 25)"
+        }
+      ],
       "expected": {
         "type": "value",
         "content": "(con integer 75025)"
@@ -125,10 +145,12 @@
     {
       "name": "fibonacci_negative",
       "description": "Fibonacci of negative number should return the negative number itself based on current implementation",
-      "input": {
-        "type": "uplc",
-        "value": "(con integer -1)"
-      },
+      "inputs": [
+        {
+          "type": "uplc",
+          "value": "(con integer -1)"
+        }
+      ],
       "expected": {
         "type": "value",
         "content": "(con integer -1)"

--- a/scenarios/fibonacci_naive_recursion/cape-tests.json
+++ b/scenarios/fibonacci_naive_recursion/cape-tests.json
@@ -5,134 +5,156 @@
     {
       "name": "fibonacci_0",
       "description": "Fibonacci of 0 should return 0",
-      "input": {
-        "type": "uplc",
-        "value": "(con integer 0)"
-      },
       "expected": {
         "type": "value",
         "content": "(con integer 0)"
-      }
+      },
+      "inputs": [
+        {
+          "type": "uplc",
+          "value": "(con integer 0)"
+        }
+      ]
     },
     {
       "name": "fibonacci_1",
       "description": "Fibonacci of 1 should return 1",
-      "input": {
-        "type": "uplc",
-        "value": "(con integer 1)"
-      },
       "expected": {
         "type": "value",
         "content": "(con integer 1)"
-      }
+      },
+      "inputs": [
+        {
+          "type": "uplc",
+          "value": "(con integer 1)"
+        }
+      ]
     },
     {
       "name": "fibonacci_2",
       "description": "Fibonacci of 2 should return 1",
-      "input": {
-        "type": "uplc",
-        "value": "(con integer 2)"
-      },
       "expected": {
         "type": "value",
         "content": "(con integer 1)"
-      }
+      },
+      "inputs": [
+        {
+          "type": "uplc",
+          "value": "(con integer 2)"
+        }
+      ]
     },
     {
       "name": "fibonacci_3",
       "description": "Fibonacci of 3 should return 2",
-      "input": {
-        "type": "uplc",
-        "value": "(con integer 3)"
-      },
       "expected": {
         "type": "value",
         "content": "(con integer 2)"
-      }
+      },
+      "inputs": [
+        {
+          "type": "uplc",
+          "value": "(con integer 3)"
+        }
+      ]
     },
     {
       "name": "fibonacci_5",
       "description": "Fibonacci of 5 should return 5",
-      "input": {
-        "type": "uplc",
-        "value": "(con integer 5)"
-      },
       "expected": {
         "type": "value",
         "content": "(con integer 5)"
-      }
+      },
+      "inputs": [
+        {
+          "type": "uplc",
+          "value": "(con integer 5)"
+        }
+      ]
     },
     {
       "name": "fibonacci_8",
       "description": "Fibonacci of 8 should return 21",
-      "input": {
-        "type": "uplc",
-        "value": "(con integer 8)"
-      },
       "expected": {
         "type": "value",
         "content": "(con integer 21)"
-      }
+      },
+      "inputs": [
+        {
+          "type": "uplc",
+          "value": "(con integer 8)"
+        }
+      ]
     },
     {
       "name": "fibonacci_10",
       "description": "Fibonacci of 10 should return 55",
-      "input": {
-        "type": "uplc",
-        "value": "(con integer 10)"
-      },
       "expected": {
         "type": "value",
         "content": "(con integer 55)"
-      }
+      },
+      "inputs": [
+        {
+          "type": "uplc",
+          "value": "(con integer 10)"
+        }
+      ]
     },
     {
       "name": "fibonacci_15",
       "description": "Fibonacci of 15 should return 610",
-      "input": {
-        "type": "uplc",
-        "value": "(con integer 15)"
-      },
       "expected": {
         "type": "value",
         "content": "(con integer 610)"
-      }
+      },
+      "inputs": [
+        {
+          "type": "uplc",
+          "value": "(con integer 15)"
+        }
+      ]
     },
     {
       "name": "fibonacci_20",
       "description": "Fibonacci of 20 should return 6765",
-      "input": {
-        "type": "uplc",
-        "value": "(con integer 20)"
-      },
       "expected": {
         "type": "value",
         "content": "(con integer 6765)"
-      }
+      },
+      "inputs": [
+        {
+          "type": "uplc",
+          "value": "(con integer 20)"
+        }
+      ]
     },
     {
       "name": "fibonacci_25",
       "description": "Fibonacci of 25 should return 75025 (original benchmark target)",
-      "input": {
-        "type": "uplc",
-        "value": "(con integer 25)"
-      },
       "expected": {
         "type": "value",
         "content": "(con integer 75025)"
-      }
+      },
+      "inputs": [
+        {
+          "type": "uplc",
+          "value": "(con integer 25)"
+        }
+      ]
     },
     {
       "name": "fibonacci_negative",
       "description": "Fibonacci of negative number should return the negative number itself based on current implementation",
-      "input": {
-        "type": "uplc",
-        "value": "(con integer -1)"
-      },
       "expected": {
         "type": "value",
         "content": "(con integer -1)"
-      }
+      },
+      "inputs": [
+        {
+          "type": "uplc",
+          "value": "(con integer -1)"
+        }
+      ]
     }
   ]
 }

--- a/scenarios/two-party-escrow/cape-tests.json
+++ b/scenarios/two-party-escrow/cape-tests.json
@@ -140,1374 +140,1464 @@
     {
       "name": "redeemer_integer_3",
       "description": "Validator fails when redeemer is integer 3 (not 0, 1, or 2)",
-      "input": {
-        "type": "builtin_data",
-        "value": "3"
-      },
       "expected": {
         "type": "error"
-      }
+      },
+      "inputs": [
+        {
+          "type": "builtin_data",
+          "value": "3"
+        }
+      ]
     },
     {
       "name": "redeemer_integer_4",
       "description": "Validator fails when redeemer is integer 4 (not 0, 1, or 2)",
-      "input": {
-        "type": "builtin_data",
-        "value": "4"
-      },
       "expected": {
         "type": "error"
-      }
+      },
+      "inputs": [
+        {
+          "type": "builtin_data",
+          "value": "4"
+        }
+      ]
     },
     {
       "name": "redeemer_integer_99",
       "description": "Validator fails when redeemer is integer 99 (not 0, 1, or 2)",
-      "input": {
-        "type": "builtin_data",
-        "value": "99"
-      },
       "expected": {
         "type": "error"
-      }
+      },
+      "inputs": [
+        {
+          "type": "builtin_data",
+          "value": "99"
+        }
+      ]
     },
     {
       "name": "redeemer_integer_negative_1",
       "description": "Validator fails when redeemer is integer -1 (not 0, 1, or 2)",
-      "input": {
-        "type": "builtin_data",
-        "value": "-1"
-      },
       "expected": {
         "type": "error"
-      }
+      },
+      "inputs": [
+        {
+          "type": "builtin_data",
+          "value": "-1"
+        }
+      ]
     },
     {
       "name": "redeemer_constructor_0",
       "description": "Validator fails when redeemer is constructor instead of integer",
-      "input": {
-        "type": "builtin_data",
-        "value": "0()"
-      },
       "expected": {
         "type": "error"
-      }
+      },
+      "inputs": [
+        {
+          "type": "builtin_data",
+          "value": "0()"
+        }
+      ]
     },
     {
       "name": "redeemer_bytestring",
       "description": "Validator fails when redeemer is bytestring instead of integer",
-      "input": {
-        "type": "builtin_data",
-        "value": "#deadbeef"
-      },
       "expected": {
         "type": "error"
-      }
+      },
+      "inputs": [
+        {
+          "type": "builtin_data",
+          "value": "#deadbeef"
+        }
+      ]
     },
     {
       "name": "redeemer_list_with_integers",
       "description": "Validator fails when redeemer is list [1,2,3] instead of integer",
-      "input": {
-        "type": "builtin_data",
-        "value": "[1 2 3]"
-      },
       "expected": {
         "type": "error"
-      }
+      },
+      "inputs": [
+        {
+          "type": "builtin_data",
+          "value": "[1 2 3]"
+        }
+      ]
     },
     {
       "name": "redeemer_map_with_data",
       "description": "Validator fails when redeemer is map instead of integer",
-      "input": {
-        "type": "builtin_data",
-        "value": "{1:42}"
-      },
       "expected": {
         "type": "error"
-      }
+      },
+      "inputs": [
+        {
+          "type": "builtin_data",
+          "value": "{1:42}"
+        }
+      ]
     },
     {
       "name": "simple_builtin_data_redeemer_0",
       "description": "Test redeemer 0 with simple builtin_data (not script_context)",
-      "input": {
-        "type": "builtin_data",
-        "value": "0"
-      },
       "expected": {
         "type": "error"
-      }
+      },
+      "inputs": [
+        {
+          "type": "builtin_data",
+          "value": "0"
+        }
+      ]
     },
     {
       "name": "deposit_successful",
       "description": "Deposit with buyer signature and exactly 75 ADA should succeed",
-      "input": {
-        "type": "script_context",
-        "script_context": {
-          "baseline": "@successful_deposit",
-          "patches": []
-        }
-      },
       "expected": {
         "type": "value",
         "content": "(con unit ())"
-      }
+      },
+      "inputs": [
+        {
+          "type": "script_context",
+          "script_context": {
+            "baseline": "@successful_deposit",
+            "patches": []
+          }
+        }
+      ]
     },
     {
       "name": "deposit_without_buyer_signature",
       "description": "Deposit without buyer signature should fail",
-      "input": {
-        "type": "script_context",
-        "script_context": {
-          "baseline": "@successful_deposit",
-          "patches": [
-            {
-              "op": "remove_signature",
-              "pubkey_hash": "@buyer_pubkey"
-            }
-          ]
-        }
-      },
       "expected": {
         "type": "error"
-      }
+      },
+      "inputs": [
+        {
+          "type": "script_context",
+          "script_context": {
+            "baseline": "@successful_deposit",
+            "patches": [
+              {
+                "op": "remove_signature",
+                "pubkey_hash": "@buyer_pubkey"
+              }
+            ]
+          }
+        }
+      ]
     },
     {
       "name": "deposit_with_incorrect_amount",
       "description": "Deposit with buyer signature but wrong amount (50 ADA) should fail",
-      "input": {
-        "type": "script_context",
-        "script_context": {
-          "baseline": "@successful_deposit",
-          "patches": [
-            {
-              "op": "add_output_utxo",
-              "address": {
-                "type": "script",
-                "script_hash": "1111111111111111111111111111111111111111111111111111111111"
-              },
-              "lovelace": 50000000
-            }
-          ]
-        }
-      },
       "expected": {
         "type": "error"
-      }
+      },
+      "inputs": [
+        {
+          "type": "script_context",
+          "script_context": {
+            "baseline": "@successful_deposit",
+            "patches": [
+              {
+                "op": "add_output_utxo",
+                "address": {
+                  "type": "script",
+                  "script_hash": "1111111111111111111111111111111111111111111111111111111111"
+                },
+                "lovelace": 50000000
+              }
+            ]
+          }
+        }
+      ]
     },
     {
       "name": "deposit_to_wrong_address",
       "description": "Deposit fails when ADA goes to pubkey address instead of script",
-      "input": {
-        "type": "script_context",
-        "script_context": {
-          "baseline": "spending",
-          "patches": [
-            {
-              "op": "set_redeemer",
-              "redeemer": "0"
-            },
-            {
-              "op": "add_signature",
-              "pubkey_hash": "@buyer_pubkey"
-            },
-            {
-              "op": "add_input_utxo",
-              "utxo_ref": "3333333333333333333333333333333333333333333333333333333333333333:0",
-              "lovelace": 75000000,
-              "is_own_input": true
-            },
-            {
-              "op": "add_output_utxo",
-              "address": {
-                "type": "pubkey",
-                "pubkey_hash": "@impostor_pubkey"
-              },
-              "lovelace": 75000000
-            }
-          ]
-        }
-      },
       "expected": {
         "type": "error"
-      }
+      },
+      "inputs": [
+        {
+          "type": "script_context",
+          "script_context": {
+            "baseline": "spending",
+            "patches": [
+              {
+                "op": "set_redeemer",
+                "redeemer": "0"
+              },
+              {
+                "op": "add_signature",
+                "pubkey_hash": "@buyer_pubkey"
+              },
+              {
+                "op": "add_input_utxo",
+                "utxo_ref": "3333333333333333333333333333333333333333333333333333333333333333:0",
+                "lovelace": 75000000,
+                "is_own_input": true
+              },
+              {
+                "op": "add_output_utxo",
+                "address": {
+                  "type": "pubkey",
+                  "pubkey_hash": "@impostor_pubkey"
+                },
+                "lovelace": 75000000
+              }
+            ]
+          }
+        }
+      ]
     },
     {
       "name": "accept_successful",
       "description": "Accept with seller signature and 75 ADA to seller should succeed",
-      "input": {
-        "type": "script_context",
-        "script_context": {
-          "baseline": "@successful_accept",
-          "patches": []
-        }
-      },
       "expected": {
         "type": "value",
         "content": "(con unit ())"
-      }
+      },
+      "inputs": [
+        {
+          "type": "script_context",
+          "script_context": {
+            "baseline": "@successful_accept",
+            "patches": []
+          }
+        }
+      ]
     },
     {
       "name": "accept_without_seller_signature",
       "description": "Accept operation fails when seller signature is missing",
-      "input": {
-        "type": "script_context",
-        "script_context": {
-          "baseline": "@successful_accept",
-          "patches": [
-            {
-              "op": "remove_signature",
-              "pubkey_hash": "@seller_pubkey"
-            }
-          ]
-        }
-      },
       "expected": {
         "type": "error"
-      }
+      },
+      "inputs": [
+        {
+          "type": "script_context",
+          "script_context": {
+            "baseline": "@successful_accept",
+            "patches": [
+              {
+                "op": "remove_signature",
+                "pubkey_hash": "@seller_pubkey"
+              }
+            ]
+          }
+        }
+      ]
     },
     {
       "name": "accept_with_incorrect_payment_amount",
       "description": "Accept operation fails with wrong payment amount (50 ADA instead of 75 ADA)",
-      "input": {
-        "type": "script_context",
-        "script_context": {
-          "baseline": "@successful_accept",
-          "patches": [
-            {
-              "op": "add_output_utxo",
-              "address": {
-                "type": "pubkey",
-                "pubkey_hash": "@seller_pubkey"
-              },
-              "lovelace": 50000000
-            }
-          ]
-        }
-      },
       "expected": {
         "type": "error"
-      }
+      },
+      "inputs": [
+        {
+          "type": "script_context",
+          "script_context": {
+            "baseline": "@successful_accept",
+            "patches": [
+              {
+                "op": "add_output_utxo",
+                "address": {
+                  "type": "pubkey",
+                  "pubkey_hash": "@seller_pubkey"
+                },
+                "lovelace": 50000000
+              }
+            ]
+          }
+        }
+      ]
     },
     {
       "name": "accept_with_payment_to_wrong_address",
       "description": "Accept operation fails when payment goes to impostor address instead of seller",
-      "input": {
-        "type": "script_context",
-        "script_context": {
-          "baseline": "spending",
-          "patches": [
-            {
-              "op": "set_redeemer",
-              "redeemer": "1"
-            },
-            {
-              "op": "add_signature",
-              "pubkey_hash": "@seller_pubkey"
-            },
-            {
-              "op": "add_input_utxo",
-              "utxo_ref": "4444444444444444444444444444444444444444444444444444444444444444:0",
-              "lovelace": 75000000,
-              "is_own_input": true
-            },
-            {
-              "op": "add_output_utxo",
-              "address": {
-                "type": "pubkey",
-                "pubkey_hash": "@impostor_pubkey"
-              },
-              "lovelace": 75000000
-            }
-          ]
-        }
-      },
       "expected": {
         "type": "error"
-      }
+      },
+      "inputs": [
+        {
+          "type": "script_context",
+          "script_context": {
+            "baseline": "spending",
+            "patches": [
+              {
+                "op": "set_redeemer",
+                "redeemer": "1"
+              },
+              {
+                "op": "add_signature",
+                "pubkey_hash": "@seller_pubkey"
+              },
+              {
+                "op": "add_input_utxo",
+                "utxo_ref": "4444444444444444444444444444444444444444444444444444444444444444:0",
+                "lovelace": 75000000,
+                "is_own_input": true
+              },
+              {
+                "op": "add_output_utxo",
+                "address": {
+                  "type": "pubkey",
+                  "pubkey_hash": "@impostor_pubkey"
+                },
+                "lovelace": 75000000
+              }
+            ]
+          }
+        }
+      ]
     },
     {
       "name": "accept_without_prior_deposit",
       "description": "Accept operation without valid deposit UTXO (should fail - invalid escrow state)",
-      "input": {
-        "type": "script_context",
-        "script_context": {
-          "baseline": "spending",
-          "patches": [
-            {
-              "op": "set_redeemer",
-              "redeemer": "1"
-            },
-            {
-              "op": "add_signature",
-              "pubkey_hash": "@seller_pubkey"
-            },
-            {
-              "op": "add_output_utxo",
-              "address": {
-                "type": "pubkey",
-                "pubkey_hash": "@seller_pubkey"
-              },
-              "lovelace": 75000000
-            }
-          ]
-        }
-      },
       "expected": {
         "type": "error"
-      }
+      },
+      "inputs": [
+        {
+          "type": "script_context",
+          "script_context": {
+            "baseline": "spending",
+            "patches": [
+              {
+                "op": "set_redeemer",
+                "redeemer": "1"
+              },
+              {
+                "op": "add_signature",
+                "pubkey_hash": "@seller_pubkey"
+              },
+              {
+                "op": "add_output_utxo",
+                "address": {
+                  "type": "pubkey",
+                  "pubkey_hash": "@seller_pubkey"
+                },
+                "lovelace": 75000000
+              }
+            ]
+          }
+        }
+      ]
     },
     {
       "name": "accept_with_multiple_inputs",
       "description": "Accept with multiple script inputs (ambiguous state - expects pass)",
-      "input": {
-        "type": "script_context",
-        "script_context": {
-          "baseline": "spending",
-          "patches": [
-            {
-              "op": "set_redeemer",
-              "redeemer": "1"
-            },
-            {
-              "op": "add_signature",
-              "pubkey_hash": "@seller_pubkey"
-            },
-            {
-              "op": "set_script_datum",
-              "datum": "@deposited_escrow_datum"
-            },
-            {
-              "op": "add_input_utxo",
-              "utxo_ref": "3333333333333333333333333333333333333333333333333333333333333333:0",
-              "lovelace": 75000000,
-              "is_own_input": true
-            },
-            {
-              "op": "add_input_utxo",
-              "utxo_ref": "3333333333333333333333333333333333333333333333333333333333333333:1",
-              "lovelace": 75000000,
-              "is_own_input": true
-            },
-            {
-              "op": "add_output_utxo",
-              "address": {
-                "type": "pubkey",
-                "pubkey_hash": "@seller_pubkey"
-              },
-              "lovelace": 75000000
-            }
-          ]
-        }
-      },
       "expected": {
         "type": "value",
         "content": "(con unit ())"
-      }
+      },
+      "inputs": [
+        {
+          "type": "script_context",
+          "script_context": {
+            "baseline": "spending",
+            "patches": [
+              {
+                "op": "set_redeemer",
+                "redeemer": "1"
+              },
+              {
+                "op": "add_signature",
+                "pubkey_hash": "@seller_pubkey"
+              },
+              {
+                "op": "set_script_datum",
+                "datum": "@deposited_escrow_datum"
+              },
+              {
+                "op": "add_input_utxo",
+                "utxo_ref": "3333333333333333333333333333333333333333333333333333333333333333:0",
+                "lovelace": 75000000,
+                "is_own_input": true
+              },
+              {
+                "op": "add_input_utxo",
+                "utxo_ref": "3333333333333333333333333333333333333333333333333333333333333333:1",
+                "lovelace": 75000000,
+                "is_own_input": true
+              },
+              {
+                "op": "add_output_utxo",
+                "address": {
+                  "type": "pubkey",
+                  "pubkey_hash": "@seller_pubkey"
+                },
+                "lovelace": 75000000
+              }
+            ]
+          }
+        }
+      ]
     },
     {
       "name": "accept_with_partial_payment_to_seller",
       "description": "Accept with only 50 ADA payment to seller (insufficient - expects fail)",
-      "input": {
-        "type": "script_context",
-        "script_context": {
-          "baseline": "spending",
-          "patches": [
-            {
-              "op": "set_redeemer",
-              "redeemer": "1"
-            },
-            {
-              "op": "add_signature",
-              "pubkey_hash": "@seller_pubkey"
-            },
-            {
-              "op": "add_input_utxo",
-              "utxo_ref": "4444444444444444444444444444444444444444444444444444444444444444:0",
-              "lovelace": 75000000,
-              "is_own_input": true
-            },
-            {
-              "op": "add_output_utxo",
-              "address": {
-                "type": "pubkey",
-                "pubkey_hash": "@seller_pubkey"
-              },
-              "lovelace": 50000000
-            }
-          ]
-        }
-      },
       "expected": {
         "type": "error"
-      }
+      },
+      "inputs": [
+        {
+          "type": "script_context",
+          "script_context": {
+            "baseline": "spending",
+            "patches": [
+              {
+                "op": "set_redeemer",
+                "redeemer": "1"
+              },
+              {
+                "op": "add_signature",
+                "pubkey_hash": "@seller_pubkey"
+              },
+              {
+                "op": "add_input_utxo",
+                "utxo_ref": "4444444444444444444444444444444444444444444444444444444444444444:0",
+                "lovelace": 75000000,
+                "is_own_input": true
+              },
+              {
+                "op": "add_output_utxo",
+                "address": {
+                  "type": "pubkey",
+                  "pubkey_hash": "@seller_pubkey"
+                },
+                "lovelace": 50000000
+              }
+            ]
+          }
+        }
+      ]
     },
     {
       "name": "accept_with_excess_payment_to_seller",
       "description": "Accept with 100 ADA payment to seller (excess amount - expects fail due to exact validation)",
-      "input": {
-        "type": "script_context",
-        "script_context": {
-          "baseline": "spending",
-          "patches": [
-            {
-              "op": "set_redeemer",
-              "redeemer": "1"
-            },
-            {
-              "op": "add_signature",
-              "pubkey_hash": "@seller_pubkey"
-            },
-            {
-              "op": "add_input_utxo",
-              "utxo_ref": "4444444444444444444444444444444444444444444444444444444444444444:0",
-              "lovelace": 75000000,
-              "is_own_input": true
-            },
-            {
-              "op": "add_output_utxo",
-              "address": {
-                "type": "pubkey",
-                "pubkey_hash": "@seller_pubkey"
-              },
-              "lovelace": 100000000
-            }
-          ]
-        }
-      },
       "expected": {
         "type": "error"
-      }
+      },
+      "inputs": [
+        {
+          "type": "script_context",
+          "script_context": {
+            "baseline": "spending",
+            "patches": [
+              {
+                "op": "set_redeemer",
+                "redeemer": "1"
+              },
+              {
+                "op": "add_signature",
+                "pubkey_hash": "@seller_pubkey"
+              },
+              {
+                "op": "add_input_utxo",
+                "utxo_ref": "4444444444444444444444444444444444444444444444444444444444444444:0",
+                "lovelace": 75000000,
+                "is_own_input": true
+              },
+              {
+                "op": "add_output_utxo",
+                "address": {
+                  "type": "pubkey",
+                  "pubkey_hash": "@seller_pubkey"
+                },
+                "lovelace": 100000000
+              }
+            ]
+          }
+        }
+      ]
     },
     {
       "name": "accept_with_datum_attached",
       "description": "Accept with datum attached to seller's payment (expects pass)",
-      "input": {
-        "type": "script_context",
-        "script_context": {
-          "baseline": "@successful_accept",
-          "patches": []
-        }
-      },
       "expected": {
         "type": "value",
         "content": "(con unit ())"
-      }
+      },
+      "inputs": [
+        {
+          "type": "script_context",
+          "script_context": {
+            "baseline": "@successful_accept",
+            "patches": []
+          }
+        }
+      ]
     },
     {
       "name": "accept_with_multiple_outputs_to_seller",
       "description": "Accept with payment split across two outputs to seller (50+25 ADA - expects pass)",
-      "input": {
-        "type": "script_context",
-        "script_context": {
-          "baseline": "spending",
-          "patches": [
-            {
-              "op": "set_redeemer",
-              "redeemer": "1"
-            },
-            {
-              "op": "add_signature",
-              "pubkey_hash": "@seller_pubkey"
-            },
-            {
-              "op": "set_script_datum",
-              "datum": "@deposited_escrow_datum"
-            },
-            {
-              "op": "add_input_utxo",
-              "utxo_ref": "3333333333333333333333333333333333333333333333333333333333333333:1",
-              "lovelace": 75000000,
-              "is_own_input": true
-            },
-            {
-              "op": "add_output_utxo",
-              "address": {
-                "type": "pubkey",
-                "pubkey_hash": "@seller_pubkey"
-              },
-              "lovelace": 50000000
-            },
-            {
-              "op": "add_output_utxo",
-              "address": {
-                "type": "pubkey",
-                "pubkey_hash": "@seller_pubkey"
-              },
-              "lovelace": 25000000
-            }
-          ]
-        }
-      },
       "expected": {
         "type": "value",
         "content": "(con unit ())"
-      }
+      },
+      "inputs": [
+        {
+          "type": "script_context",
+          "script_context": {
+            "baseline": "spending",
+            "patches": [
+              {
+                "op": "set_redeemer",
+                "redeemer": "1"
+              },
+              {
+                "op": "add_signature",
+                "pubkey_hash": "@seller_pubkey"
+              },
+              {
+                "op": "set_script_datum",
+                "datum": "@deposited_escrow_datum"
+              },
+              {
+                "op": "add_input_utxo",
+                "utxo_ref": "3333333333333333333333333333333333333333333333333333333333333333:1",
+                "lovelace": 75000000,
+                "is_own_input": true
+              },
+              {
+                "op": "add_output_utxo",
+                "address": {
+                  "type": "pubkey",
+                  "pubkey_hash": "@seller_pubkey"
+                },
+                "lovelace": 50000000
+              },
+              {
+                "op": "add_output_utxo",
+                "address": {
+                  "type": "pubkey",
+                  "pubkey_hash": "@seller_pubkey"
+                },
+                "lovelace": 25000000
+              }
+            ]
+          }
+        }
+      ]
     },
     {
       "name": "accept_with_remaining_script_output",
       "description": "Accept while leaving funds in script (should fail - incomplete withdrawal)",
-      "input": {
-        "type": "script_context",
-        "script_context": {
-          "baseline": "spending",
-          "patches": [
-            {
-              "op": "set_redeemer",
-              "redeemer": "1"
-            },
-            {
-              "op": "add_signature",
-              "pubkey_hash": "@seller_pubkey"
-            },
-            {
-              "op": "add_input_utxo",
-              "utxo_ref": "4444444444444444444444444444444444444444444444444444444444444444:0",
-              "lovelace": 75000000,
-              "is_own_input": true
-            },
-            {
-              "op": "add_output_utxo",
-              "address": {
-                "type": "pubkey",
-                "pubkey_hash": "@seller_pubkey"
-              },
-              "lovelace": 75000000
-            },
-            {
-              "op": "add_output_utxo",
-              "address": {
-                "type": "script",
-                "script_hash": "1111111111111111111111111111111111111111111111111111111111"
-              },
-              "lovelace": 10000000
-            }
-          ]
-        }
-      },
       "expected": {
         "type": "error"
-      }
+      },
+      "inputs": [
+        {
+          "type": "script_context",
+          "script_context": {
+            "baseline": "spending",
+            "patches": [
+              {
+                "op": "set_redeemer",
+                "redeemer": "1"
+              },
+              {
+                "op": "add_signature",
+                "pubkey_hash": "@seller_pubkey"
+              },
+              {
+                "op": "add_input_utxo",
+                "utxo_ref": "4444444444444444444444444444444444444444444444444444444444444444:0",
+                "lovelace": 75000000,
+                "is_own_input": true
+              },
+              {
+                "op": "add_output_utxo",
+                "address": {
+                  "type": "pubkey",
+                  "pubkey_hash": "@seller_pubkey"
+                },
+                "lovelace": 75000000
+              },
+              {
+                "op": "add_output_utxo",
+                "address": {
+                  "type": "script",
+                  "script_hash": "1111111111111111111111111111111111111111111111111111111111"
+                },
+                "lovelace": 10000000
+              }
+            ]
+          }
+        }
+      ]
     },
     {
       "name": "refund_successful",
       "description": "Refund after deadline with buyer signature should succeed",
-      "input": {
-        "type": "script_context",
-        "script_context": {
-          "baseline": "@successful_refund",
-          "patches": []
-        }
-      },
       "expected": {
         "type": "value",
         "content": "(con unit ())"
-      }
+      },
+      "inputs": [
+        {
+          "type": "script_context",
+          "script_context": {
+            "baseline": "@successful_refund",
+            "patches": []
+          }
+        }
+      ]
     },
     {
       "name": "refund_after_exact_deadline",
       "description": "Refund exactly 1 second after deadline expiry should succeed",
-      "input": {
-        "type": "script_context",
-        "script_context": {
-          "baseline": "@successful_refund",
-          "patches": []
-        }
-      },
       "expected": {
         "type": "value",
         "content": "(con unit ())"
-      }
+      },
+      "inputs": [
+        {
+          "type": "script_context",
+          "script_context": {
+            "baseline": "@successful_refund",
+            "patches": []
+          }
+        }
+      ]
     },
     {
       "name": "refund_with_multiple_inputs",
       "description": "Refund with multiple script inputs should succeed (no single input validation)",
-      "input": {
-        "type": "script_context",
-        "script_context": {
-          "baseline": "spending",
-          "patches": [
-            {
-              "op": "set_redeemer",
-              "redeemer": "2"
-            },
-            {
-              "op": "add_signature",
-              "pubkey_hash": "@buyer_pubkey"
-            },
-            {
-              "op": "set_script_datum",
-              "datum": "@deposited_escrow_datum"
-            },
-            {
-              "op": "set_valid_range",
-              "from_time": 3000
-            },
-            {
-              "op": "add_input_utxo",
-              "utxo_ref": "3333333333333333333333333333333333333333333333333333333333333333:0",
-              "lovelace": 75000000,
-              "is_own_input": true
-            },
-            {
-              "op": "add_input_utxo",
-              "utxo_ref": "3333333333333333333333333333333333333333333333333333333333333333:1",
-              "lovelace": 75000000,
-              "is_own_input": true
-            },
-            {
-              "op": "add_output_utxo",
-              "address": {
-                "type": "pubkey",
-                "pubkey_hash": "@buyer_pubkey"
-              },
-              "lovelace": 75000000
-            }
-          ]
-        }
-      },
       "expected": {
         "type": "value",
         "content": "(con unit ())"
-      }
+      },
+      "inputs": [
+        {
+          "type": "script_context",
+          "script_context": {
+            "baseline": "spending",
+            "patches": [
+              {
+                "op": "set_redeemer",
+                "redeemer": "2"
+              },
+              {
+                "op": "add_signature",
+                "pubkey_hash": "@buyer_pubkey"
+              },
+              {
+                "op": "set_script_datum",
+                "datum": "@deposited_escrow_datum"
+              },
+              {
+                "op": "set_valid_range",
+                "from_time": 3000
+              },
+              {
+                "op": "add_input_utxo",
+                "utxo_ref": "3333333333333333333333333333333333333333333333333333333333333333:0",
+                "lovelace": 75000000,
+                "is_own_input": true
+              },
+              {
+                "op": "add_input_utxo",
+                "utxo_ref": "3333333333333333333333333333333333333333333333333333333333333333:1",
+                "lovelace": 75000000,
+                "is_own_input": true
+              },
+              {
+                "op": "add_output_utxo",
+                "address": {
+                  "type": "pubkey",
+                  "pubkey_hash": "@buyer_pubkey"
+                },
+                "lovelace": 75000000
+              }
+            ]
+          }
+        }
+      ]
     },
     {
       "name": "refund_with_datum_attached",
       "description": "Refund with datum attached to buyer's output should succeed",
-      "input": {
-        "type": "script_context",
-        "script_context": {
-          "baseline": "spending",
-          "patches": [
-            {
-              "op": "set_redeemer",
-              "redeemer": "2"
-            },
-            {
-              "op": "add_signature",
-              "pubkey_hash": "@buyer_pubkey"
-            },
-            {
-              "op": "set_script_datum",
-              "datum": "@deposited_escrow_datum"
-            },
-            {
-              "op": "set_valid_range",
-              "from_time": 3600
-            },
-            {
-              "op": "add_input_utxo",
-              "utxo_ref": "3333333333333333333333333333333333333333333333333333333333333333:1",
-              "lovelace": 75000000,
-              "is_own_input": true
-            },
-            {
-              "op": "add_output_utxo",
-              "address": {
-                "type": "pubkey",
-                "pubkey_hash": "@buyer_pubkey"
-              },
-              "lovelace": 75000000
-            }
-          ]
-        }
-      },
       "expected": {
         "type": "value",
         "content": "(con unit ())"
-      }
+      },
+      "inputs": [
+        {
+          "type": "script_context",
+          "script_context": {
+            "baseline": "spending",
+            "patches": [
+              {
+                "op": "set_redeemer",
+                "redeemer": "2"
+              },
+              {
+                "op": "add_signature",
+                "pubkey_hash": "@buyer_pubkey"
+              },
+              {
+                "op": "set_script_datum",
+                "datum": "@deposited_escrow_datum"
+              },
+              {
+                "op": "set_valid_range",
+                "from_time": 3600
+              },
+              {
+                "op": "add_input_utxo",
+                "utxo_ref": "3333333333333333333333333333333333333333333333333333333333333333:1",
+                "lovelace": 75000000,
+                "is_own_input": true
+              },
+              {
+                "op": "add_output_utxo",
+                "address": {
+                  "type": "pubkey",
+                  "pubkey_hash": "@buyer_pubkey"
+                },
+                "lovelace": 75000000
+              }
+            ]
+          }
+        }
+      ]
     },
     {
       "name": "refund_with_multiple_outputs_to_buyer",
       "description": "Refund split across two outputs to buyer (50+25 ADA) should succeed",
-      "input": {
-        "type": "script_context",
-        "script_context": {
-          "baseline": "spending",
-          "patches": [
-            {
-              "op": "set_redeemer",
-              "redeemer": "2"
-            },
-            {
-              "op": "add_signature",
-              "pubkey_hash": "@buyer_pubkey"
-            },
-            {
-              "op": "set_script_datum",
-              "datum": "@deposited_escrow_datum"
-            },
-            {
-              "op": "set_valid_range",
-              "from_time": 5000
-            },
-            {
-              "op": "add_input_utxo",
-              "utxo_ref": "3333333333333333333333333333333333333333333333333333333333333333:1",
-              "lovelace": 75000000,
-              "is_own_input": true
-            },
-            {
-              "op": "add_output_utxo",
-              "address": {
-                "type": "pubkey",
-                "pubkey_hash": "@buyer_pubkey"
-              },
-              "lovelace": 50000000
-            },
-            {
-              "op": "add_output_utxo",
-              "address": {
-                "type": "pubkey",
-                "pubkey_hash": "@buyer_pubkey"
-              },
-              "lovelace": 25000000
-            }
-          ]
-        }
-      },
       "expected": {
         "type": "value",
         "content": "(con unit ())"
-      }
+      },
+      "inputs": [
+        {
+          "type": "script_context",
+          "script_context": {
+            "baseline": "spending",
+            "patches": [
+              {
+                "op": "set_redeemer",
+                "redeemer": "2"
+              },
+              {
+                "op": "add_signature",
+                "pubkey_hash": "@buyer_pubkey"
+              },
+              {
+                "op": "set_script_datum",
+                "datum": "@deposited_escrow_datum"
+              },
+              {
+                "op": "set_valid_range",
+                "from_time": 5000
+              },
+              {
+                "op": "add_input_utxo",
+                "utxo_ref": "3333333333333333333333333333333333333333333333333333333333333333:1",
+                "lovelace": 75000000,
+                "is_own_input": true
+              },
+              {
+                "op": "add_output_utxo",
+                "address": {
+                  "type": "pubkey",
+                  "pubkey_hash": "@buyer_pubkey"
+                },
+                "lovelace": 50000000
+              },
+              {
+                "op": "add_output_utxo",
+                "address": {
+                  "type": "pubkey",
+                  "pubkey_hash": "@buyer_pubkey"
+                },
+                "lovelace": 25000000
+              }
+            ]
+          }
+        }
+      ]
     },
     {
       "name": "refund_without_buyer_signature",
       "description": "Refund without buyer signature should fail",
-      "input": {
-        "type": "script_context",
-        "script_context": {
-          "baseline": "@successful_refund",
-          "patches": [
-            {
-              "op": "remove_signature",
-              "pubkey_hash": "@buyer_pubkey"
-            }
-          ]
-        }
-      },
       "expected": {
         "type": "error"
-      }
+      },
+      "inputs": [
+        {
+          "type": "script_context",
+          "script_context": {
+            "baseline": "@successful_refund",
+            "patches": [
+              {
+                "op": "remove_signature",
+                "pubkey_hash": "@buyer_pubkey"
+              }
+            ]
+          }
+        }
+      ]
     },
     {
       "name": "refund_with_seller_signature_only",
       "description": "Refund with seller signature instead of buyer should fail",
-      "input": {
-        "type": "script_context",
-        "script_context": {
-          "baseline": "spending",
-          "patches": [
-            {
-              "op": "set_redeemer",
-              "redeemer": "2"
-            },
-            {
-              "op": "add_signature",
-              "pubkey_hash": "@seller_pubkey"
-            },
-            {
-              "op": "set_valid_range",
-              "from_time": 2000
-            },
-            {
-              "op": "add_input_utxo",
-              "utxo_ref": "4444444444444444444444444444444444444444444444444444444444444444:0",
-              "lovelace": 75000000,
-              "is_own_input": true
-            },
-            {
-              "op": "add_output_utxo",
-              "address": {
-                "type": "pubkey",
-                "pubkey_hash": "@buyer_pubkey"
-              },
-              "lovelace": 75000000
-            }
-          ]
-        }
-      },
       "expected": {
         "type": "error"
-      }
+      },
+      "inputs": [
+        {
+          "type": "script_context",
+          "script_context": {
+            "baseline": "spending",
+            "patches": [
+              {
+                "op": "set_redeemer",
+                "redeemer": "2"
+              },
+              {
+                "op": "add_signature",
+                "pubkey_hash": "@seller_pubkey"
+              },
+              {
+                "op": "set_valid_range",
+                "from_time": 2000
+              },
+              {
+                "op": "add_input_utxo",
+                "utxo_ref": "4444444444444444444444444444444444444444444444444444444444444444:0",
+                "lovelace": 75000000,
+                "is_own_input": true
+              },
+              {
+                "op": "add_output_utxo",
+                "address": {
+                  "type": "pubkey",
+                  "pubkey_hash": "@buyer_pubkey"
+                },
+                "lovelace": 75000000
+              }
+            ]
+          }
+        }
+      ]
     },
     {
       "name": "refund_with_impostor_signature",
       "description": "Refund with impostor signature should fail",
-      "input": {
-        "type": "script_context",
-        "script_context": {
-          "baseline": "spending",
-          "patches": [
-            {
-              "op": "set_redeemer",
-              "redeemer": "2"
-            },
-            {
-              "op": "add_signature",
-              "pubkey_hash": "@impostor_pubkey"
-            },
-            {
-              "op": "set_valid_range",
-              "from_time": 2000
-            },
-            {
-              "op": "add_input_utxo",
-              "utxo_ref": "4444444444444444444444444444444444444444444444444444444444444444:0",
-              "lovelace": 75000000,
-              "is_own_input": true
-            },
-            {
-              "op": "add_output_utxo",
-              "address": {
-                "type": "pubkey",
-                "pubkey_hash": "@buyer_pubkey"
-              },
-              "lovelace": 75000000
-            }
-          ]
-        }
-      },
       "expected": {
         "type": "error"
-      }
+      },
+      "inputs": [
+        {
+          "type": "script_context",
+          "script_context": {
+            "baseline": "spending",
+            "patches": [
+              {
+                "op": "set_redeemer",
+                "redeemer": "2"
+              },
+              {
+                "op": "add_signature",
+                "pubkey_hash": "@impostor_pubkey"
+              },
+              {
+                "op": "set_valid_range",
+                "from_time": 2000
+              },
+              {
+                "op": "add_input_utxo",
+                "utxo_ref": "4444444444444444444444444444444444444444444444444444444444444444:0",
+                "lovelace": 75000000,
+                "is_own_input": true
+              },
+              {
+                "op": "add_output_utxo",
+                "address": {
+                  "type": "pubkey",
+                  "pubkey_hash": "@buyer_pubkey"
+                },
+                "lovelace": 75000000
+              }
+            ]
+          }
+        }
+      ]
     },
     {
       "name": "refund_before_deadline",
       "description": "Refund before deadline expiry should fail",
-      "input": {
-        "type": "script_context",
-        "script_context": {
-          "baseline": "spending",
-          "patches": [
-            {
-              "op": "set_redeemer",
-              "redeemer": "2"
-            },
-            {
-              "op": "add_signature",
-              "pubkey_hash": "@buyer_pubkey"
-            },
-            {
-              "op": "set_valid_range",
-              "from_time": 900
-            },
-            {
-              "op": "add_input_utxo",
-              "utxo_ref": "4444444444444444444444444444444444444444444444444444444444444444:0",
-              "lovelace": 75000000,
-              "is_own_input": true
-            },
-            {
-              "op": "add_output_utxo",
-              "address": {
-                "type": "pubkey",
-                "pubkey_hash": "@buyer_pubkey"
-              },
-              "lovelace": 75000000
-            }
-          ]
-        }
-      },
       "expected": {
         "type": "error"
-      }
+      },
+      "inputs": [
+        {
+          "type": "script_context",
+          "script_context": {
+            "baseline": "spending",
+            "patches": [
+              {
+                "op": "set_redeemer",
+                "redeemer": "2"
+              },
+              {
+                "op": "add_signature",
+                "pubkey_hash": "@buyer_pubkey"
+              },
+              {
+                "op": "set_valid_range",
+                "from_time": 900
+              },
+              {
+                "op": "add_input_utxo",
+                "utxo_ref": "4444444444444444444444444444444444444444444444444444444444444444:0",
+                "lovelace": 75000000,
+                "is_own_input": true
+              },
+              {
+                "op": "add_output_utxo",
+                "address": {
+                  "type": "pubkey",
+                  "pubkey_hash": "@buyer_pubkey"
+                },
+                "lovelace": 75000000
+              }
+            ]
+          }
+        }
+      ]
     },
     {
       "name": "refund_at_exact_deadline",
       "description": "Refund exactly at deadline should fail (must be strictly after)",
-      "input": {
-        "type": "script_context",
-        "script_context": {
-          "baseline": "spending",
-          "patches": [
-            {
-              "op": "set_redeemer",
-              "redeemer": "2"
-            },
-            {
-              "op": "add_signature",
-              "pubkey_hash": "@buyer_pubkey"
-            },
-            {
-              "op": "set_valid_range",
-              "from_time": 1800
-            },
-            {
-              "op": "add_input_utxo",
-              "utxo_ref": "4444444444444444444444444444444444444444444444444444444444444444:0",
-              "lovelace": 75000000,
-              "is_own_input": true
-            },
-            {
-              "op": "add_output_utxo",
-              "address": {
-                "type": "pubkey",
-                "pubkey_hash": "@buyer_pubkey"
-              },
-              "lovelace": 75000000
-            }
-          ]
-        }
-      },
       "expected": {
         "type": "error"
-      }
+      },
+      "inputs": [
+        {
+          "type": "script_context",
+          "script_context": {
+            "baseline": "spending",
+            "patches": [
+              {
+                "op": "set_redeemer",
+                "redeemer": "2"
+              },
+              {
+                "op": "add_signature",
+                "pubkey_hash": "@buyer_pubkey"
+              },
+              {
+                "op": "set_valid_range",
+                "from_time": 1800
+              },
+              {
+                "op": "add_input_utxo",
+                "utxo_ref": "4444444444444444444444444444444444444444444444444444444444444444:0",
+                "lovelace": 75000000,
+                "is_own_input": true
+              },
+              {
+                "op": "add_output_utxo",
+                "address": {
+                  "type": "pubkey",
+                  "pubkey_hash": "@buyer_pubkey"
+                },
+                "lovelace": 75000000
+              }
+            ]
+          }
+        }
+      ]
     },
     {
       "name": "refund_with_no_time_range",
       "description": "Refund without time range should fail (missing temporal context)",
-      "input": {
-        "type": "script_context",
-        "script_context": {
-          "baseline": "spending",
-          "patches": [
-            {
-              "op": "set_redeemer",
-              "redeemer": "2"
-            },
-            {
-              "op": "add_signature",
-              "pubkey_hash": "@buyer_pubkey"
-            },
-            {
-              "op": "add_input_utxo",
-              "utxo_ref": "4444444444444444444444444444444444444444444444444444444444444444:0",
-              "lovelace": 75000000,
-              "is_own_input": true
-            },
-            {
-              "op": "add_output_utxo",
-              "address": {
-                "type": "pubkey",
-                "pubkey_hash": "@buyer_pubkey"
-              },
-              "lovelace": 75000000
-            }
-          ]
-        }
-      },
       "expected": {
         "type": "error"
-      }
+      },
+      "inputs": [
+        {
+          "type": "script_context",
+          "script_context": {
+            "baseline": "spending",
+            "patches": [
+              {
+                "op": "set_redeemer",
+                "redeemer": "2"
+              },
+              {
+                "op": "add_signature",
+                "pubkey_hash": "@buyer_pubkey"
+              },
+              {
+                "op": "add_input_utxo",
+                "utxo_ref": "4444444444444444444444444444444444444444444444444444444444444444:0",
+                "lovelace": 75000000,
+                "is_own_input": true
+              },
+              {
+                "op": "add_output_utxo",
+                "address": {
+                  "type": "pubkey",
+                  "pubkey_hash": "@buyer_pubkey"
+                },
+                "lovelace": 75000000
+              }
+            ]
+          }
+        }
+      ]
     },
     {
       "name": "refund_with_incorrect_amount",
       "description": "Refund with wrong total amount (80 ADA instead of 75) should fail",
-      "input": {
-        "type": "script_context",
-        "script_context": {
-          "baseline": "spending",
-          "patches": [
-            {
-              "op": "set_redeemer",
-              "redeemer": "2"
-            },
-            {
-              "op": "add_signature",
-              "pubkey_hash": "@buyer_pubkey"
-            },
-            {
-              "op": "set_valid_range",
-              "from_time": 2000
-            },
-            {
-              "op": "add_input_utxo",
-              "utxo_ref": "4444444444444444444444444444444444444444444444444444444444444444:0",
-              "lovelace": 75000000,
-              "is_own_input": true
-            },
-            {
-              "op": "add_output_utxo",
-              "address": {
-                "type": "pubkey",
-                "pubkey_hash": "@buyer_pubkey"
-              },
-              "lovelace": 80000000
-            }
-          ]
-        }
-      },
       "expected": {
         "type": "error"
-      }
+      },
+      "inputs": [
+        {
+          "type": "script_context",
+          "script_context": {
+            "baseline": "spending",
+            "patches": [
+              {
+                "op": "set_redeemer",
+                "redeemer": "2"
+              },
+              {
+                "op": "add_signature",
+                "pubkey_hash": "@buyer_pubkey"
+              },
+              {
+                "op": "set_valid_range",
+                "from_time": 2000
+              },
+              {
+                "op": "add_input_utxo",
+                "utxo_ref": "4444444444444444444444444444444444444444444444444444444444444444:0",
+                "lovelace": 75000000,
+                "is_own_input": true
+              },
+              {
+                "op": "add_output_utxo",
+                "address": {
+                  "type": "pubkey",
+                  "pubkey_hash": "@buyer_pubkey"
+                },
+                "lovelace": 80000000
+              }
+            ]
+          }
+        }
+      ]
     },
     {
       "name": "refund_with_partial_refund",
       "description": "Partial refund (50 ADA to buyer) should fail",
-      "input": {
-        "type": "script_context",
-        "script_context": {
-          "baseline": "spending",
-          "patches": [
-            {
-              "op": "set_redeemer",
-              "redeemer": "2"
-            },
-            {
-              "op": "add_signature",
-              "pubkey_hash": "@buyer_pubkey"
-            },
-            {
-              "op": "set_valid_range",
-              "from_time": 2000
-            },
-            {
-              "op": "add_input_utxo",
-              "utxo_ref": "4444444444444444444444444444444444444444444444444444444444444444:0",
-              "lovelace": 75000000,
-              "is_own_input": true
-            },
-            {
-              "op": "add_output_utxo",
-              "address": {
-                "type": "pubkey",
-                "pubkey_hash": "@buyer_pubkey"
-              },
-              "lovelace": 50000000
-            }
-          ]
-        }
-      },
       "expected": {
         "type": "error"
-      }
+      },
+      "inputs": [
+        {
+          "type": "script_context",
+          "script_context": {
+            "baseline": "spending",
+            "patches": [
+              {
+                "op": "set_redeemer",
+                "redeemer": "2"
+              },
+              {
+                "op": "add_signature",
+                "pubkey_hash": "@buyer_pubkey"
+              },
+              {
+                "op": "set_valid_range",
+                "from_time": 2000
+              },
+              {
+                "op": "add_input_utxo",
+                "utxo_ref": "4444444444444444444444444444444444444444444444444444444444444444:0",
+                "lovelace": 75000000,
+                "is_own_input": true
+              },
+              {
+                "op": "add_output_utxo",
+                "address": {
+                  "type": "pubkey",
+                  "pubkey_hash": "@buyer_pubkey"
+                },
+                "lovelace": 50000000
+              }
+            ]
+          }
+        }
+      ]
     },
     {
       "name": "refund_with_excess_refund",
       "description": "Excess refund (100 ADA to buyer) should fail",
-      "input": {
-        "type": "script_context",
-        "script_context": {
-          "baseline": "spending",
-          "patches": [
-            {
-              "op": "set_redeemer",
-              "redeemer": "2"
-            },
-            {
-              "op": "add_signature",
-              "pubkey_hash": "@buyer_pubkey"
-            },
-            {
-              "op": "set_valid_range",
-              "from_time": 2000
-            },
-            {
-              "op": "add_input_utxo",
-              "utxo_ref": "4444444444444444444444444444444444444444444444444444444444444444:0",
-              "lovelace": 75000000,
-              "is_own_input": true
-            },
-            {
-              "op": "add_output_utxo",
-              "address": {
-                "type": "pubkey",
-                "pubkey_hash": "@buyer_pubkey"
-              },
-              "lovelace": 100000000
-            }
-          ]
-        }
-      },
       "expected": {
         "type": "error"
-      }
+      },
+      "inputs": [
+        {
+          "type": "script_context",
+          "script_context": {
+            "baseline": "spending",
+            "patches": [
+              {
+                "op": "set_redeemer",
+                "redeemer": "2"
+              },
+              {
+                "op": "add_signature",
+                "pubkey_hash": "@buyer_pubkey"
+              },
+              {
+                "op": "set_valid_range",
+                "from_time": 2000
+              },
+              {
+                "op": "add_input_utxo",
+                "utxo_ref": "4444444444444444444444444444444444444444444444444444444444444444:0",
+                "lovelace": 75000000,
+                "is_own_input": true
+              },
+              {
+                "op": "add_output_utxo",
+                "address": {
+                  "type": "pubkey",
+                  "pubkey_hash": "@buyer_pubkey"
+                },
+                "lovelace": 100000000
+              }
+            ]
+          }
+        }
+      ]
     },
     {
       "name": "refund_to_wrong_address",
       "description": "Refund to wrong address (seller instead of buyer) should fail",
-      "input": {
-        "type": "script_context",
-        "script_context": {
-          "baseline": "spending",
-          "patches": [
-            {
-              "op": "set_redeemer",
-              "redeemer": "2"
-            },
-            {
-              "op": "add_signature",
-              "pubkey_hash": "@buyer_pubkey"
-            },
-            {
-              "op": "set_valid_range",
-              "from_time": 2000
-            },
-            {
-              "op": "add_input_utxo",
-              "utxo_ref": "4444444444444444444444444444444444444444444444444444444444444444:0",
-              "lovelace": 75000000,
-              "is_own_input": true
-            },
-            {
-              "op": "add_output_utxo",
-              "address": {
-                "type": "pubkey",
-                "pubkey_hash": "@seller_pubkey"
-              },
-              "lovelace": 75000000
-            }
-          ]
-        }
-      },
       "expected": {
         "type": "error"
-      }
+      },
+      "inputs": [
+        {
+          "type": "script_context",
+          "script_context": {
+            "baseline": "spending",
+            "patches": [
+              {
+                "op": "set_redeemer",
+                "redeemer": "2"
+              },
+              {
+                "op": "add_signature",
+                "pubkey_hash": "@buyer_pubkey"
+              },
+              {
+                "op": "set_valid_range",
+                "from_time": 2000
+              },
+              {
+                "op": "add_input_utxo",
+                "utxo_ref": "4444444444444444444444444444444444444444444444444444444444444444:0",
+                "lovelace": 75000000,
+                "is_own_input": true
+              },
+              {
+                "op": "add_output_utxo",
+                "address": {
+                  "type": "pubkey",
+                  "pubkey_hash": "@seller_pubkey"
+                },
+                "lovelace": 75000000
+              }
+            ]
+          }
+        }
+      ]
     },
     {
       "name": "refund_with_remaining_script_output",
       "description": "Refund leaving funds in script should fail (incomplete withdrawal)",
-      "input": {
-        "type": "script_context",
-        "script_context": {
-          "baseline": "spending",
-          "patches": [
-            {
-              "op": "set_redeemer",
-              "redeemer": "2"
-            },
-            {
-              "op": "add_signature",
-              "pubkey_hash": "@buyer_pubkey"
-            },
-            {
-              "op": "set_valid_range",
-              "from_time": 2000
-            },
-            {
-              "op": "add_input_utxo",
-              "utxo_ref": "4444444444444444444444444444444444444444444444444444444444444444:0",
-              "lovelace": 75000000,
-              "is_own_input": true
-            },
-            {
-              "op": "add_output_utxo",
-              "address": {
-                "type": "pubkey",
-                "pubkey_hash": "@buyer_pubkey"
-              },
-              "lovelace": 65000000
-            },
-            {
-              "op": "add_output_utxo",
-              "address": {
-                "type": "script",
-                "script_hash": "1111111111111111111111111111111111111111111111111111111111"
-              },
-              "lovelace": 10000000
-            }
-          ]
-        }
-      },
       "expected": {
         "type": "error"
-      }
+      },
+      "inputs": [
+        {
+          "type": "script_context",
+          "script_context": {
+            "baseline": "spending",
+            "patches": [
+              {
+                "op": "set_redeemer",
+                "redeemer": "2"
+              },
+              {
+                "op": "add_signature",
+                "pubkey_hash": "@buyer_pubkey"
+              },
+              {
+                "op": "set_valid_range",
+                "from_time": 2000
+              },
+              {
+                "op": "add_input_utxo",
+                "utxo_ref": "4444444444444444444444444444444444444444444444444444444444444444:0",
+                "lovelace": 75000000,
+                "is_own_input": true
+              },
+              {
+                "op": "add_output_utxo",
+                "address": {
+                  "type": "pubkey",
+                  "pubkey_hash": "@buyer_pubkey"
+                },
+                "lovelace": 65000000
+              },
+              {
+                "op": "add_output_utxo",
+                "address": {
+                  "type": "script",
+                  "script_hash": "1111111111111111111111111111111111111111111111111111111111"
+                },
+                "lovelace": 10000000
+              }
+            ]
+          }
+        }
+      ]
     },
     {
       "name": "refund_without_prior_deposit",
       "description": "Refund without valid deposit UTXO should fail (invalid escrow state)",
-      "input": {
-        "type": "script_context",
-        "script_context": {
-          "baseline": "spending",
-          "patches": [
-            {
-              "op": "set_redeemer",
-              "redeemer": "2"
-            },
-            {
-              "op": "add_signature",
-              "pubkey_hash": "@buyer_pubkey"
-            },
-            {
-              "op": "set_valid_range",
-              "from_time": 2000
-            },
-            {
-              "op": "add_output_utxo",
-              "address": {
-                "type": "pubkey",
-                "pubkey_hash": "@buyer_pubkey"
-              },
-              "lovelace": 75000000
-            }
-          ]
-        }
-      },
       "expected": {
         "type": "error"
-      }
+      },
+      "inputs": [
+        {
+          "type": "script_context",
+          "script_context": {
+            "baseline": "spending",
+            "patches": [
+              {
+                "op": "set_redeemer",
+                "redeemer": "2"
+              },
+              {
+                "op": "add_signature",
+                "pubkey_hash": "@buyer_pubkey"
+              },
+              {
+                "op": "set_valid_range",
+                "from_time": 2000
+              },
+              {
+                "op": "add_output_utxo",
+                "address": {
+                  "type": "pubkey",
+                  "pubkey_hash": "@buyer_pubkey"
+                },
+                "lovelace": 75000000
+              }
+            ]
+          }
+        }
+      ]
     },
     {
       "name": "refund_after_accept_should_fail",
       "description": "Refund attempt after seller has already accepted should fail (state validation)",
-      "input": {
-        "type": "script_context",
-        "script_context": {
-          "baseline": "spending",
-          "patches": [
-            {
-              "op": "set_redeemer",
-              "redeemer": "2"
-            },
-            {
-              "op": "add_signature",
-              "pubkey_hash": "@buyer_pubkey"
-            },
-            {
-              "op": "set_valid_range",
-              "from_time": 2000
-            },
-            {
-              "op": "set_script_datum",
-              "datum": "@accepted_escrow_datum"
-            },
-            {
-              "op": "add_input_utxo",
-              "utxo_ref": "4444444444444444444444444444444444444444444444444444444444444444:0",
-              "lovelace": 75000000,
-              "is_own_input": true
-            },
-            {
-              "op": "add_output_utxo",
-              "address": {
-                "type": "pubkey",
-                "pubkey_hash": "@buyer_pubkey"
-              },
-              "lovelace": 75000000
-            }
-          ]
-        }
-      },
       "expected": {
         "type": "error"
-      }
+      },
+      "inputs": [
+        {
+          "type": "script_context",
+          "script_context": {
+            "baseline": "spending",
+            "patches": [
+              {
+                "op": "set_redeemer",
+                "redeemer": "2"
+              },
+              {
+                "op": "add_signature",
+                "pubkey_hash": "@buyer_pubkey"
+              },
+              {
+                "op": "set_valid_range",
+                "from_time": 2000
+              },
+              {
+                "op": "set_script_datum",
+                "datum": "@accepted_escrow_datum"
+              },
+              {
+                "op": "add_input_utxo",
+                "utxo_ref": "4444444444444444444444444444444444444444444444444444444444444444:0",
+                "lovelace": 75000000,
+                "is_own_input": true
+              },
+              {
+                "op": "add_output_utxo",
+                "address": {
+                  "type": "pubkey",
+                  "pubkey_hash": "@buyer_pubkey"
+                },
+                "lovelace": 75000000
+              }
+            ]
+          }
+        }
+      ]
     },
     {
       "name": "accept_after_refund_should_fail",
       "description": "Accept attempt after buyer has already refunded should fail (state validation)",
-      "input": {
-        "type": "script_context",
-        "script_context": {
-          "baseline": "spending",
-          "patches": [
-            {
-              "op": "set_redeemer",
-              "redeemer": "1"
-            },
-            {
-              "op": "add_signature",
-              "pubkey_hash": "@seller_pubkey"
-            },
-            {
-              "op": "set_script_datum",
-              "datum": "@refunded_escrow_datum"
-            },
-            {
-              "op": "add_input_utxo",
-              "utxo_ref": "4444444444444444444444444444444444444444444444444444444444444444:0",
-              "lovelace": 75000000,
-              "is_own_input": true
-            },
-            {
-              "op": "add_output_utxo",
-              "address": {
-                "type": "pubkey",
-                "pubkey_hash": "@seller_pubkey"
-              },
-              "lovelace": 75000000
-            }
-          ]
-        }
-      },
       "expected": {
         "type": "error"
-      }
+      },
+      "inputs": [
+        {
+          "type": "script_context",
+          "script_context": {
+            "baseline": "spending",
+            "patches": [
+              {
+                "op": "set_redeemer",
+                "redeemer": "1"
+              },
+              {
+                "op": "add_signature",
+                "pubkey_hash": "@seller_pubkey"
+              },
+              {
+                "op": "set_script_datum",
+                "datum": "@refunded_escrow_datum"
+              },
+              {
+                "op": "add_input_utxo",
+                "utxo_ref": "4444444444444444444444444444444444444444444444444444444444444444:0",
+                "lovelace": 75000000,
+                "is_own_input": true
+              },
+              {
+                "op": "add_output_utxo",
+                "address": {
+                  "type": "pubkey",
+                  "pubkey_hash": "@seller_pubkey"
+                },
+                "lovelace": 75000000
+              }
+            ]
+          }
+        }
+      ]
     },
     {
       "name": "double_refund_should_fail",
       "description": "Multiple refund attempts should fail (double spending prevention)",
-      "input": {
-        "type": "script_context",
-        "script_context": {
-          "baseline": "spending",
-          "patches": [
-            {
-              "op": "set_redeemer",
-              "redeemer": "2"
-            },
-            {
-              "op": "add_signature",
-              "pubkey_hash": "@buyer_pubkey"
-            },
-            {
-              "op": "set_valid_range",
-              "from_time": 2000
-            },
-            {
-              "op": "set_script_datum",
-              "datum": "@refunded_escrow_datum"
-            },
-            {
-              "op": "add_input_utxo",
-              "utxo_ref": "4444444444444444444444444444444444444444444444444444444444444444:0",
-              "lovelace": 75000000,
-              "is_own_input": true
-            },
-            {
-              "op": "add_output_utxo",
-              "address": {
-                "type": "pubkey",
-                "pubkey_hash": "@buyer_pubkey"
-              },
-              "lovelace": 75000000
-            }
-          ]
-        }
-      },
       "expected": {
         "type": "error"
-      }
+      },
+      "inputs": [
+        {
+          "type": "script_context",
+          "script_context": {
+            "baseline": "spending",
+            "patches": [
+              {
+                "op": "set_redeemer",
+                "redeemer": "2"
+              },
+              {
+                "op": "add_signature",
+                "pubkey_hash": "@buyer_pubkey"
+              },
+              {
+                "op": "set_valid_range",
+                "from_time": 2000
+              },
+              {
+                "op": "set_script_datum",
+                "datum": "@refunded_escrow_datum"
+              },
+              {
+                "op": "add_input_utxo",
+                "utxo_ref": "4444444444444444444444444444444444444444444444444444444444444444:0",
+                "lovelace": 75000000,
+                "is_own_input": true
+              },
+              {
+                "op": "add_output_utxo",
+                "address": {
+                  "type": "pubkey",
+                  "pubkey_hash": "@buyer_pubkey"
+                },
+                "lovelace": 75000000
+              }
+            ]
+          }
+        }
+      ]
     },
     {
       "name": "double_accept_should_fail",
       "description": "Multiple accept attempts should fail (double spending prevention)",
-      "input": {
-        "type": "script_context",
-        "script_context": {
-          "baseline": "spending",
-          "patches": [
-            {
-              "op": "set_redeemer",
-              "redeemer": "1"
-            },
-            {
-              "op": "add_signature",
-              "pubkey_hash": "@seller_pubkey"
-            },
-            {
-              "op": "set_script_datum",
-              "datum": "@accepted_escrow_datum"
-            },
-            {
-              "op": "add_input_utxo",
-              "utxo_ref": "4444444444444444444444444444444444444444444444444444444444444444:0",
-              "lovelace": 75000000,
-              "is_own_input": true
-            },
-            {
-              "op": "add_output_utxo",
-              "address": {
-                "type": "pubkey",
-                "pubkey_hash": "@seller_pubkey"
-              },
-              "lovelace": 75000000
-            }
-          ]
-        }
-      },
       "expected": {
         "type": "error"
-      }
+      },
+      "inputs": [
+        {
+          "type": "script_context",
+          "script_context": {
+            "baseline": "spending",
+            "patches": [
+              {
+                "op": "set_redeemer",
+                "redeemer": "1"
+              },
+              {
+                "op": "add_signature",
+                "pubkey_hash": "@seller_pubkey"
+              },
+              {
+                "op": "set_script_datum",
+                "datum": "@accepted_escrow_datum"
+              },
+              {
+                "op": "add_input_utxo",
+                "utxo_ref": "4444444444444444444444444444444444444444444444444444444444444444:0",
+                "lovelace": 75000000,
+                "is_own_input": true
+              },
+              {
+                "op": "add_output_utxo",
+                "address": {
+                  "type": "pubkey",
+                  "pubkey_hash": "@seller_pubkey"
+                },
+                "lovelace": 75000000
+              }
+            ]
+          }
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Extends the CAPE test framework to support **multi-argument functions** by changing the test format from single `input` to multiple `inputs`. This enables benchmarks like ECD (Euclidean Common Divisor) that require multiple parameters.

## Changes

### Core Framework Updates

**lib/Cape/Tests.hs**
- Changed `TestCase.tcInput :: Maybe TestInput` to `tcInputs :: [TestInput]`
- Updated FromJSON parser to read `inputs` array
- Added `Eq` instance to `InputType` for testing

**measure-app/Main.hs**
- Added `applyInputsToProgram` function for sequential input application
- Supports both UPLC and BuiltinData inputs
- UPLC inputs applied at term level via `UPLC.Apply`
- BuiltinData inputs applied using `MkPlc.mkConstant`
- Fixed name-shadowing warnings in ToJSON Measurements instance

### Test Infrastructure

**test/Cape/TestsSpec.hs**
- Added 4 comprehensive unit tests for multi-input support:
  - Single input in array
  - Multiple UPLC inputs
  - Empty inputs array (error-only tests)
  - Multiple BuiltinData inputs
- Uses `__i` QuasiQuoter for clean multi-line JSON

**cape.cabal**
- Added `QuasiQuotes` to global default-extensions
- Added `string-interpolate` dependency to test suite

### Scenario Migrations

All existing scenarios migrated to `inputs` format:
- scenarios/factorial/cape-tests.json
- scenarios/factorial_naive_recursion/cape-tests.json
- scenarios/fibonacci/cape-tests.json
- scenarios/fibonacci_naive_recursion/cape-tests.json
- scenarios/two-party-escrow/cape-tests.json

## Testing

- ✅ **220 Haskell unit tests pass** (100%)
- ✅ **51/53 CAPE integration tests pass**
- ✅ All existing submissions verify successfully
- ✅ Zero build warnings with -Werror

## Backward Compatibility

This is a **breaking change** - all test files use `inputs` array format atomically (no parallel support for old `input` format). All existing scenarios have been migrated.

## Closes

Closes #133

## Follow-up

Unblocks #132 (Add ECD synthetic scenario) which requires two-argument function support.