### PR TITLE
Add ECD (Euclidean Common Divisor) synthetic benchmark scenario

### DIFF
--- a/cape.cabal
+++ b/cape.cabal
@@ -81,6 +81,7 @@ library
     Cape.ScriptContextBuilder
     Cape.Tests
     Cape.Verify
+    Ecd
     Factorial
     Fibonacci
     PlutusCore.Data.Compact.Parser
@@ -151,6 +152,7 @@ test-suite cape-tests
     Cape.Protocol.ParametersSpec
     Cape.ScriptContextBuilderSpec
     Cape.TestsSpec
+    EcdSpec
     FactorialSpec
     FibonacciSpec
     PlutusCore.Data.Compact.ParserSpec

--- a/lib/Ecd.hs
+++ b/lib/Ecd.hs
@@ -1,0 +1,32 @@
+{-# LANGUAGE Strict #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+--
+{-# OPTIONS_GHC -fno-full-laziness #-}
+{-# OPTIONS_GHC -fno-ignore-interface-pragmas #-}
+{-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
+{-# OPTIONS_GHC -fno-spec-constr #-}
+{-# OPTIONS_GHC -fno-specialise #-}
+{-# OPTIONS_GHC -fno-strictness #-}
+{-# OPTIONS_GHC -fno-unbox-small-strict-fields #-}
+{-# OPTIONS_GHC -fno-unbox-strict-fields #-}
+{-# OPTIONS_GHC -fplugin PlutusTx.Plugin #-}
+{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:no-conservative-optimisation #-}
+{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:no-preserve-logging #-}
+{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:remove-trace #-}
+{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:target-version=1.1.0 #-}
+
+module Ecd (ecdCode) where
+
+import PlutusTx
+import PlutusTx.Prelude
+
+-- | Compiled ECD (Euclidean Common Divisor) function
+ecdCode :: CompiledCode (Integer -> Integer -> Integer)
+ecdCode = $$(PlutusTx.compile [||ecd||])
+
+{-# INLINEABLE ecd #-}
+ecd :: Integer -> Integer -> Integer
+ecd a b
+  | b == 0 = abs a
+  | otherwise = ecd b (a `modulo` b)

--- a/plinth-submissions-app/Main.hs
+++ b/plinth-submissions-app/Main.hs
@@ -2,6 +2,7 @@ module Main (main) where
 
 import Prelude
 
+import Ecd (ecdCode)
 import Factorial (factorialCode)
 import Fibonacci (fibonacciCode)
 import PlutusCore.Pretty qualified as PP
@@ -13,6 +14,9 @@ import UntypedPlutusCore.DeBruijn (unDeBruijnTerm)
 
 main :: IO ()
 main = do
+  writeCodeToFile
+    "submissions/ecd/Plinth_1.45.0.0_Unisay/ecd.uplc"
+    ecdCode
   writeCodeToFile
     "submissions/fibonacci_naive_recursion/Plinth_1.45.0.0_Unisay/fibonacci.uplc"
     fibonacciCode

--- a/scenarios/ecd/cape-tests.json
+++ b/scenarios/ecd/cape-tests.json
@@ -1,0 +1,258 @@
+{
+  "version": "1.0.0",
+  "description": "Comprehensive ECD (Euclidean Common Divisor) function testing across multiple input pairs",
+  "tests": [
+    {
+      "name": "ecd_0_12",
+      "description": "ECD of 0 and 12 should return 12 (edge case: first argument is zero)",
+      "inputs": [
+        {
+          "type": "uplc",
+          "value": "(con integer 0)"
+        },
+        {
+          "type": "uplc",
+          "value": "(con integer 12)"
+        }
+      ],
+      "expected": {
+        "type": "value",
+        "content": "(con integer 12)"
+      }
+    },
+    {
+      "name": "ecd_12_0",
+      "description": "ECD of 12 and 0 should return 12 (edge case: second argument is zero)",
+      "inputs": [
+        {
+          "type": "uplc",
+          "value": "(con integer 12)"
+        },
+        {
+          "type": "uplc",
+          "value": "(con integer 0)"
+        }
+      ],
+      "expected": {
+        "type": "value",
+        "content": "(con integer 12)"
+      }
+    },
+    {
+      "name": "ecd_7_7",
+      "description": "ECD of 7 and 7 should return 7 (edge case: identical numbers)",
+      "inputs": [
+        {
+          "type": "uplc",
+          "value": "(con integer 7)"
+        },
+        {
+          "type": "uplc",
+          "value": "(con integer 7)"
+        }
+      ],
+      "expected": {
+        "type": "value",
+        "content": "(con integer 7)"
+      }
+    },
+    {
+      "name": "ecd_6_9",
+      "description": "ECD of 6 and 9 should return 3",
+      "inputs": [
+        {
+          "type": "uplc",
+          "value": "(con integer 6)"
+        },
+        {
+          "type": "uplc",
+          "value": "(con integer 9)"
+        }
+      ],
+      "expected": {
+        "type": "value",
+        "content": "(con integer 3)"
+      }
+    },
+    {
+      "name": "ecd_12_8",
+      "description": "ECD of 12 and 8 should return 4",
+      "inputs": [
+        {
+          "type": "uplc",
+          "value": "(con integer 12)"
+        },
+        {
+          "type": "uplc",
+          "value": "(con integer 8)"
+        }
+      ],
+      "expected": {
+        "type": "value",
+        "content": "(con integer 4)"
+      }
+    },
+    {
+      "name": "ecd_15_25",
+      "description": "ECD of 15 and 25 should return 5",
+      "inputs": [
+        {
+          "type": "uplc",
+          "value": "(con integer 15)"
+        },
+        {
+          "type": "uplc",
+          "value": "(con integer 25)"
+        }
+      ],
+      "expected": {
+        "type": "value",
+        "content": "(con integer 5)"
+      }
+    },
+    {
+      "name": "ecd_17_19",
+      "description": "ECD of 17 and 19 should return 1 (coprime numbers)",
+      "inputs": [
+        {
+          "type": "uplc",
+          "value": "(con integer 17)"
+        },
+        {
+          "type": "uplc",
+          "value": "(con integer 19)"
+        }
+      ],
+      "expected": {
+        "type": "value",
+        "content": "(con integer 1)"
+      }
+    },
+    {
+      "name": "ecd_13_29",
+      "description": "ECD of 13 and 29 should return 1 (coprime numbers)",
+      "inputs": [
+        {
+          "type": "uplc",
+          "value": "(con integer 13)"
+        },
+        {
+          "type": "uplc",
+          "value": "(con integer 29)"
+        }
+      ],
+      "expected": {
+        "type": "value",
+        "content": "(con integer 1)"
+      }
+    },
+    {
+      "name": "ecd_48_18",
+      "description": "ECD of 48 and 18 should return 6",
+      "inputs": [
+        {
+          "type": "uplc",
+          "value": "(con integer 48)"
+        },
+        {
+          "type": "uplc",
+          "value": "(con integer 18)"
+        }
+      ],
+      "expected": {
+        "type": "value",
+        "content": "(con integer 6)"
+      }
+    },
+    {
+      "name": "ecd_100_75",
+      "description": "ECD of 100 and 75 should return 25",
+      "inputs": [
+        {
+          "type": "uplc",
+          "value": "(con integer 100)"
+        },
+        {
+          "type": "uplc",
+          "value": "(con integer 75)"
+        }
+      ],
+      "expected": {
+        "type": "value",
+        "content": "(con integer 25)"
+      }
+    },
+    {
+      "name": "ecd_1071_462",
+      "description": "ECD of 1071 and 462 should return 21 (larger numbers)",
+      "inputs": [
+        {
+          "type": "uplc",
+          "value": "(con integer 1071)"
+        },
+        {
+          "type": "uplc",
+          "value": "(con integer 462)"
+        }
+      ],
+      "expected": {
+        "type": "value",
+        "content": "(con integer 21)"
+      }
+    },
+    {
+      "name": "ecd_2520_1890",
+      "description": "ECD of 2520 and 1890 should return 630 (larger numbers)",
+      "inputs": [
+        {
+          "type": "uplc",
+          "value": "(con integer 2520)"
+        },
+        {
+          "type": "uplc",
+          "value": "(con integer 1890)"
+        }
+      ],
+      "expected": {
+        "type": "value",
+        "content": "(con integer 630)"
+      }
+    },
+    {
+      "name": "ecd_negative_12_8",
+      "description": "ECD of -12 and 8 should return 4 (negative first argument handled via abs)",
+      "inputs": [
+        {
+          "type": "uplc",
+          "value": "(con integer -12)"
+        },
+        {
+          "type": "uplc",
+          "value": "(con integer 8)"
+        }
+      ],
+      "expected": {
+        "type": "value",
+        "content": "(con integer 4)"
+      }
+    },
+    {
+      "name": "ecd_12_negative_8",
+      "description": "ECD of 12 and -8 should return 4 (negative second argument handled via abs)",
+      "inputs": [
+        {
+          "type": "uplc",
+          "value": "(con integer 12)"
+        },
+        {
+          "type": "uplc",
+          "value": "(con integer -8)"
+        }
+      ],
+      "expected": {
+        "type": "value",
+        "content": "(con integer 4)"
+      }
+    }
+  ]
+}

--- a/scenarios/ecd/ecd.md
+++ b/scenarios/ecd/ecd.md
@@ -1,0 +1,63 @@
+# ECD (Euclidean Common Divisor) Benchmark Scenario
+
+> **For submission requirements, metrics explanation, and validation steps, see the [Submission Guide](../../doc/submission-guide.md)**
+
+## Overview
+
+The ECD (Euclidean Common Divisor, also known as GCD - Greatest Common Divisor) benchmark measures compiler optimization effectiveness for a prescribed recursive algorithm. This scenario requires all submissions to implement the exact naive recursive Euclidean algorithm specified below, enabling pure compiler-to-compiler comparison where performance differences reflect compiler capabilities rather than algorithmic choices.
+
+## Exact Task
+
+Implement the prescribed naive recursive Euclidean algorithm and compile it as a **parameterized UPLC program** that accepts pairs of integer inputs and computes their greatest common divisor across all test cases.
+
+### Prescribed Algorithm
+
+All submissions MUST implement this exact algorithm:
+
+```haskell
+ecd :: Integer -> Integer -> Integer
+ecd a b
+  | b == 0    = abs a
+  | otherwise = ecd b (a `mod` b)
+```
+
+**Requirements:**
+
+- Naive recursive implementation matching the classical Euclidean algorithm above
+- Proper edge case handling (when b = 0, return abs a)
+- No tail-call optimization or accumulator patterns
+- No iterative loops
+- No algorithmic optimizations beyond compiler's automatic optimizations
+- Direct translation of the specified algorithm into your compiler's source language
+
+### Test Suite
+
+Your implementation must pass all test cases in `cape-tests.json`:
+
+- Edge cases: `ecd(0, 12) = 12`, `ecd(12, 0) = 12`, `ecd(n, n) = n`
+- Small values: `ecd(6, 9) = 3`, `ecd(12, 8) = 4`, `ecd(15, 25) = 5`
+- Coprime numbers: `ecd(17, 19) = 1`, `ecd(13, 29) = 1`
+- Moderate values: `ecd(48, 18) = 6`, `ecd(100, 75) = 25`
+- Larger values: `ecd(1071, 462) = 21`, `ecd(2520, 1890) = 630`
+- Negative inputs: `ecd(-12, 8) = 4`, `ecd(12, -8) = 4`
+
+## Technical Constraints
+
+- **Plutus Core Version**: Target Plutus Core 1.1.0
+- **Plutus Version**: V3 recommended (V1, V2 acceptable)
+- **Budget Limits**: Must complete within standard CEK machine execution limits for all test cases
+- **No External Dependencies**: Program must be self-contained
+- **Deterministic**: Must produce consistent results across multiple executions
+
+## Algorithm Compliance
+
+Submissions are reviewed during PR process to verify algorithm compliance:
+
+- Submission README must explain how the implementation matches the prescribed algorithm
+- Reviewers verify source code (if available) follows the naive recursive pattern
+- No deviations from the specified algorithm are permitted (e.g., no tail-recursion, no iterative loops, no Stein's algorithm)
+- Compiler-specific syntax and idioms are acceptable as long as the algorithm structure is preserved
+
+---
+
+_This benchmark enables compiler authors to demonstrate their optimization capabilities on a standardized algorithm, providing valuable insights for the Cardano developer community._

--- a/submissions/ecd/Plinth_1.45.0.0_Unisay/ecd.uplc
+++ b/submissions/ecd/Plinth_1.45.0.0_Unisay/ecd.uplc
@@ -1,0 +1,62 @@
+(program
+  1.1.0
+  [
+    (lam s-0 [ s-0 s-0 ])
+    (lam
+      s-1
+      (lam
+        a-2
+        (lam
+          b-3
+          (force
+            (force
+              [
+                [
+                  [
+                    (force (builtin ifThenElse))
+                    [ [ (builtin equalsInteger) (con integer 0) ] b-3 ]
+                  ]
+                  (delay
+                    (delay
+                      (force
+                        (force
+                          [
+                            [
+                              [
+                                (force (builtin ifThenElse))
+                                [
+                                  [ (builtin lessThanInteger) a-2 ]
+                                  (con integer 0)
+                                ]
+                              ]
+                              (delay
+                                (delay
+                                  [
+                                    [
+                                      (builtin subtractInteger) (con integer 0)
+                                    ]
+                                    a-2
+                                  ]
+                                )
+                              )
+                            ]
+                            (delay (delay a-2))
+                          ]
+                        )
+                      )
+                    )
+                  )
+                ]
+                (delay
+                  (delay
+                    [ [ [ s-1 s-1 ] b-3 ] [ [ (builtin modInteger) a-2 ] b-3 ] ]
+                  )
+                )
+              ]
+            )
+          )
+        )
+      )
+    )
+  ]
+)

--- a/submissions/ecd/Plinth_1.45.0.0_Unisay/metadata.json
+++ b/submissions/ecd/Plinth_1.45.0.0_Unisay/metadata.json
@@ -1,0 +1,32 @@
+{
+  "compiler": {
+    "name": "Plinth",
+    "version": "1.45.0.0",
+    "commit_hash": "f67df1cd505bf9779ff106ba2eba3aededcf4732"
+  },
+  "compilation_config": {
+    "optimization_level": "Plinth",
+    "target": "uplc",
+    "flags": ["Plinth"],
+    "environment": {
+      "dependencies": {
+        "plutus-tx": "1.45.0.0",
+        "plutus-core": "1.45.0.0",
+        "plutus-ledger-api": "1.45.0.0"
+      }
+    }
+  },
+  "contributors": [
+    {
+      "name": "Unisay",
+      "organization": "UPLC-CAPE Project"
+    }
+  ],
+  "submission": {
+    "date": "2025-11-03T00:00:00Z",
+    "source_available": true,
+    "source_repository": "https://github.com/IntersectMBO/UPLC-CAPE",
+    "source_commit_hash": "f67df1cd505bf9779ff106ba2eba3aededcf4732",
+    "implementation_notes": "ECD (Euclidean Common Divisor) implementation using Plinth with naive recursive algorithm"
+  }
+}

--- a/submissions/ecd/Plinth_1.45.0.0_Unisay/metrics.json
+++ b/submissions/ecd/Plinth_1.45.0.0_Unisay/metrics.json
@@ -1,0 +1,138 @@
+{
+  "evaluations": [
+    {
+      "cpu_units": 1646133,
+      "description": "ECD of 0 and 12 should return 12 (edge case: first argument is zero)",
+      "execution_result": "success",
+      "memory_units": 7207,
+      "name": "ecd_0_12"
+    },
+    {
+      "cpu_units": 937821,
+      "description": "ECD of 12 and 0 should return 12 (edge case: second argument is zero)",
+      "execution_result": "success",
+      "memory_units": 4404,
+      "name": "ecd_12_0"
+    },
+    {
+      "cpu_units": 1646133,
+      "description": "ECD of 7 and 7 should return 7 (edge case: identical numbers)",
+      "execution_result": "success",
+      "memory_units": 7207,
+      "name": "ecd_7_7"
+    },
+    {
+      "cpu_units": 3062757,
+      "description": "ECD of 6 and 9 should return 3",
+      "execution_result": "success",
+      "memory_units": 12813,
+      "name": "ecd_6_9"
+    },
+    {
+      "cpu_units": 2354445,
+      "description": "ECD of 12 and 8 should return 4",
+      "execution_result": "success",
+      "memory_units": 10010,
+      "name": "ecd_12_8"
+    },
+    {
+      "cpu_units": 3771069,
+      "description": "ECD of 15 and 25 should return 5",
+      "execution_result": "success",
+      "memory_units": 15616,
+      "name": "ecd_15_25"
+    },
+    {
+      "cpu_units": 3771069,
+      "description": "ECD of 17 and 19 should return 1 (coprime numbers)",
+      "execution_result": "success",
+      "memory_units": 15616,
+      "name": "ecd_17_19"
+    },
+    {
+      "cpu_units": 3771069,
+      "description": "ECD of 13 and 29 should return 1 (coprime numbers)",
+      "execution_result": "success",
+      "memory_units": 15616,
+      "name": "ecd_13_29"
+    },
+    {
+      "cpu_units": 3062757,
+      "description": "ECD of 48 and 18 should return 6",
+      "execution_result": "success",
+      "memory_units": 12813,
+      "name": "ecd_48_18"
+    },
+    {
+      "cpu_units": 2354445,
+      "description": "ECD of 100 and 75 should return 25",
+      "execution_result": "success",
+      "memory_units": 10010,
+      "name": "ecd_100_75"
+    },
+    {
+      "cpu_units": 3062757,
+      "description": "ECD of 1071 and 462 should return 21 (larger numbers)",
+      "execution_result": "success",
+      "memory_units": 12813,
+      "name": "ecd_1071_462"
+    },
+    {
+      "cpu_units": 2354445,
+      "description": "ECD of 2520 and 1890 should return 630 (larger numbers)",
+      "execution_result": "success",
+      "memory_units": 10010,
+      "name": "ecd_2520_1890"
+    },
+    {
+      "cpu_units": 2354445,
+      "description": "ECD of -12 and 8 should return 4 (negative first argument handled via abs)",
+      "execution_result": "success",
+      "memory_units": 10010,
+      "name": "ecd_negative_12_8"
+    },
+    {
+      "cpu_units": 2519653,
+      "description": "ECD of 12 and -8 should return 4 (negative second argument handled via abs)",
+      "execution_result": "success",
+      "memory_units": 10412,
+      "name": "ecd_12_negative_8"
+    }
+  ],
+  "execution_environment": {
+    "evaluator": "unknown"
+  },
+  "measurements": {
+    "block_cpu_budget_pct": 0.009427672500000001,
+    "block_memory_budget_pct": 0.02518709677419355,
+    "cpu_units": {
+      "maximum": 3771069,
+      "median": 2437049,
+      "minimum": 937821,
+      "sum": 36668998,
+      "sum_negative": 0,
+      "sum_positive": 36668998
+    },
+    "execution_fee_lovelace": 11562,
+    "memory_units": {
+      "maximum": 15616,
+      "median": 10211,
+      "minimum": 4404,
+      "sum": 154557,
+      "sum_negative": 0,
+      "sum_positive": 154557
+    },
+    "reference_script_fee_lovelace": 840,
+    "script_size_bytes": 56,
+    "scripts_per_block": 3970,
+    "scripts_per_tx": 896,
+    "term_size": 57,
+    "total_fee_lovelace": 12402,
+    "tx_cpu_budget_pct": 0.037710690000000005,
+    "tx_memory_budget_pct": 0.11154285714285715
+  },
+  "scenario": "ecd",
+  "timestamp": "2025-11-04T10:30:13Z",
+  "version": "1.0.0",
+  "notes": "Generated using UPLC-CAPE measure tool"
+}

--- a/test/EcdSpec.hs
+++ b/test/EcdSpec.hs
@@ -1,0 +1,89 @@
+module EcdSpec (spec) where
+
+import Prelude
+
+import Cape.PrettyResult (EvalResult (..), evaluateCompiledCode)
+import Ecd
+import PlutusCore.MkPlc (mkConstant)
+import PlutusTx.Code (applyCode)
+import PlutusTx.Lift (liftCodeDef)
+import Test.Hspec
+
+spec :: Spec
+spec = do
+  describe "ECD function tests" do
+    it "ecd_0_12 should return 12 (edge case: first argument is zero)" do
+      result <- evaluateEcd 0 12
+      result `shouldSatisfy` isSuccessWithValue 12
+
+    it "ecd_12_0 should return 12 (edge case: second argument is zero)" do
+      result <- evaluateEcd 12 0
+      result `shouldSatisfy` isSuccessWithValue 12
+
+    it "ecd_7_7 should return 7 (edge case: identical numbers)" do
+      result <- evaluateEcd 7 7
+      result `shouldSatisfy` isSuccessWithValue 7
+
+    it "ecd_6_9 should return 3" do
+      result <- evaluateEcd 6 9
+      result `shouldSatisfy` isSuccessWithValue 3
+
+    it "ecd_12_8 should return 4" do
+      result <- evaluateEcd 12 8
+      result `shouldSatisfy` isSuccessWithValue 4
+
+    it "ecd_15_25 should return 5" do
+      result <- evaluateEcd 15 25
+      result `shouldSatisfy` isSuccessWithValue 5
+
+    it "ecd_17_19 should return 1 (coprime numbers)" do
+      result <- evaluateEcd 17 19
+      result `shouldSatisfy` isSuccessWithValue 1
+
+    it "ecd_13_29 should return 1 (coprime numbers)" do
+      result <- evaluateEcd 13 29
+      result `shouldSatisfy` isSuccessWithValue 1
+
+    it "ecd_48_18 should return 6" do
+      result <- evaluateEcd 48 18
+      result `shouldSatisfy` isSuccessWithValue 6
+
+    it "ecd_100_75 should return 25" do
+      result <- evaluateEcd 100 75
+      result `shouldSatisfy` isSuccessWithValue 25
+
+    it "ecd_1071_462 should return 21 (larger numbers)" do
+      result <- evaluateEcd 1071 462
+      result `shouldSatisfy` isSuccessWithValue 21
+
+    it "ecd_2520_1890 should return 630 (larger numbers)" do
+      result <- evaluateEcd 2520 1890
+      result `shouldSatisfy` isSuccessWithValue 630
+
+    it "ecd_negative_12_8 should return 4 (negative first argument)" do
+      result <- evaluateEcd (-12) 8
+      result `shouldSatisfy` isSuccessWithValue 4
+
+    it "ecd_12_negative_8 should return 4 (negative second argument)" do
+      result <- evaluateEcd 12 (-8)
+      result `shouldSatisfy` isSuccessWithValue 4
+
+--------------------------------------------------------------------------------
+-- Helper Functions ------------------------------------------------------------
+
+-- | Evaluate ECD function with two integer inputs
+evaluateEcd :: Integer -> Integer -> IO EvalResult
+evaluateEcd a b = do
+  case ecdCode `applyCode` liftCodeDef a of
+    Left err -> error $ "Failed to apply first argument: " <> show err
+    Right partiallyApplied ->
+      case partiallyApplied `applyCode` liftCodeDef b of
+        Left err -> error $ "Failed to apply second argument: " <> show err
+        Right fullyApplied -> pure $ evaluateCompiledCode fullyApplied
+
+-- | Check if evaluation succeeded with expected integer value
+isSuccessWithValue :: Integer -> EvalResult -> Bool
+isSuccessWithValue expected EvalResult {evalResult = result} =
+  case result of
+    Left _ -> False -- Evaluation failed
+    Right term -> term == mkConstant () expected


### PR DESCRIPTION
## Summary

Adds a new synthetic benchmark scenario for the **ECD (Euclidean Common Divisor)** algorithm, also known as GCD. This is the first multi-argument benchmark in CAPE, demonstrating the multi-input framework from #134.

## Implementation

### Scenario Definition
- Complete specification following factorial/fibonacci pattern
- Prescribed naive recursive Euclidean algorithm
- 14 comprehensive test cases using two-input format

### Algorithm
```haskell
ecd :: Integer -> Integer -> Integer
ecd a b
  | b == 0    = abs a
  | otherwise = ecd b (a `mod` b)
```

### Test Coverage

**Edge Cases:**
- `ecd(0, 12) = 12`, `ecd(12, 0) = 12` - Zero arguments
- `ecd(7, 7) = 7` - Identical numbers

**Standard Cases:**
- Small values: `ecd(6, 9) = 3`, `ecd(12, 8) = 4`
- Coprime: `ecd(17, 19) = 1`, `ecd(13, 29) = 1`
- Larger: `ecd(1071, 462) = 21`, `ecd(2520, 1890) = 630`

**Negative Inputs:**
- `ecd(-12, 8) = 4`, `ecd(12, -8) = 4`

## Files Added

**Scenario:**
- `scenarios/ecd/ecd.md` - Complete specification
- `scenarios/ecd/cape-tests.json` - 14 test cases with `inputs` array

**Implementation:**
- `lib/Ecd.hs` - Naive recursive implementation
- `test/EcdSpec.hs` - 14 unit tests matching cape-tests.json

**Baseline Submission:**
- `submissions/ecd/Plinth_1.45.0.0_Unisay/` - Verified baseline (14/14 tests pass)

**Configuration:**
- `cape.cabal` - Added Ecd module and EcdSpec
- `plinth-submissions-app/Main.hs` - Registered ECD generation

## Testing

- ✅ **222 Haskell tests pass** (14 new ECD tests)
- ✅ **53/53 CAPE integration tests pass**
- ✅ **14/14 ECD submission tests pass**
- ✅ **Zero build warnings** with -Werror

## Technical Details

- **Type**: Synthetic benchmark (prescribed algorithm)
- **Signature**: `Integer -> Integer -> Integer` (curried)
- **Target**: Plutus Core 1.1.0
- **Input Format**: Two separate UPLC terms in `inputs` array

## Depends On

Requires #134 (multi-input support) which has been merged.

## Closes

Closes #132