### PR TITLE
fix(report): restore Fixed Algorithm Scenarios in index

### DIFF
--- a/scripts/cape-subcommands/submission/report.sh
+++ b/scripts/cape-subcommands/submission/report.sh
@@ -326,11 +326,11 @@ build_filtered_stats() {
     first_benchmark=false
 
     local category winners_json
-    category=$(categorize_scenario "$benchmark")
+    category=$(categorize_scenario "$bench")
     winners_json=$(find_winners "$benchmark_csv")
 
     echo '    {'
-    echo '      "name": "'$benchmark'",'
+    echo '      "name": "'$bench'",'
     echo '      "category": "'$category'",'
     echo '      "submission_count": '$submission_count','
     echo '      "winners": '$winners_json','


### PR DESCRIPTION
## Summary

- Fix `build_filtered_stats` in `scripts/cape-subcommands/submission/report.sh` to use the loop variable `$bench` instead of the stale `$benchmark`. The rewrite in #165 renamed the local loop variable but missed two usages inside the body.
- Because bash has dynamic scoping, `$benchmark` leaked in from the outer `for benchmark in $all_benchmarks` loop, always expanding to the alphabetically last scenario (`two_party_escrow`). Every emitted stats entry therefore had `name = "two_party_escrow"` and `category = "open"`, which emptied the Fixed Algorithm Scenarios section on the published site (`intersectmbo.github.io/UPLC-CAPE`) and collapsed every card under Open pointing to `benchmarks/two_party_escrow.html`.

## Note

Report HTML is intentionally not regenerated in this PR — the GitHub Pages workflow will regenerate and publish on merge.