### PR TITLE
feat(github): add pull request template with maintainer edits reminder

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,27 @@
+# Pull Request
+
+## Description
+
+<!-- Provide a brief description of the changes in this PR -->
+
+## Type of Change
+
+- [ ] New benchmark submission
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Documentation update
+- [ ] Infrastructure/tooling improvement
+- [ ] Other (please describe):
+
+## Checklist
+
+- [ ] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
+- [ ] My code follows the project's code style (run `treefmt` to format)
+- [ ] I have run `cape submission verify` for any submission changes
+- [ ] I have run `cabal test` if I modified Haskell code
+- [ ] I have tested my changes locally
+- [ ] **Allow edits from maintainers** is enabled (helps maintainers assist with your PR)
+
+## Additional Context
+
+<!-- Add any other context, screenshots, or information about the PR here -->


### PR DESCRIPTION
Add PR template that reminds contributors to enable 'Allow edits from
maintainers' option. This helps maintainers assist with PRs from forks
by allowing them to push fixes and improvements directly to contributor
branches.

Template includes:
- Description and type of change sections
- Comprehensive checklist with formatting, testing, and verification steps
- Prominent reminder to enable maintainer edits
- Reference to CONTRIBUTING.md guidelines