### PR TITLE
Support structured value, native assets, and datum on UTXOs

### DIFF
--- a/lib/Cape/ScriptContextBuilder.hs
+++ b/lib/Cape/ScriptContextBuilder.hs
@@ -28,7 +28,7 @@ data PatchOperation
   = AddSignature PubKeyHash
   | RemoveSignature PubKeyHash
   | SetRedeemer Redeemer
-  | AddInputUTXO TxOutRef Value Bool
+  | AddInputUTXO TxOutRef Value Bool OutputDatum
   | SetValidRange (Maybe POSIXTime) (Maybe POSIXTime)
   | AddOutputUTXO Address Value
   | RemoveOutputUTXO Int
@@ -120,7 +120,7 @@ applyPatch ctx patch =
       pure $ ctx {scriptContextTxInfo = updatedTxInfo}
     SetRedeemer redeemer -> do
       pure $ ctx {scriptContextRedeemer = redeemer}
-    AddInputUTXO txOutRef value isOwnInput -> do
+    AddInputUTXO txOutRef value isOwnInput outputDatum -> do
       let txInfo = scriptContextTxInfo ctx
           -- Use script address for script inputs, dummy address for regular inputs
           inputAddr =
@@ -132,7 +132,7 @@ applyPatch ctx patch =
                   )
                   Nothing
               else Address (PubKeyCredential (PubKeyHash "")) Nothing
-          newTxIn = TxInInfo txOutRef (TxOut inputAddr value NoOutputDatum Nothing)
+          newTxIn = TxInInfo txOutRef (TxOut inputAddr value outputDatum Nothing)
           updatedInputs = List.cons newTxIn (txInfoInputs txInfo)
           updatedTxInfo = txInfo {txInfoInputs = updatedInputs}
           updatedCtx = ctx {scriptContextTxInfo = updatedTxInfo}

--- a/lib/Cape/Tests.hs
+++ b/lib/Cape/Tests.hs
@@ -25,6 +25,8 @@ module Cape.Tests (
   InputType (..),
   ScriptContextSpec (..),
   PatchOperationSpec (..),
+  ValueSpec (..),
+  AssetSpec (..),
   ExpectedResult (..),
   ResultType (..),
   BaselineType (..),
@@ -41,7 +43,7 @@ module Cape.Tests (
 import Prelude
 
 import Cape.ScriptContextBuilder
-import Data.Aeson (FromJSON (..), withObject, (.:), (.:?))
+import Data.Aeson (FromJSON (..), withObject, (.:), (.:?), (.!=))
 import Data.Aeson qualified as Json
 import Data.Aeson.Types qualified as AesonTypes
 import Data.ByteString.Lazy qualified as LBS
@@ -265,6 +267,32 @@ data ScriptContextSpec = ScriptContextSpec
   }
   deriving stock (Show)
 
+-- | Specification for a UTXO value (lovelace + optional native assets).
+--
+--     JSON examples:
+--     @
+--     {"lovelace": 2000000}
+--     {"lovelace": 2000000, "assets": [{"currency_symbol": "#dddd...", "token_name": "#7465", "quantity": 1000}]}
+--     @
+data ValueSpec = ValueSpec
+  { vsLovelace :: Integer
+  -- ^ Lovelace amount
+  , vsAssets :: [AssetSpec]
+  -- ^ Native assets (empty list when none)
+  }
+  deriving stock (Show, Eq)
+
+-- | Specification for a native asset within a value.
+data AssetSpec = AssetSpec
+  { asCurrencySymbol :: Text
+  -- ^ Currency symbol as hex-encoded bytestring (e.g. "#dddd...dddd")
+  , asTokenName :: Text
+  -- ^ Token name as hex-encoded bytestring (e.g. "#76657374")
+  , asQuantity :: Integer
+  -- ^ Token quantity
+  }
+  deriving stock (Show, Eq)
+
 -- | Patch operations for modifying ScriptContext.
 data PatchOperationSpec
   = -- | Add signature by pubkey hash
@@ -289,18 +317,19 @@ data PatchOperationSpec
     --     {"op": "set_redeemer", "redeemer": "0"}
     --     @
     SetRedeemerSpec AesonTypes.Value
-  | -- | Add input UTXO (ref, lovelace, is_own)
+  | -- | Add input UTXO with value and optional datum
     --
     --     JSON example:
     --     @
     --     {
     --       "op": "add_input_utxo",
     --       "utxo_ref": "1234567890abcdef:0",
-    --       "lovelace": 75000000,
-    --       "is_own_input": true
+    --       "value": {"lovelace": 2000000, "assets": [{"currency_symbol": "#dddd...", "token_name": "#76657374", "quantity": 1000}]},
+    --       "is_own_input": true,
+    --       "datum": "@vesting_datum"
     --     }
     --     @
-    AddInputUTXOSpec Text Integer Bool
+    AddInputUTXOSpec Text ValueSpec Bool (Maybe AesonTypes.Value)
   | -- | Set validity range
     --
     --     JSON example:
@@ -316,17 +345,17 @@ data PatchOperationSpec
     --
     --     JSON examples:
     --     @
-    --     {"op": "add_output_utxo", "address": {"type": "script"}, "lovelace": 75000000}
-    --     {"op": "add_output_utxo", "address": {"type": "pubkey", "pubkey_hash": "@impostor_pubkey"}, "lovelace": 50000000}
+    --     {"op": "add_output_utxo", "address": {"type": "script"}, "value": {"lovelace": 75000000}}
+    --     {"op": "add_output_utxo", "address": {"type": "script"}, "value": {"lovelace": 2000000, "assets": [...]}}
     --     @
-    AddOutputUTXOSpec AddressSpec Integer
+    AddOutputUTXOSpec AddressSpec ValueSpec
   | -- | Add output UTXO with datum to specified address
     --
     --     JSON example:
     --     @
-    --     {"op": "add_output_utxo", "address": {"type": "script"}, "lovelace": 75000000, "datum": "@deposited_escrow_datum"}
+    --     {"op": "add_output_utxo", "address": {"type": "script"}, "value": {"lovelace": 75000000}, "datum": "@datum"}
     --     @
-    AddOutputUTXOWithDatumSpec AddressSpec Integer AesonTypes.Value
+    AddOutputUTXOWithDatumSpec AddressSpec ValueSpec AesonTypes.Value
   | -- | Remove output UTXO by index
     --
     --     JSON example:
@@ -508,22 +537,36 @@ instance FromJSON PatchOperationSpec where
       "add_input_utxo" ->
         AddInputUTXOSpec
           <$> o .: "utxo_ref"
-          <*> o .: "lovelace"
+          <*> o .: "value"
           <*> o .: "is_own_input"
+          <*> o .:? "datum"
       "set_valid_range" ->
         SetValidRangeSpec
           <$> o .:? "from_time"
           <*> o .:? "to_time"
       "add_output_utxo" -> do
         address <- o .: "address"
-        lovelace <- o .: "lovelace"
+        valueSpec <- o .: "value"
         mDatum <- o .:? "datum"
         case mDatum of
-          Just datum -> pure $ AddOutputUTXOWithDatumSpec address lovelace datum
-          Nothing -> pure $ AddOutputUTXOSpec address lovelace
+          Just datum -> pure $ AddOutputUTXOWithDatumSpec address valueSpec datum
+          Nothing -> pure $ AddOutputUTXOSpec address valueSpec
       "remove_output_utxo" -> RemoveOutputUTXOSpec <$> o .: "index"
       "set_script_datum" -> SetScriptDatumSpec <$> o .: "datum"
       _ -> fail $ "Unknown patch operation: " <> toString op
+
+instance FromJSON ValueSpec where
+  parseJSON = withObject "ValueSpec" \o ->
+    ValueSpec
+      <$> o .: "lovelace"
+      <*> o .:? "assets" .!= []
+
+instance FromJSON AssetSpec where
+  parseJSON = withObject "AssetSpec" \o ->
+    AssetSpec
+      <$> o .: "currency_symbol"
+      <*> o .: "token_name"
+      <*> o .: "quantity"
 
 instance FromJSON AddressSpec where
   parseJSON = withObject "AddressSpec" \o -> do
@@ -748,6 +791,68 @@ resolveScriptContextReference dataStructures refName =
     Just _ -> Nothing -- Not a script_context reference
     Nothing -> Nothing -- Reference not found
 
+-- * Value Construction
+
+{- | Build a Value from a ValueSpec (lovelace + optional assets).
+
+Constructs a multi-asset Value by starting with lovelace and combining
+each resolved asset value using @foldl'@ and @(<>)@.
+-}
+buildValue ::
+  HaskellMap.Map Text DataStructureEntry ->
+  ValueSpec ->
+  IO V3.Value
+buildValue dataStructures ValueSpec {vsLovelace, vsAssets} = do
+  let adaValue = V3.singleton V3.adaSymbol V3.adaToken vsLovelace
+  case vsAssets of
+    [] -> pure adaValue
+    assets -> do
+      assetValues <- traverse (resolveAsset dataStructures) assets
+      pure $ foldl' (<>) adaValue assetValues
+
+{- | Resolve an AssetSpec into a singleton Value.
+
+Currency symbol and token name support @references to builtin_data.
+-}
+resolveAsset ::
+  HaskellMap.Map Text DataStructureEntry ->
+  AssetSpec ->
+  IO V3.Value
+resolveAsset dataStructures AssetSpec {asCurrencySymbol, asTokenName, asQuantity} = do
+  csBytes <- resolveAsBytes dataStructures asCurrencySymbol
+  tnBytes <- resolveAsBytes dataStructures asTokenName
+  let cs = V3.CurrencySymbol csBytes
+      tn = V3.TokenName tnBytes
+  pure $ V3.singleton cs tn asQuantity
+
+{- | Resolve a text value to BuiltinByteString.
+
+Supports @references (resolving to BuiltinData bytestrings)
+and hex-encoded literals (prefixed with #).
+-}
+resolveAsBytes ::
+  HaskellMap.Map Text DataStructureEntry -> Text -> IO V3.BuiltinByteString
+resolveAsBytes dataStructures text
+  | Text.isPrefixOf "@" text && Text.length text > 1 = do
+      resolvedBuiltinData <- resolveBuiltinDataReference dataStructures text
+      let coreData = Builtins.builtinDataToData resolvedBuiltinData
+      case coreData of
+        PLC.B bytestring -> pure $ Builtins.toBuiltin bytestring
+        _ -> die $ "Expected bytestring data for asset component: " <> toString text
+  | otherwise = do
+      -- Resolve as text (handles non-reference cases)
+      let resolved = resolveTextReference dataStructures text
+      case parseBuiltinDataText resolved of
+        Left parseErr ->
+          die $
+            "Failed to parse asset component: "
+              <> toString (renderParseError parseErr)
+        Right builtinData ->
+          let coreData = builtinData
+           in case coreData of
+                PLC.B bytestring -> pure $ Builtins.toBuiltin bytestring
+                _ -> die $ "Expected bytestring for asset component: " <> toString text
+
 -- * Patch Operation Conversion
 
 {- | Convert PatchOperationSpec to PatchOperation with reference resolution.
@@ -843,24 +948,39 @@ convertPatchOperation dataStructures spec =
           die $
             "Redeemer must be a string with BuiltinData encoding, got: "
               <> show other
-    AddInputUTXOSpec utxoRefText lovelaceAmount isOwnInput -> do
+    AddInputUTXOSpec utxoRefText valueSpec isOwnInput mDatumValue -> do
       let resolvedUtxoRef = resolveTextReference dataStructures utxoRefText
       case parseTxOutRef resolvedUtxoRef of
         Left parseErr ->
           die ("Failed to parse UTXO reference: " <> show parseErr)
         Right txOutRef -> do
-          let value = V3.singleton V3.adaSymbol V3.adaToken lovelaceAmount
-          pure $ AddInputUTXO txOutRef value isOwnInput
+          value <- buildValue dataStructures valueSpec
+          outputDatum <- case mDatumValue of
+            Nothing -> pure V3.NoOutputDatum
+            Just (Json.String dataText) ->
+              if Text.isPrefixOf "@" dataText && Text.length dataText > 1
+                then do
+                  resolvedBuiltinData <-
+                    resolveBuiltinDataReference dataStructures dataText
+                  pure $ V3.OutputDatum (V3.Datum resolvedBuiltinData)
+                else case parseBuiltinDataText dataText of
+                  Left parseErr ->
+                    die ("Failed to parse input datum: " <> toString (renderParseError parseErr))
+                  Right parsedBuiltinData ->
+                    pure $ V3.OutputDatum (V3.Datum (BI.BuiltinData parsedBuiltinData))
+            Just other ->
+              die $ "Input datum must be a string, got: " <> show other
+          pure $ AddInputUTXO txOutRef value isOwnInput outputDatum
     SetValidRangeSpec fromTime toTime -> do
       let fromPosix = fmap V3.POSIXTime fromTime
           toPosix = fmap V3.POSIXTime toTime
       pure $ SetValidRange fromPosix toPosix
-    AddOutputUTXOSpec addressSpec lovelaceAmount -> do
-      let value = V3.singleton V3.adaSymbol V3.adaToken lovelaceAmount
+    AddOutputUTXOSpec addressSpec valueSpec -> do
+      value <- buildValue dataStructures valueSpec
       address <- parseAddressSpec dataStructures addressSpec
       pure $ AddOutputUTXO address value
-    AddOutputUTXOWithDatumSpec addressSpec lovelaceAmount datumValue -> do
-      let value = V3.singleton V3.adaSymbol V3.adaToken lovelaceAmount
+    AddOutputUTXOWithDatumSpec addressSpec valueSpec datumValue -> do
+      value <- buildValue dataStructures valueSpec
       address <- parseAddressSpec dataStructures addressSpec
       -- Convert JSON Value to BuiltinData with reference resolution support
       case datumValue of

--- a/scenarios/two_party_escrow/cape-tests.json
+++ b/scenarios/two_party_escrow/cape-tests.json
@@ -46,7 +46,9 @@
           {
             "op": "add_input_utxo",
             "utxo_ref": "3333333333333333333333333333333333333333333333333333333333333333:0",
-            "lovelace": 75000000,
+            "value": {
+              "lovelace": 75000000
+            },
             "is_own_input": false
           },
           {
@@ -55,7 +57,9 @@
               "type": "script",
               "script_hash": "1111111111111111111111111111111111111111111111111111111111"
             },
-            "lovelace": 75000000,
+            "value": {
+              "lovelace": 75000000
+            },
             "datum": "@deposited_escrow_datum"
           }
         ]
@@ -81,7 +85,9 @@
           {
             "op": "add_input_utxo",
             "utxo_ref": "4444444444444444444444444444444444444444444444444444444444444444:0",
-            "lovelace": 75000000,
+            "value": {
+              "lovelace": 75000000
+            },
             "is_own_input": true,
             "datum": "@deposited_escrow_datum"
           },
@@ -91,7 +97,9 @@
               "type": "pubkey",
               "pubkey_hash": "@seller_pubkey"
             },
-            "lovelace": 75000000
+            "value": {
+              "lovelace": 75000000
+            }
           }
         ]
       }
@@ -120,7 +128,9 @@
           {
             "op": "add_input_utxo",
             "utxo_ref": "3333333333333333333333333333333333333333333333333333333333333333:1",
-            "lovelace": 75000000,
+            "value": {
+              "lovelace": 75000000
+            },
             "is_own_input": true,
             "datum": "@deposited_escrow_datum"
           },
@@ -130,7 +140,9 @@
               "type": "pubkey",
               "pubkey_hash": "@buyer_pubkey"
             },
-            "lovelace": 75000000
+            "value": {
+              "lovelace": 75000000
+            }
           }
         ]
       }
@@ -310,7 +322,9 @@
                   "type": "script",
                   "script_hash": "1111111111111111111111111111111111111111111111111111111111"
                 },
-                "lovelace": 50000000
+                "value": {
+                  "lovelace": 50000000
+                }
               }
             ]
           }
@@ -340,7 +354,9 @@
               {
                 "op": "add_input_utxo",
                 "utxo_ref": "3333333333333333333333333333333333333333333333333333333333333333:0",
-                "lovelace": 75000000,
+                "value": {
+                  "lovelace": 75000000
+                },
                 "is_own_input": true
               },
               {
@@ -349,7 +365,9 @@
                   "type": "pubkey",
                   "pubkey_hash": "@impostor_pubkey"
                 },
-                "lovelace": 75000000
+                "value": {
+                  "lovelace": 75000000
+                }
               }
             ]
           }
@@ -412,7 +430,9 @@
                   "type": "pubkey",
                   "pubkey_hash": "@seller_pubkey"
                 },
-                "lovelace": 50000000
+                "value": {
+                  "lovelace": 50000000
+                }
               }
             ]
           }
@@ -442,7 +462,9 @@
               {
                 "op": "add_input_utxo",
                 "utxo_ref": "4444444444444444444444444444444444444444444444444444444444444444:0",
-                "lovelace": 75000000,
+                "value": {
+                  "lovelace": 75000000
+                },
                 "is_own_input": true
               },
               {
@@ -451,7 +473,9 @@
                   "type": "pubkey",
                   "pubkey_hash": "@impostor_pubkey"
                 },
-                "lovelace": 75000000
+                "value": {
+                  "lovelace": 75000000
+                }
               }
             ]
           }
@@ -484,7 +508,9 @@
                   "type": "pubkey",
                   "pubkey_hash": "@seller_pubkey"
                 },
-                "lovelace": 75000000
+                "value": {
+                  "lovelace": 75000000
+                }
               }
             ]
           }
@@ -519,13 +545,17 @@
               {
                 "op": "add_input_utxo",
                 "utxo_ref": "3333333333333333333333333333333333333333333333333333333333333333:0",
-                "lovelace": 75000000,
+                "value": {
+                  "lovelace": 75000000
+                },
                 "is_own_input": true
               },
               {
                 "op": "add_input_utxo",
                 "utxo_ref": "3333333333333333333333333333333333333333333333333333333333333333:1",
-                "lovelace": 75000000,
+                "value": {
+                  "lovelace": 75000000
+                },
                 "is_own_input": true
               },
               {
@@ -534,7 +564,9 @@
                   "type": "pubkey",
                   "pubkey_hash": "@seller_pubkey"
                 },
-                "lovelace": 75000000
+                "value": {
+                  "lovelace": 75000000
+                }
               }
             ]
           }
@@ -564,7 +596,9 @@
               {
                 "op": "add_input_utxo",
                 "utxo_ref": "4444444444444444444444444444444444444444444444444444444444444444:0",
-                "lovelace": 75000000,
+                "value": {
+                  "lovelace": 75000000
+                },
                 "is_own_input": true
               },
               {
@@ -573,7 +607,9 @@
                   "type": "pubkey",
                   "pubkey_hash": "@seller_pubkey"
                 },
-                "lovelace": 50000000
+                "value": {
+                  "lovelace": 50000000
+                }
               }
             ]
           }
@@ -603,7 +639,9 @@
               {
                 "op": "add_input_utxo",
                 "utxo_ref": "4444444444444444444444444444444444444444444444444444444444444444:0",
-                "lovelace": 75000000,
+                "value": {
+                  "lovelace": 75000000
+                },
                 "is_own_input": true
               },
               {
@@ -612,7 +650,9 @@
                   "type": "pubkey",
                   "pubkey_hash": "@seller_pubkey"
                 },
-                "lovelace": 100000000
+                "value": {
+                  "lovelace": 100000000
+                }
               }
             ]
           }
@@ -664,7 +704,9 @@
               {
                 "op": "add_input_utxo",
                 "utxo_ref": "3333333333333333333333333333333333333333333333333333333333333333:1",
-                "lovelace": 75000000,
+                "value": {
+                  "lovelace": 75000000
+                },
                 "is_own_input": true
               },
               {
@@ -673,7 +715,9 @@
                   "type": "pubkey",
                   "pubkey_hash": "@seller_pubkey"
                 },
-                "lovelace": 50000000
+                "value": {
+                  "lovelace": 50000000
+                }
               },
               {
                 "op": "add_output_utxo",
@@ -681,7 +725,9 @@
                   "type": "pubkey",
                   "pubkey_hash": "@seller_pubkey"
                 },
-                "lovelace": 25000000
+                "value": {
+                  "lovelace": 25000000
+                }
               }
             ]
           }
@@ -711,7 +757,9 @@
               {
                 "op": "add_input_utxo",
                 "utxo_ref": "4444444444444444444444444444444444444444444444444444444444444444:0",
-                "lovelace": 75000000,
+                "value": {
+                  "lovelace": 75000000
+                },
                 "is_own_input": true
               },
               {
@@ -720,7 +768,9 @@
                   "type": "pubkey",
                   "pubkey_hash": "@seller_pubkey"
                 },
-                "lovelace": 75000000
+                "value": {
+                  "lovelace": 75000000
+                }
               },
               {
                 "op": "add_output_utxo",
@@ -728,7 +778,9 @@
                   "type": "script",
                   "script_hash": "1111111111111111111111111111111111111111111111111111111111"
                 },
-                "lovelace": 10000000
+                "value": {
+                  "lovelace": 10000000
+                }
               }
             ]
           }
@@ -801,13 +853,17 @@
               {
                 "op": "add_input_utxo",
                 "utxo_ref": "3333333333333333333333333333333333333333333333333333333333333333:0",
-                "lovelace": 75000000,
+                "value": {
+                  "lovelace": 75000000
+                },
                 "is_own_input": true
               },
               {
                 "op": "add_input_utxo",
                 "utxo_ref": "3333333333333333333333333333333333333333333333333333333333333333:1",
-                "lovelace": 75000000,
+                "value": {
+                  "lovelace": 75000000
+                },
                 "is_own_input": true
               },
               {
@@ -816,7 +872,9 @@
                   "type": "pubkey",
                   "pubkey_hash": "@buyer_pubkey"
                 },
-                "lovelace": 75000000
+                "value": {
+                  "lovelace": 75000000
+                }
               }
             ]
           }
@@ -855,7 +913,9 @@
               {
                 "op": "add_input_utxo",
                 "utxo_ref": "3333333333333333333333333333333333333333333333333333333333333333:1",
-                "lovelace": 75000000,
+                "value": {
+                  "lovelace": 75000000
+                },
                 "is_own_input": true
               },
               {
@@ -864,7 +924,9 @@
                   "type": "pubkey",
                   "pubkey_hash": "@buyer_pubkey"
                 },
-                "lovelace": 75000000
+                "value": {
+                  "lovelace": 75000000
+                }
               }
             ]
           }
@@ -903,7 +965,9 @@
               {
                 "op": "add_input_utxo",
                 "utxo_ref": "3333333333333333333333333333333333333333333333333333333333333333:1",
-                "lovelace": 75000000,
+                "value": {
+                  "lovelace": 75000000
+                },
                 "is_own_input": true
               },
               {
@@ -912,7 +976,9 @@
                   "type": "pubkey",
                   "pubkey_hash": "@buyer_pubkey"
                 },
-                "lovelace": 50000000
+                "value": {
+                  "lovelace": 50000000
+                }
               },
               {
                 "op": "add_output_utxo",
@@ -920,7 +986,9 @@
                   "type": "pubkey",
                   "pubkey_hash": "@buyer_pubkey"
                 },
-                "lovelace": 25000000
+                "value": {
+                  "lovelace": 25000000
+                }
               }
             ]
           }
@@ -975,7 +1043,9 @@
               {
                 "op": "add_input_utxo",
                 "utxo_ref": "4444444444444444444444444444444444444444444444444444444444444444:0",
-                "lovelace": 75000000,
+                "value": {
+                  "lovelace": 75000000
+                },
                 "is_own_input": true
               },
               {
@@ -984,7 +1054,9 @@
                   "type": "pubkey",
                   "pubkey_hash": "@buyer_pubkey"
                 },
-                "lovelace": 75000000
+                "value": {
+                  "lovelace": 75000000
+                }
               }
             ]
           }
@@ -1018,7 +1090,9 @@
               {
                 "op": "add_input_utxo",
                 "utxo_ref": "4444444444444444444444444444444444444444444444444444444444444444:0",
-                "lovelace": 75000000,
+                "value": {
+                  "lovelace": 75000000
+                },
                 "is_own_input": true
               },
               {
@@ -1027,7 +1101,9 @@
                   "type": "pubkey",
                   "pubkey_hash": "@buyer_pubkey"
                 },
-                "lovelace": 75000000
+                "value": {
+                  "lovelace": 75000000
+                }
               }
             ]
           }
@@ -1061,7 +1137,9 @@
               {
                 "op": "add_input_utxo",
                 "utxo_ref": "4444444444444444444444444444444444444444444444444444444444444444:0",
-                "lovelace": 75000000,
+                "value": {
+                  "lovelace": 75000000
+                },
                 "is_own_input": true
               },
               {
@@ -1070,7 +1148,9 @@
                   "type": "pubkey",
                   "pubkey_hash": "@buyer_pubkey"
                 },
-                "lovelace": 75000000
+                "value": {
+                  "lovelace": 75000000
+                }
               }
             ]
           }
@@ -1104,7 +1184,9 @@
               {
                 "op": "add_input_utxo",
                 "utxo_ref": "4444444444444444444444444444444444444444444444444444444444444444:0",
-                "lovelace": 75000000,
+                "value": {
+                  "lovelace": 75000000
+                },
                 "is_own_input": true
               },
               {
@@ -1113,7 +1195,9 @@
                   "type": "pubkey",
                   "pubkey_hash": "@buyer_pubkey"
                 },
-                "lovelace": 75000000
+                "value": {
+                  "lovelace": 75000000
+                }
               }
             ]
           }
@@ -1143,7 +1227,9 @@
               {
                 "op": "add_input_utxo",
                 "utxo_ref": "4444444444444444444444444444444444444444444444444444444444444444:0",
-                "lovelace": 75000000,
+                "value": {
+                  "lovelace": 75000000
+                },
                 "is_own_input": true
               },
               {
@@ -1152,7 +1238,9 @@
                   "type": "pubkey",
                   "pubkey_hash": "@buyer_pubkey"
                 },
-                "lovelace": 75000000
+                "value": {
+                  "lovelace": 75000000
+                }
               }
             ]
           }
@@ -1186,7 +1274,9 @@
               {
                 "op": "add_input_utxo",
                 "utxo_ref": "4444444444444444444444444444444444444444444444444444444444444444:0",
-                "lovelace": 75000000,
+                "value": {
+                  "lovelace": 75000000
+                },
                 "is_own_input": true
               },
               {
@@ -1195,7 +1285,9 @@
                   "type": "pubkey",
                   "pubkey_hash": "@buyer_pubkey"
                 },
-                "lovelace": 80000000
+                "value": {
+                  "lovelace": 80000000
+                }
               }
             ]
           }
@@ -1229,7 +1321,9 @@
               {
                 "op": "add_input_utxo",
                 "utxo_ref": "4444444444444444444444444444444444444444444444444444444444444444:0",
-                "lovelace": 75000000,
+                "value": {
+                  "lovelace": 75000000
+                },
                 "is_own_input": true
               },
               {
@@ -1238,7 +1332,9 @@
                   "type": "pubkey",
                   "pubkey_hash": "@buyer_pubkey"
                 },
-                "lovelace": 50000000
+                "value": {
+                  "lovelace": 50000000
+                }
               }
             ]
           }
@@ -1272,7 +1368,9 @@
               {
                 "op": "add_input_utxo",
                 "utxo_ref": "4444444444444444444444444444444444444444444444444444444444444444:0",
-                "lovelace": 75000000,
+                "value": {
+                  "lovelace": 75000000
+                },
                 "is_own_input": true
               },
               {
@@ -1281,7 +1379,9 @@
                   "type": "pubkey",
                   "pubkey_hash": "@buyer_pubkey"
                 },
-                "lovelace": 100000000
+                "value": {
+                  "lovelace": 100000000
+                }
               }
             ]
           }
@@ -1315,7 +1415,9 @@
               {
                 "op": "add_input_utxo",
                 "utxo_ref": "4444444444444444444444444444444444444444444444444444444444444444:0",
-                "lovelace": 75000000,
+                "value": {
+                  "lovelace": 75000000
+                },
                 "is_own_input": true
               },
               {
@@ -1324,7 +1426,9 @@
                   "type": "pubkey",
                   "pubkey_hash": "@seller_pubkey"
                 },
-                "lovelace": 75000000
+                "value": {
+                  "lovelace": 75000000
+                }
               }
             ]
           }
@@ -1358,7 +1462,9 @@
               {
                 "op": "add_input_utxo",
                 "utxo_ref": "4444444444444444444444444444444444444444444444444444444444444444:0",
-                "lovelace": 75000000,
+                "value": {
+                  "lovelace": 75000000
+                },
                 "is_own_input": true
               },
               {
@@ -1367,7 +1473,9 @@
                   "type": "pubkey",
                   "pubkey_hash": "@buyer_pubkey"
                 },
-                "lovelace": 65000000
+                "value": {
+                  "lovelace": 65000000
+                }
               },
               {
                 "op": "add_output_utxo",
@@ -1375,7 +1483,9 @@
                   "type": "script",
                   "script_hash": "1111111111111111111111111111111111111111111111111111111111"
                 },
-                "lovelace": 10000000
+                "value": {
+                  "lovelace": 10000000
+                }
               }
             ]
           }
@@ -1412,7 +1522,9 @@
                   "type": "pubkey",
                   "pubkey_hash": "@buyer_pubkey"
                 },
-                "lovelace": 75000000
+                "value": {
+                  "lovelace": 75000000
+                }
               }
             ]
           }
@@ -1450,7 +1562,9 @@
               {
                 "op": "add_input_utxo",
                 "utxo_ref": "4444444444444444444444444444444444444444444444444444444444444444:0",
-                "lovelace": 75000000,
+                "value": {
+                  "lovelace": 75000000
+                },
                 "is_own_input": true
               },
               {
@@ -1459,7 +1573,9 @@
                   "type": "pubkey",
                   "pubkey_hash": "@buyer_pubkey"
                 },
-                "lovelace": 75000000
+                "value": {
+                  "lovelace": 75000000
+                }
               }
             ]
           }
@@ -1493,7 +1609,9 @@
               {
                 "op": "add_input_utxo",
                 "utxo_ref": "4444444444444444444444444444444444444444444444444444444444444444:0",
-                "lovelace": 75000000,
+                "value": {
+                  "lovelace": 75000000
+                },
                 "is_own_input": true
               },
               {
@@ -1502,7 +1620,9 @@
                   "type": "pubkey",
                   "pubkey_hash": "@seller_pubkey"
                 },
-                "lovelace": 75000000
+                "value": {
+                  "lovelace": 75000000
+                }
               }
             ]
           }
@@ -1540,7 +1660,9 @@
               {
                 "op": "add_input_utxo",
                 "utxo_ref": "4444444444444444444444444444444444444444444444444444444444444444:0",
-                "lovelace": 75000000,
+                "value": {
+                  "lovelace": 75000000
+                },
                 "is_own_input": true
               },
               {
@@ -1549,7 +1671,9 @@
                   "type": "pubkey",
                   "pubkey_hash": "@buyer_pubkey"
                 },
-                "lovelace": 75000000
+                "value": {
+                  "lovelace": 75000000
+                }
               }
             ]
           }
@@ -1583,7 +1707,9 @@
               {
                 "op": "add_input_utxo",
                 "utxo_ref": "4444444444444444444444444444444444444444444444444444444444444444:0",
-                "lovelace": 75000000,
+                "value": {
+                  "lovelace": 75000000
+                },
                 "is_own_input": true
               },
               {
@@ -1592,7 +1718,9 @@
                   "type": "pubkey",
                   "pubkey_hash": "@seller_pubkey"
                 },
-                "lovelace": 75000000
+                "value": {
+                  "lovelace": 75000000
+                }
               }
             ]
           }

--- a/test/Cape/ScriptContextBuilderSpec.hs
+++ b/test/Cape/ScriptContextBuilderSpec.hs
@@ -208,7 +208,7 @@ spec = do
               txId = TxId "3333333333333333333333333333333333333333333333333333333333333333"
               txOutRef = TxOutRef txId 5
               value = singleton adaSymbol adaToken 50000000
-              result = applyPatch baseline (AddInputUTXO txOutRef value False)
+              result = applyPatch baseline (AddInputUTXO txOutRef value False NoOutputDatum)
           case result of
             Right ctx -> do
               -- Should add input to transaction
@@ -226,7 +226,7 @@ spec = do
             txId = TxId "3333333333333333333333333333333333333333333333333333333333333333"
             txOutRef = TxOutRef txId 5
             value = singleton adaSymbol adaToken 75000000
-            result = applyPatch baseline (AddInputUTXO txOutRef value True)
+            result = applyPatch baseline (AddInputUTXO txOutRef value True NoOutputDatum)
         case result of
           Right ctx -> do
             -- Should add input to transaction
@@ -244,7 +244,7 @@ spec = do
             txId = TxId "4444444444444444444444444444444444444444444444444444444444444444"
             txOutRef = TxOutRef txId 2
             value = singleton adaSymbol adaToken 100000000
-            result = applyPatch baseline (AddInputUTXO txOutRef value True)
+            result = applyPatch baseline (AddInputUTXO txOutRef value True NoOutputDatum)
         case result of
           Right ctx -> case scriptContextScriptInfo ctx of
             SpendingScript _ maybeDatum ->
@@ -261,8 +261,8 @@ spec = do
             value1 = singleton adaSymbol adaToken 25000000
             value2 = singleton adaSymbol adaToken 50000000
             patches =
-              [ AddInputUTXO txOutRef1 value1 False
-              , AddInputUTXO txOutRef2 value2 True
+              [ AddInputUTXO txOutRef1 value1 False NoOutputDatum
+              , AddInputUTXO txOutRef2 value2 True NoOutputDatum
               ]
             result = applyPatches patches baseline
         case result of
@@ -490,7 +490,7 @@ spec = do
               SpendingBaseline
               [ AddSignature pkh
               , SetRedeemer redeemer
-              , AddInputUTXO txOutRef (singleton adaSymbol adaToken 75000000) True
+              , AddInputUTXO txOutRef (singleton adaSymbol adaToken 75000000) True NoOutputDatum
               , SetValidRange (Just fromTime) (Just toTime)
               ]
           result = buildScriptContext builder

--- a/test/Cape/TestsSpec.hs
+++ b/test/Cape/TestsSpec.hs
@@ -183,13 +183,14 @@ spec = do
                         "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" -- Seller signature
                     , AddInputUTXOSpec
                         "4444444444444444444444444444444444444444444444444444444444444444:0"
-                        75000000
+                        (ValueSpec 75000000 [])
                         True
+                        Nothing
                     , AddOutputUTXOSpec
                         ( PubkeyAddressSpec
                             "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
                         )
-                        75000000
+                        (ValueSpec 75000000 [])
                     ]
                 }
             testInput =
@@ -422,18 +423,34 @@ spec = do
               testJSONRoundTrip
                 "{\"op\": \"set_redeemer\", \"redeemer\": \"42\"}"
                 (SetRedeemerSpec (Json.String "42"))
-            AddInputUTXOSpec _ _ _ ->
+            AddInputUTXOSpec {} ->
               testJSONRoundTrip
-                "{\"op\": \"add_input_utxo\", \"utxo_ref\": \"txid:0\", \"lovelace\": 1000000, \"is_own_input\": true}"
-                (AddInputUTXOSpec "txid:0" 1000000 True)
+                [__i|{
+                  "op": "add_input_utxo",
+                  "utxo_ref": "txid:0",
+                  "value": {
+                    "lovelace": 1000000
+                  },
+                  "is_own_input": true
+                }|]
+                (AddInputUTXOSpec "txid:0" (ValueSpec 1000000 []) True Nothing)
             SetValidRangeSpec _ _ ->
               testJSONRoundTrip
                 "{\"op\": \"set_valid_range\", \"from_time\": 1000, \"to_time\": 2000}"
                 (SetValidRangeSpec (Just 1000) (Just 2000))
-            AddOutputUTXOSpec _ _ ->
+            AddOutputUTXOSpec {} ->
               testJSONRoundTrip
-                "{\"op\": \"add_output_utxo\", \"address\": {\"type\": \"pubkey\", \"pubkey_hash\": \"deadbeef\"}, \"lovelace\": 500000}"
-                (AddOutputUTXOSpec (PubkeyAddressSpec "deadbeef") 500000)
+                [__i|{
+                  "op": "add_output_utxo",
+                  "address": {
+                    "type": "pubkey",
+                    "pubkey_hash": "deadbeef"
+                  },
+                  "value": {
+                    "lovelace": 500000
+                  }
+                }|]
+                (AddOutputUTXOSpec (PubkeyAddressSpec "deadbeef") (ValueSpec 500000 []))
             RemoveOutputUTXOSpec _ ->
               testJSONRoundTrip
                 "{\"op\": \"remove_output_utxo\", \"index\": 0}"
@@ -442,12 +459,22 @@ spec = do
               testJSONRoundTrip
                 "{\"op\": \"set_script_datum\", \"datum\": \"42\"}"
                 (SetScriptDatumSpec (Json.String "42"))
-            AddOutputUTXOWithDatumSpec _ _ _ ->
+            AddOutputUTXOWithDatumSpec {} ->
               testJSONRoundTrip
-                "{\"op\": \"add_output_utxo\", \"address\": {\"type\": \"pubkey\", \"pubkey_hash\": \"deadbeef\"}, \"lovelace\": 500000, \"datum\": \"42\"}"
+                [__i|{
+                  "op": "add_output_utxo",
+                  "address": {
+                    "type": "pubkey",
+                    "pubkey_hash": "deadbeef"
+                  },
+                  "value": {
+                    "lovelace": 500000
+                  },
+                  "datum": "42"
+                }|]
                 ( AddOutputUTXOWithDatumSpec
                     (PubkeyAddressSpec "deadbeef")
-                    500000
+                    (ValueSpec 500000 [])
                     (Json.String "42")
                 )
       -- NO wildcard pattern! Compilation will fail if a constructor is added
@@ -458,16 +485,68 @@ spec = do
         [ AddSignatureSpec "test"
         , RemoveSignatureSpec "test"
         , SetRedeemerSpec (Json.String "test")
-        , AddInputUTXOSpec "test:0" 1000000 True
+        , AddInputUTXOSpec "test:0" (ValueSpec 1000000 []) True Nothing
         , SetValidRangeSpec (Just 100) (Just 200)
-        , AddOutputUTXOSpec (PubkeyAddressSpec "test") 1000000
+        , AddOutputUTXOSpec (PubkeyAddressSpec "test") (ValueSpec 1000000 [])
         , RemoveOutputUTXOSpec 0
         , SetScriptDatumSpec (Json.String "test")
         , AddOutputUTXOWithDatumSpec
             (PubkeyAddressSpec "test")
-            1000000
+            (ValueSpec 1000000 [])
             (Json.String "test")
         ]
+
+    context "value with assets and datum" do
+      it "parses add_input_utxo with assets and datum" do
+        let expected :: PatchOperationSpec
+            expected =
+              AddInputUTXOSpec
+                "txid:0"
+                (ValueSpec 2000000 [AssetSpec "#dddd" "#7465" 1000])
+                True
+                (Just (Json.String "42"))
+        case Json.eitherDecode
+          [__i|{
+            "op": "add_input_utxo",
+            "utxo_ref": "txid:0",
+            "value": {
+              "lovelace": 2000000,
+              "assets": [{
+                "currency_symbol": "\#dddd",
+                "token_name": "\#7465",
+                "quantity": 1000
+              }]
+            },
+            "is_own_input": true,
+            "datum": "42"
+          }|] of
+          Left err -> expectationFailure $ "Failed to parse: " <> err
+          Right parsedSpec -> parsedSpec `shouldBe` expected
+
+      it "parses add_output_utxo with assets" do
+        let expected :: PatchOperationSpec
+            expected =
+              AddOutputUTXOSpec
+                (ScriptAddressSpec "1111")
+                (ValueSpec 2000000 [AssetSpec "#dddd" "#7465" 500])
+        case Json.eitherDecode
+          [__i|{
+            "op": "add_output_utxo",
+            "address": {
+              "type": "script",
+              "script_hash": "1111"
+            },
+            "value": {
+              "lovelace": 2000000,
+              "assets": [{
+                "currency_symbol": "\#dddd",
+                "token_name": "\#7465",
+                "quantity": 500
+              }]
+            }
+          }|] of
+          Left err -> expectationFailure $ "Failed to parse: " <> err
+          Right parsedSpec -> parsedSpec `shouldBe` expected
 
   describe "Multiple inputs support" do
     context "JSON parsing with inputs array" do

--- a/test/TwoPartyEscrowSpec.hs
+++ b/test/TwoPartyEscrowSpec.hs
@@ -67,7 +67,7 @@ spec = do
                 [ SetRedeemer Fixed.depositRedeemer
                 , AddSignature Fixed.buyerKeyHash
                 , SetValidRange (Just 1000) Nothing -- Match depositedEscrowDatum.depositTime
-                , AddInputUTXO Fixed.txOutRef value False -- Input from buyer wallet (not script)
+                , AddInputUTXO Fixed.txOutRef value False NoOutputDatum -- Input from buyer wallet (not script)
                 , AddOutputUTXOWithDatum Fixed.scriptAddr value Fixed.depositedEscrowDatum
                 ]
       expectSuccess evaluateValidator contextData
@@ -81,7 +81,7 @@ spec = do
                 SpendingBaseline
                 [ SetRedeemer Fixed.depositRedeemer
                 , -- Note: No AddSignature (simulating removed buyer signature)
-                  AddInputUTXO Fixed.txOutRef value True
+                  AddInputUTXO Fixed.txOutRef value True NoOutputDatum
                 , AddOutputUTXO Fixed.scriptAddr value
                 ]
       expectFailure evaluateValidator contextData
@@ -96,7 +96,7 @@ spec = do
                 SpendingBaseline
                 [ SetRedeemer Fixed.depositRedeemer
                 , AddSignature Fixed.buyerKeyHash
-                , AddInputUTXO Fixed.txOutRef correctInputValue True
+                , AddInputUTXO Fixed.txOutRef correctInputValue True NoOutputDatum
                 , AddOutputUTXO Fixed.scriptAddr wrongOutputValue -- Wrong amount: 50 ADA instead of 75 ADA
                 ]
       expectFailure evaluateValidator contextData
@@ -111,7 +111,7 @@ spec = do
                 SpendingBaseline
                 [ SetRedeemer Fixed.depositRedeemer
                 , AddSignature Fixed.buyerKeyHash
-                , AddInputUTXO Fixed.txOutRef inputValue True
+                , AddInputUTXO Fixed.txOutRef inputValue True NoOutputDatum
                 , AddOutputUTXO Fixed.impostorAddr outputValue -- Output to wrong address!
                 ]
       expectFailure evaluateValidator contextData
@@ -126,7 +126,7 @@ spec = do
                 [ SetRedeemer Fixed.depositRedeemer
                 , AddSignature Fixed.buyerKeyHash
                 , SetValidRange (Just 1000) Nothing -- Deposit time
-                , AddInputUTXO Fixed.txOutRef value False -- Input from buyer wallet (not script)
+                , AddInputUTXO Fixed.txOutRef value False NoOutputDatum -- Input from buyer wallet (not script)
                 , AddOutputUTXOWithDatum Fixed.scriptAddr value Fixed.depositedEscrowDatum
                 ]
       expectSuccess evaluateValidator contextData
@@ -141,7 +141,7 @@ spec = do
                 [ SetRedeemer Fixed.depositRedeemer
                 , AddSignature Fixed.buyerKeyHash
                 , SetValidRange (Just 1000) Nothing
-                , AddInputUTXO Fixed.txOutRef value True
+                , AddInputUTXO Fixed.txOutRef value True NoOutputDatum
                 , AddOutputUTXOWithDatum Fixed.scriptAddr value Fixed.acceptedEscrowDatum -- Wrong state!
                 ]
       expectFailure evaluateValidator contextData
@@ -160,7 +160,7 @@ spec = do
                 [ SetRedeemer Fixed.acceptRedeemer
                 , AddSignature Fixed.sellerKeyHash
                 , SetScriptDatum Fixed.depositedEscrowDatum -- Add proper datum for Accept operation
-                , AddInputUTXO Fixed.txOutRef2 inputValue True -- Script input with escrowed funds
+                , AddInputUTXO Fixed.txOutRef2 inputValue True NoOutputDatum -- Script input with escrowed funds
                 , AddOutputUTXO Fixed.sellerAddr inputValue -- Payment to seller
                 ]
       expectSuccess evaluateValidator contextData
@@ -175,7 +175,7 @@ spec = do
                 [ SetRedeemer Fixed.acceptRedeemer
                 , SetScriptDatum Fixed.depositedEscrowDatum -- Add proper datum
                 , -- Note: No AddSignature (simulating missing seller signature)
-                  AddInputUTXO Fixed.txOutRef2 inputValue True
+                  AddInputUTXO Fixed.txOutRef2 inputValue True NoOutputDatum
                 , AddOutputUTXO Fixed.sellerAddr inputValue
                 ]
       expectFailure evaluateValidator contextData
@@ -191,7 +191,7 @@ spec = do
                 [ SetRedeemer Fixed.acceptRedeemer
                 , AddSignature Fixed.sellerKeyHash
                 , SetScriptDatum Fixed.depositedEscrowDatum -- Add proper datum
-                , AddInputUTXO Fixed.txOutRef2 correctInputValue True
+                , AddInputUTXO Fixed.txOutRef2 correctInputValue True NoOutputDatum
                 , AddOutputUTXO Fixed.sellerAddr wrongOutputValue -- Wrong payment amount: 50 ADA instead of 75 ADA
                 ]
       expectFailure evaluateValidator contextData
@@ -206,7 +206,7 @@ spec = do
                 [ SetRedeemer Fixed.acceptRedeemer
                 , AddSignature Fixed.sellerKeyHash -- Seller signs, but payment goes to impostor!
                 , SetScriptDatum Fixed.depositedEscrowDatum -- Add proper datum
-                , AddInputUTXO Fixed.txOutRef2 inputValue True
+                , AddInputUTXO Fixed.txOutRef2 inputValue True NoOutputDatum
                 , AddOutputUTXO Fixed.impostorAddr inputValue -- Payment to wrong address!
                 ]
       expectFailure evaluateValidator contextData
@@ -240,8 +240,8 @@ spec = do
                 [ SetRedeemer Fixed.acceptRedeemer
                 , AddSignature Fixed.sellerKeyHash
                 , SetScriptDatum Fixed.depositedEscrowDatum -- Add proper datum for Accept operation
-                , AddInputUTXO Fixed.txOutRef inputValue True -- First script input
-                , AddInputUTXO Fixed.txOutRef2 inputValue True -- Second script input
+                , AddInputUTXO Fixed.txOutRef inputValue True NoOutputDatum -- First script input
+                , AddInputUTXO Fixed.txOutRef2 inputValue True NoOutputDatum -- Second script input
                 , AddOutputUTXO Fixed.sellerAddr inputValue
                 ]
       result <- evaluateValidator contextData
@@ -260,7 +260,7 @@ spec = do
                 [ SetRedeemer Fixed.acceptRedeemer
                 , AddSignature Fixed.sellerKeyHash
                 , SetScriptDatum Fixed.depositedEscrowDatum -- Add proper datum for Accept operation
-                , AddInputUTXO Fixed.txOutRef2 inputValue True
+                , AddInputUTXO Fixed.txOutRef2 inputValue True NoOutputDatum
                 , AddOutputUTXO Fixed.sellerAddr partialPayment -- Insufficient payment
                 ]
       expectFailure evaluateValidator contextData
@@ -277,7 +277,7 @@ spec = do
                 [ SetRedeemer Fixed.acceptRedeemer
                 , AddSignature Fixed.sellerKeyHash
                 , SetScriptDatum Fixed.depositedEscrowDatum -- Add proper datum for Accept operation
-                , AddInputUTXO Fixed.txOutRef2 inputValue True
+                , AddInputUTXO Fixed.txOutRef2 inputValue True NoOutputDatum
                 , AddOutputUTXO Fixed.sellerAddr excessPayment -- More than required
                 ]
       result <- evaluateValidator contextData
@@ -296,7 +296,7 @@ spec = do
                 [ SetRedeemer Fixed.acceptRedeemer
                 , AddSignature Fixed.sellerKeyHash
                 , SetScriptDatum Fixed.depositedEscrowDatum -- Add proper datum
-                , AddInputUTXO Fixed.txOutRef2 inputValue True
+                , AddInputUTXO Fixed.txOutRef2 inputValue True NoOutputDatum
                 , AddOutputUTXO Fixed.sellerAddr inputValue -- Payment with potential datum
                 ]
       result <- evaluateValidator contextData
@@ -315,7 +315,7 @@ spec = do
                 [ SetRedeemer Fixed.acceptRedeemer
                 , AddSignature Fixed.sellerKeyHash
                 , SetScriptDatum Fixed.depositedEscrowDatum -- Add proper datum
-                , AddInputUTXO Fixed.txOutRef2 inputValue True
+                , AddInputUTXO Fixed.txOutRef2 inputValue True NoOutputDatum
                 , AddOutputUTXO Fixed.sellerAddr firstPayment -- First payment
                 , AddOutputUTXO Fixed.sellerAddr secondPayment -- Second payment
                 ]
@@ -335,7 +335,7 @@ spec = do
                 [ SetRedeemer Fixed.acceptRedeemer
                 , AddSignature Fixed.sellerKeyHash
                 , SetScriptDatum Fixed.depositedEscrowDatum -- Add proper datum for Accept operation
-                , AddInputUTXO Fixed.txOutRef2 inputValue True
+                , AddInputUTXO Fixed.txOutRef2 inputValue True NoOutputDatum
                 , AddOutputUTXO Fixed.sellerAddr inputValue -- Payment to seller
                 , AddOutputUTXO Fixed.scriptAddr (adaValue 10_000_000) -- Remaining in script
                 ]
@@ -359,7 +359,7 @@ spec = do
                 , AddSignature Fixed.buyerKeyHash
                 , SetScriptDatum Fixed.depositedEscrowDatum -- Add proper datum
                 , SetValidRange (Just 2801) Nothing -- After deadline (1000 + 1800 = 2800, so 2801)
-                , AddInputUTXO Fixed.txOutRef2 inputValue True -- Script input with escrowed funds
+                , AddInputUTXO Fixed.txOutRef2 inputValue True NoOutputDatum -- Script input with escrowed funds
                 , AddOutputUTXO Fixed.buyerAddr inputValue -- Refund to buyer
                 ]
       expectSuccess evaluateValidator contextData
@@ -375,7 +375,7 @@ spec = do
                 , AddSignature Fixed.buyerKeyHash
                 , SetScriptDatum Fixed.depositedEscrowDatum -- Add proper datum
                 , SetValidRange (Just 2801) Nothing -- Exactly at deadline + 1 (1000 + 1800 = 2800, so 2801)
-                , AddInputUTXO Fixed.txOutRef2 inputValue True
+                , AddInputUTXO Fixed.txOutRef2 inputValue True NoOutputDatum
                 , AddOutputUTXO Fixed.buyerAddr inputValue
                 ]
       expectSuccess evaluateValidator contextData
@@ -391,8 +391,8 @@ spec = do
                 , AddSignature Fixed.buyerKeyHash
                 , SetScriptDatum Fixed.depositedEscrowDatum -- Add proper datum
                 , SetValidRange (Just 3000) Nothing -- Well after deadline (1000 + 1800 = 2800)
-                , AddInputUTXO Fixed.txOutRef inputValue True -- First script input
-                , AddInputUTXO Fixed.txOutRef2 inputValue True -- Second script input
+                , AddInputUTXO Fixed.txOutRef inputValue True NoOutputDatum -- First script input
+                , AddInputUTXO Fixed.txOutRef2 inputValue True NoOutputDatum -- Second script input
                 , AddOutputUTXO Fixed.buyerAddr inputValue
                 ]
       expectSuccess evaluateValidator contextData
@@ -408,7 +408,7 @@ spec = do
                 , AddSignature Fixed.buyerKeyHash
                 , SetScriptDatum Fixed.depositedEscrowDatum -- Add proper datum
                 , SetValidRange (Just 3600) Nothing -- 1 hour after deadline
-                , AddInputUTXO Fixed.txOutRef2 inputValue True
+                , AddInputUTXO Fixed.txOutRef2 inputValue True NoOutputDatum
                 , AddOutputUTXO Fixed.buyerAddr inputValue -- With potential datum
                 ]
       expectSuccess evaluateValidator contextData
@@ -426,7 +426,7 @@ spec = do
                 , AddSignature Fixed.buyerKeyHash
                 , SetScriptDatum Fixed.depositedEscrowDatum -- Add proper datum
                 , SetValidRange (Just 5000) Nothing -- Well after deadline
-                , AddInputUTXO Fixed.txOutRef2 inputValue True
+                , AddInputUTXO Fixed.txOutRef2 inputValue True NoOutputDatum
                 , AddOutputUTXO Fixed.buyerAddr firstPayment -- First refund output
                 , AddOutputUTXO Fixed.buyerAddr secondPayment -- Second refund output
                 ]
@@ -444,7 +444,7 @@ spec = do
                 , SetScriptDatum Fixed.depositedEscrowDatum -- Add proper datum for Refund operation
                 , -- Note: No AddSignature (missing buyer signature)
                   SetValidRange (Just 3000) Nothing -- After deadline
-                , AddInputUTXO Fixed.txOutRef2 inputValue True
+                , AddInputUTXO Fixed.txOutRef2 inputValue True NoOutputDatum
                 , AddOutputUTXO Fixed.buyerAddr inputValue
                 ]
       expectFailure evaluateValidator contextData
@@ -459,7 +459,7 @@ spec = do
                 [ SetRedeemer Fixed.refundRedeemer
                 , AddSignature Fixed.sellerKeyHash -- Wrong signer!
                 , SetValidRange (Just 3000) Nothing -- After deadline
-                , AddInputUTXO Fixed.txOutRef2 inputValue True
+                , AddInputUTXO Fixed.txOutRef2 inputValue True NoOutputDatum
                 , AddOutputUTXO Fixed.buyerAddr inputValue
                 ]
       expectFailure evaluateValidator contextData
@@ -474,7 +474,7 @@ spec = do
                 [ SetRedeemer Fixed.refundRedeemer
                 , AddSignature Fixed.impostorPubkey -- Impostor signature!
                 , SetValidRange (Just 3000) Nothing -- After deadline
-                , AddInputUTXO Fixed.txOutRef2 inputValue True
+                , AddInputUTXO Fixed.txOutRef2 inputValue True NoOutputDatum
                 , AddOutputUTXO Fixed.buyerAddr inputValue
                 ]
       expectFailure evaluateValidator contextData
@@ -490,7 +490,7 @@ spec = do
                 [ SetRedeemer Fixed.refundRedeemer
                 , AddSignature Fixed.buyerKeyHash
                 , SetValidRange (Just 900) Nothing -- Before deadline (1800 seconds)
-                , AddInputUTXO Fixed.txOutRef2 inputValue True
+                , AddInputUTXO Fixed.txOutRef2 inputValue True NoOutputDatum
                 , AddOutputUTXO Fixed.buyerAddr inputValue
                 ]
       expectFailure evaluateValidator contextData
@@ -505,7 +505,7 @@ spec = do
                 [ SetRedeemer Fixed.refundRedeemer
                 , AddSignature Fixed.buyerKeyHash
                 , SetValidRange (Just 2800) Nothing -- Exactly at deadline (should fail)
-                , AddInputUTXO Fixed.txOutRef2 inputValue True
+                , AddInputUTXO Fixed.txOutRef2 inputValue True NoOutputDatum
                 , AddOutputUTXO Fixed.buyerAddr inputValue
                 ]
       expectFailure evaluateValidator contextData
@@ -520,7 +520,7 @@ spec = do
                 [ SetRedeemer Fixed.refundRedeemer
                 , AddSignature Fixed.buyerKeyHash
                 , -- Note: No SetValidRange (using default always-valid range)
-                  AddInputUTXO Fixed.txOutRef2 inputValue True
+                  AddInputUTXO Fixed.txOutRef2 inputValue True NoOutputDatum
                 , AddOutputUTXO Fixed.buyerAddr inputValue
                 ]
       expectFailure evaluateValidator contextData
@@ -537,7 +537,7 @@ spec = do
                 [ SetRedeemer Fixed.refundRedeemer
                 , AddSignature Fixed.buyerKeyHash
                 , SetValidRange (Just 3000) Nothing -- After deadline
-                , AddInputUTXO Fixed.txOutRef2 inputValue True
+                , AddInputUTXO Fixed.txOutRef2 inputValue True NoOutputDatum
                 , AddOutputUTXO Fixed.buyerAddr wrongRefund -- Wrong amount
                 ]
       expectFailure evaluateValidator contextData
@@ -553,7 +553,7 @@ spec = do
                 [ SetRedeemer Fixed.refundRedeemer
                 , AddSignature Fixed.buyerKeyHash
                 , SetValidRange (Just 3000) Nothing -- After deadline
-                , AddInputUTXO Fixed.txOutRef2 inputValue True
+                , AddInputUTXO Fixed.txOutRef2 inputValue True NoOutputDatum
                 , AddOutputUTXO Fixed.buyerAddr partialRefund -- Insufficient refund
                 ]
       expectFailure evaluateValidator contextData
@@ -569,7 +569,7 @@ spec = do
                 [ SetRedeemer Fixed.refundRedeemer
                 , AddSignature Fixed.buyerKeyHash
                 , SetValidRange (Just 3000) Nothing -- After deadline
-                , AddInputUTXO Fixed.txOutRef2 inputValue True
+                , AddInputUTXO Fixed.txOutRef2 inputValue True NoOutputDatum
                 , AddOutputUTXO Fixed.buyerAddr excessRefund -- Too much refund
                 ]
       expectFailure evaluateValidator contextData
@@ -584,7 +584,7 @@ spec = do
                 [ SetRedeemer Fixed.refundRedeemer
                 , AddSignature Fixed.buyerKeyHash
                 , SetValidRange (Just 3000) Nothing -- After deadline
-                , AddInputUTXO Fixed.txOutRef2 inputValue True
+                , AddInputUTXO Fixed.txOutRef2 inputValue True NoOutputDatum
                 , AddOutputUTXO Fixed.sellerAddr inputValue -- Wrong recipient!
                 ]
       expectFailure evaluateValidator contextData
@@ -601,7 +601,7 @@ spec = do
                 [ SetRedeemer Fixed.refundRedeemer
                 , AddSignature Fixed.buyerKeyHash
                 , SetValidRange (Just 3000) Nothing -- After deadline
-                , AddInputUTXO Fixed.txOutRef2 inputValue True
+                , AddInputUTXO Fixed.txOutRef2 inputValue True NoOutputDatum
                 , AddOutputUTXO Fixed.buyerAddr partialRefund
                 , AddOutputUTXO Fixed.scriptAddr remainingInScript -- Funds left in script!
                 ]
@@ -637,7 +637,7 @@ spec = do
                 , AddSignature Fixed.buyerKeyHash
                 , SetValidRange (Just 3000) Nothing -- After deadline -- After deadline
                 , SetScriptDatum Fixed.acceptedEscrowDatum -- Already accepted!
-                , AddInputUTXO Fixed.txOutRef2 (Fixed.lovelaceValue Fixed.escrowPrice) True
+                , AddInputUTXO Fixed.txOutRef2 (Fixed.lovelaceValue Fixed.escrowPrice) True NoOutputDatum
                 , AddOutputUTXO Fixed.buyerAddr (Fixed.lovelaceValue Fixed.escrowPrice)
                 ]
       expectFailure evaluateValidator contextData
@@ -651,7 +651,7 @@ spec = do
                 [ SetRedeemer Fixed.acceptRedeemer
                 , AddSignature Fixed.sellerKeyHash
                 , SetScriptDatum Fixed.refundedEscrowDatum -- Already refunded!
-                , AddInputUTXO Fixed.txOutRef2 (Fixed.lovelaceValue Fixed.escrowPrice) True
+                , AddInputUTXO Fixed.txOutRef2 (Fixed.lovelaceValue Fixed.escrowPrice) True NoOutputDatum
                 , AddOutputUTXO Fixed.sellerAddr (Fixed.lovelaceValue Fixed.escrowPrice)
                 ]
       expectFailure evaluateValidator contextData
@@ -666,7 +666,7 @@ spec = do
                 , AddSignature Fixed.buyerKeyHash
                 , SetValidRange (Just 3000) Nothing -- After deadline -- After deadline
                 , SetScriptDatum Fixed.refundedEscrowDatum -- Already refunded!
-                , AddInputUTXO Fixed.txOutRef2 (Fixed.lovelaceValue Fixed.escrowPrice) True
+                , AddInputUTXO Fixed.txOutRef2 (Fixed.lovelaceValue Fixed.escrowPrice) True NoOutputDatum
                 , AddOutputUTXO Fixed.buyerAddr (Fixed.lovelaceValue Fixed.escrowPrice)
                 ]
       expectFailure evaluateValidator contextData
@@ -680,7 +680,7 @@ spec = do
                 [ SetRedeemer Fixed.acceptRedeemer
                 , AddSignature Fixed.sellerKeyHash
                 , SetScriptDatum Fixed.acceptedEscrowDatum -- Already accepted!
-                , AddInputUTXO Fixed.txOutRef2 (Fixed.lovelaceValue Fixed.escrowPrice) True
+                , AddInputUTXO Fixed.txOutRef2 (Fixed.lovelaceValue Fixed.escrowPrice) True NoOutputDatum
                 , AddOutputUTXO Fixed.sellerAddr (Fixed.lovelaceValue Fixed.escrowPrice)
                 ]
       expectFailure evaluateValidator contextData


### PR DESCRIPTION
## Summary

- Introduce structured `value` attribute for UTXO patch operations, consolidating `lovelace` and native assets under a single domain object that mirrors the Cardano Value type
- Add optional `datum` field to `add_input_utxo` for inline datum on resolved TxOut inputs
- Migrate `two_party_escrow` test suite to the new value format

Closes IntersectMBO/plutus-private#2152

## Motivation

Real-world validators like Linear Vesting operate on custom tokens and check datum preservation across input/output UTXOs. The test framework previously only supported lovelace values and `NoOutputDatum` on inputs, with no structured representation of Cardano's multi-asset Value.

## Key changes

| File | Change |
|------|--------|
| `lib/Cape/ScriptContextBuilder.hs` | `AddInputUTXO` now carries `OutputDatum` parameter |
| `lib/Cape/Tests.hs` | New `ValueSpec`/`AssetSpec` types, `buildValue`/`resolveAsset`/`resolveAsBytes` helpers, consolidated JSON parsing under `"value"` |
| `test/Cape/ScriptContextBuilderSpec.hs` | Updated `AddInputUTXO` call sites |
| `test/Cape/TestsSpec.hs` | Updated spec constructors and JSON round-trip tests |
| `test/TwoPartyEscrowSpec.hs` | Updated `AddInputUTXO` call sites with `NoOutputDatum` |
| `scenarios/two_party_escrow/cape-tests.json` | Migrated to `"value": {"lovelace": N}` format |

## Example usage in `cape-tests.json`

Lovelace only:
```json
{"op": "add_input_utxo", "utxo_ref": "3333...:0", "value": {"lovelace": 75000000}, "is_own_input": true}
```

With native assets and datum:
```json
{
  "op": "add_input_utxo",
  "utxo_ref": "3333...:0",
  "value": {
    "lovelace": 2000000,
    "assets": [
      {"currency_symbol": "@cs_ref", "token_name": "@tn_ref", "quantity": 1000}
    ]
  },
  "is_own_input": true,
  "datum": "@vesting_datum"
}
```