### PR TITLE
Update preview Plutus to 1.61 and CHaP flake input

### DIFF
--- a/cabal.project.preview
+++ b/cabal.project.preview
@@ -6,8 +6,8 @@
 
 import: cabal.project
 
--- Use latest CHaP index-state to access plutus-core 1.60.0.0
-index-state: cardano-haskell-packages 2026-03-30T00:00:00Z
+-- Use latest CHaP index-state to access plutus-core 1.61.0.0
+index-state: cardano-haskell-packages 2026-04-11T06:29:42Z
 
 -- Enable preview flag to build Preview.* modules with BuiltinCasing
 flags: +preview

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1761257466,
-        "narHash": "sha256-4igwonBFjlM0DRRyXL3iHci+kCIp1AxfpYoc9QEQ1Cg=",
+        "lastModified": 1775892872,
+        "narHash": "sha256-8qwpclExAZYF5e35xqt9yQYcal3FJLirKNIMiomAIvs=",
         "owner": "IntersectMBO",
         "repo": "cardano-haskell-packages",
-        "rev": "6a82820564add7918f1199c6e321f917d260a262",
+        "rev": "86660ad10909f521a9c42cb01e9626aefd3903cf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Update CHaP flake input from 2025-10-23 to 2026-04-11 and preview index-state so the preview build resolves plutus 1.61 (matching current plutus master).

Closes IntersectMBO/plutus-private#2159