### PR TITLE
Update GHC from 9.6.6 to 9.6.7

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -74,7 +74,7 @@
         # haskell.nix project for building the Cabal project
         project = pkgs.haskell-nix.cabalProject' {
           src = ./.;
-          compiler-nix-name = "ghc966";
+          compiler-nix-name = "ghc967";
 
           # CHaP repository mapping
           inputMap = {


### PR DESCRIPTION
Match the GHC version used by the plutus repo to avoid differences in GHC Core generation affecting PlutusTx plugin behavior.

Closes IntersectMBO/plutus-private#2158