### PR TITLE
HTLC: switch claim to upper-bound validity check (production-safe)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist-newstyle/
 build-and-deploy.sh
 result
 result-*
+*.code-workspace

--- a/lib/HTLC.hs
+++ b/lib/HTLC.hs
@@ -102,7 +102,7 @@ validateClaim ctx HTLCDatum {recipient, secretHash, timeout} preimage =
         traceError "Missing recipient signature"
     | not (equalsByteString (sha2_256 preimage) secretHash) ->
         traceError "Preimage does not match stored hash"
-    | lessThanEqualsInteger timeoutInt currentTime ->
+    | lessThanEqualsInteger timeoutInt upperTime ->
         traceError "Claim not permitted at or after timeout"
     | not (equalsInteger (countScriptInputs txInfo ownScriptHash) 1) ->
         traceError "Double satisfaction"
@@ -111,7 +111,7 @@ validateClaim ctx HTLCDatum {recipient, secretHash, timeout} preimage =
     txInfo = scriptContextTxInfo ctx
     recipientHash = extractPubKeyHash recipient
     signed = txSignedBy txInfo (PubKeyHash recipientHash)
-    POSIXTime currentTime = lowerBoundTime (txInfoValidRange txInfo)
+    POSIXTime upperTime = upperBoundTime (txInfoValidRange txInfo)
     POSIXTime timeoutInt = timeout
     ownScriptHash = ownInputScriptHash ctx
 
@@ -146,7 +146,17 @@ there but not re-exported.
 lowerBoundTime :: POSIXTimeRange -> POSIXTime
 lowerBoundTime (Interval (LowerBound (Finite t) True) _) = t
 lowerBoundTime (Interval (LowerBound (Finite (POSIXTime t)) False) _) = POSIXTime (t + 1)
-lowerBoundTime _ = traceError "Time range not Finite"
+lowerBoundTime _ = traceError "Lower bound of valid range must be finite"
+
+{- | Extract the normalised inclusive upper bound from a POSIXTimeRange,
+failing if it is not finite. Used by 'validateClaim' to check that the
+transaction's validity window ends strictly before the timeout.
+-}
+{-# INLINEABLE upperBoundTime #-}
+upperBoundTime :: POSIXTimeRange -> POSIXTime
+upperBoundTime (Interval _ (UpperBound (Finite t) True)) = t
+upperBoundTime (Interval _ (UpperBound (Finite (POSIXTime t)) False)) = POSIXTime (t - 1)
+upperBoundTime _ = traceError "Upper bound of valid range must be finite"
 
 -- | Extract PubKeyHash bytes from an Address.
 {-# INLINEABLE extractPubKeyHash #-}

--- a/scenarios/htlc/cape-tests.json
+++ b/scenarios/htlc/cape-tests.json
@@ -37,7 +37,8 @@
           },
           {
             "op": "set_valid_range",
-            "from_time": 50
+            "from_time": 50,
+            "to_time": 50
           },
           {
             "op": "add_input_utxo",
@@ -191,7 +192,8 @@
             "patches": [
               {
                 "op": "set_valid_range",
-                "from_time": 99
+                "from_time": 99,
+                "to_time": 99
               }
             ]
           }
@@ -364,7 +366,8 @@
             "patches": [
               {
                 "op": "set_valid_range",
-                "from_time": 100
+                "from_time": 100,
+                "to_time": 100
               }
             ]
           }
@@ -385,7 +388,29 @@
             "patches": [
               {
                 "op": "set_valid_range",
-                "from_time": 150
+                "from_time": 150,
+                "to_time": 150
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "claim_infinite_upper_bound",
+      "description": "Claim with from_time=50 and no upper bound (+inf) should fail; the upper bound must be finite",
+      "expected": {
+        "type": "error"
+      },
+      "inputs": [
+        {
+          "type": "script_context",
+          "script_context": {
+            "baseline": "@successful_claim",
+            "patches": [
+              {
+                "op": "set_valid_range",
+                "from_time": 50
               }
             ]
           }
@@ -525,6 +550,27 @@
               {
                 "op": "set_valid_range",
                 "from_time": 100
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "refund_infinite_lower_bound",
+      "description": "Refund with no lower bound (-inf) should fail; the lower bound must be finite",
+      "expected": {
+        "type": "error"
+      },
+      "inputs": [
+        {
+          "type": "script_context",
+          "script_context": {
+            "baseline": "@successful_refund",
+            "patches": [
+              {
+                "op": "set_valid_range",
+                "to_time": 200
               }
             ]
           }

--- a/scenarios/htlc/htlc.md
+++ b/scenarios/htlc/htlc.md
@@ -70,8 +70,8 @@ When testing this validator, the test framework uses generic dummy constants for
 
 - The validator is spending from a script address with the above dummy script hash
 - No continuing output is required: both claim and refund fully consume the script UTXO
-- Claim validation requires recipient signature, a preimage whose SHA-256 digest matches the datum hash, and current time strictly less than the timeout
-- Refund validation requires payer signature and current time strictly greater than the timeout
+- Claim validation requires recipient signature, a preimage whose SHA-256 digest matches the datum hash, and the upper bound of the valid range to be finite and strictly less than the timeout
+- Refund validation requires payer signature and the lower bound of the valid range to be finite and strictly greater than the timeout
 
 **Test Framework Behavior:**
 
@@ -91,8 +91,8 @@ flowchart LR
 
 | Current State | Event | Condition | Next State |
 | --- | --- | --- | --- |
-| **Locked** | `Claim(preimage)` | `sha2_256(preimage) == hash`, recipient sig, `currentTime < timeout` | **Claimed** |
-| **Locked** | `Refund()` | Payer sig, `currentTime > timeout` | **Refunded** |
+| **Locked** | `Claim(preimage)` | `sha2_256(preimage) == hash`, recipient sig, `upperBound(validRange) < timeout` | **Claimed** |
+| **Locked** | `Refund()` | Payer sig, `lowerBound(validRange) > timeout` | **Refunded** |
 | **Claimed** | - | Funds delivered to recipient | **Final** |
 | **Refunded** | - | Funds returned to payer | **Final** |
 
@@ -103,7 +103,7 @@ flowchart LR
 - **Refunded**: Payer has reclaimed the funds after the timeout expired without a successful claim.
 - **Final**: Terminal state, no UTXO remains at the script address.
 
-**Note**: The two paths are mutually exclusive at the validator level via the temporal check: claim requires `currentTime < timeout`, refund requires `currentTime > timeout`, and both use the **strict** comparison against the lower bound of the transaction's valid range.
+**Note**: The two paths are mutually exclusive at the validator level via the temporal check: claim requires the **upper bound** of the transaction's valid range to be finite and strictly less than `timeout`, while refund requires the **lower bound** to be finite and strictly greater than `timeout`. Both comparisons are strict.
 
 ## View 2: Transaction Sequence View
 
@@ -187,16 +187,16 @@ Both **Claim** and **Refund** sequences are measured for comprehensive performan
 
 - **Authorization**: Transaction signed by recipient's PubKeyHash
 - **Preimage Check**: `sha2_256(preimage) == hash` (the datum's stored digest)
-- **Time Check**: Current time (lower bound of valid range) must be strictly less than `timeout`
+- **Time Check**: Upper bound of valid range must be finite and strictly less than `timeout`
 - **Single Script Input**: Exactly one input from this script address (prevents double satisfaction)
 
 #### Refund Operation (Redeemer = 1())
 
 - **Authorization**: Transaction signed by payer's PubKeyHash
-- **Time Check**: Current time (lower bound of valid range) must be strictly greater than `timeout`
+- **Time Check**: Lower bound of valid range must be finite and strictly greater than `timeout`
 - **Single Script Input**: Exactly one input from this script address (prevents double satisfaction)
 
-**Note on time semantics**: The validator reads the **lower bound** of `txInfoValidRange` and treats it as "current time". For a finite inclusive lower bound `t`, `currentTime = t`; for a finite exclusive lower bound, `currentTime = t + 1`. An infinite lower bound is rejected. This mirrors the convention used by the Linear Vesting and Two-Party Escrow scenarios.
+**Note on time semantics**: For the claim path the validator reads the **upper bound** of `txInfoValidRange`; it must be finite (an infinite upper bound is rejected) and must satisfy `upperBound < timeout` (strict). For the refund path the validator reads the **lower bound**; it must be finite (an infinite lower bound is rejected) and must satisfy `lowerBound > timeout` (strict). For a finite inclusive upper bound `t`, `upperBound = t`; for a finite exclusive upper bound `t`, `upperBound = t − 1`. Symmetrically for the lower bound: inclusive `t` ⇒ `lowerBound = t`; exclusive `t` ⇒ `lowerBound = t + 1`. This is the production-safe convention — using the upper bound for the "before deadline" check guarantees the real block time cannot exceed the deadline even when the transaction specifies an unusually wide validity range. Linear Vesting and Two-Party Escrow currently use a different convention; unification is tracked in a follow-up issue.
 
 ## Test Constants and Fixed Values
 
@@ -245,11 +245,13 @@ The HTLC tests rely on a consistent set of fixed constants to ensure reproducibl
 
 **Temporal Boundaries:**
 
-- **Well Before Timeout**: time=50 — Valid for claim
-- **Just Before Timeout**: time=99 — Valid for claim
+Claim fixtures use a point interval `[t, t]` so the upper bound equals `t`; refund fixtures use `[t, +∞)` so the lower bound equals `t`.
+
+- **Well Before Timeout**: time=50 — Valid for claim (upperBound=50 < 100)
+- **Just Before Timeout**: time=99 — Valid for claim (upperBound=99 < 100)
 - **At Timeout**: time=100 — Should fail for both claim and refund (strict comparisons)
-- **Just After Timeout**: time=101 — Valid for refund
-- **Well After Timeout**: time=200 — Valid for refund
+- **Just After Timeout**: time=101 — Valid for refund (lowerBound=101 > 100)
+- **Well After Timeout**: time=200 — Valid for refund (lowerBound=200 > 100)
 
 ## Test Cases
 
@@ -299,6 +301,8 @@ The HTLC validator is tested through a comprehensive suite of test cases coverin
 
 - **`claim_after_timeout`** Verifies claim fails at time=150 (after timeout), even with correct preimage and recipient signature.
 
+- **`claim_infinite_upper_bound`** Verifies claim fails when the validity range has no upper bound (`[50, +∞)`). The validator rejects an infinite upper bound.
+
 ### Claim Double Satisfaction Test
 
 - **`claim_double_satisfaction`** Verifies claim fails when there are two inputs from the script address. The single-script-input check prevents double satisfaction attacks.
@@ -316,6 +320,8 @@ The HTLC validator is tested through a comprehensive suite of test cases coverin
 - **`refund_before_timeout`** Verifies refund fails at time=50, before the timeout. The payer must wait until after the deadline.
 
 - **`refund_at_timeout`** Verifies refund fails at time=100, exactly at the timeout boundary. The check is strictly greater than, so equal is not sufficient.
+
+- **`refund_infinite_lower_bound`** Verifies refund fails when the validity range has no lower bound (`(−∞, 200]`). The validator rejects an infinite lower bound.
 
 ### Refund Double Satisfaction Test
 

--- a/submissions/htlc/Plinth_1.45.0.0_Unisay/htlc.uplc
+++ b/submissions/htlc/Plinth_1.45.0.0_Unisay/htlc.uplc
@@ -59,7 +59,7 @@
                                                                               ownInputScriptHash-18
                                                                               [
                                                                                 (lam
-                                                                                  lowerBoundTime-19
+                                                                                  `$fUnsafeFromDataBool_$cunsafeFromBuiltinData`-19
                                                                                   [
                                                                                     (lam
                                                                                       extractPubKeyHash-20
@@ -317,16 +317,227 @@
                                                                                                                               )
                                                                                                                             )
                                                                                                                             [
-                                                                                                                              lowerBoundTime-19
-                                                                                                                              [
+                                                                                                                              (lam
+                                                                                                                                l-36
                                                                                                                                 [
+                                                                                                                                  (lam
+                                                                                                                                    tup-37
+                                                                                                                                    (force
+                                                                                                                                      (force
+                                                                                                                                        [
+                                                                                                                                          [
+                                                                                                                                            [
+                                                                                                                                              (force
+                                                                                                                                                (builtin
+                                                                                                                                                  ifThenElse
+                                                                                                                                                )
+                                                                                                                                              )
+                                                                                                                                              [
+                                                                                                                                                [
+                                                                                                                                                  (builtin
+                                                                                                                                                    equalsInteger
+                                                                                                                                                  )
+                                                                                                                                                  (con
+                                                                                                                                                    integer
+                                                                                                                                                    1
+                                                                                                                                                  )
+                                                                                                                                                ]
+                                                                                                                                                [
+                                                                                                                                                  (force
+                                                                                                                                                    (force
+                                                                                                                                                      (builtin
+                                                                                                                                                        fstPair
+                                                                                                                                                      )
+                                                                                                                                                    )
+                                                                                                                                                  )
+                                                                                                                                                  tup-37
+                                                                                                                                                ]
+                                                                                                                                              ]
+                                                                                                                                            ]
+                                                                                                                                            (delay
+                                                                                                                                              (delay
+                                                                                                                                                (force
+                                                                                                                                                  (case
+                                                                                                                                                    [
+                                                                                                                                                      `$fUnsafeFromDataBool_$cunsafeFromBuiltinData`-19
+                                                                                                                                                      [
+                                                                                                                                                        (force
+                                                                                                                                                          (builtin
+                                                                                                                                                            headList
+                                                                                                                                                          )
+                                                                                                                                                        )
+                                                                                                                                                        [
+                                                                                                                                                          (force
+                                                                                                                                                            (builtin
+                                                                                                                                                              tailList
+                                                                                                                                                            )
+                                                                                                                                                          )
+                                                                                                                                                          l-36
+                                                                                                                                                        ]
+                                                                                                                                                      ]
+                                                                                                                                                    ]
+                                                                                                                                                    (delay
+                                                                                                                                                      [
+                                                                                                                                                        (builtin
+                                                                                                                                                          unIData
+                                                                                                                                                        )
+                                                                                                                                                        [
+                                                                                                                                                          (force
+                                                                                                                                                            (builtin
+                                                                                                                                                              headList
+                                                                                                                                                            )
+                                                                                                                                                          )
+                                                                                                                                                          [
+                                                                                                                                                            (force
+                                                                                                                                                              (force
+                                                                                                                                                                (builtin
+                                                                                                                                                                  sndPair
+                                                                                                                                                                )
+                                                                                                                                                              )
+                                                                                                                                                            )
+                                                                                                                                                            tup-37
+                                                                                                                                                          ]
+                                                                                                                                                        ]
+                                                                                                                                                      ]
+                                                                                                                                                    )
+                                                                                                                                                    (delay
+                                                                                                                                                      [
+                                                                                                                                                        [
+                                                                                                                                                          (builtin
+                                                                                                                                                            subtractInteger
+                                                                                                                                                          )
+                                                                                                                                                          [
+                                                                                                                                                            (builtin
+                                                                                                                                                              unIData
+                                                                                                                                                            )
+                                                                                                                                                            [
+                                                                                                                                                              (force
+                                                                                                                                                                (builtin
+                                                                                                                                                                  headList
+                                                                                                                                                                )
+                                                                                                                                                              )
+                                                                                                                                                              [
+                                                                                                                                                                (force
+                                                                                                                                                                  (force
+                                                                                                                                                                    (builtin
+                                                                                                                                                                      sndPair
+                                                                                                                                                                    )
+                                                                                                                                                                  )
+                                                                                                                                                                )
+                                                                                                                                                                tup-37
+                                                                                                                                                              ]
+                                                                                                                                                            ]
+                                                                                                                                                          ]
+                                                                                                                                                        ]
+                                                                                                                                                        (con
+                                                                                                                                                          integer
+                                                                                                                                                          1
+                                                                                                                                                        )
+                                                                                                                                                      ]
+                                                                                                                                                    )
+                                                                                                                                                  )
+                                                                                                                                                )
+                                                                                                                                              )
+                                                                                                                                            )
+                                                                                                                                          ]
+                                                                                                                                          (delay
+                                                                                                                                            (delay
+                                                                                                                                              [
+                                                                                                                                                (lam
+                                                                                                                                                  x-38
+                                                                                                                                                  (error
+
+                                                                                                                                                  )
+                                                                                                                                                )
+                                                                                                                                                [
+                                                                                                                                                  [
+                                                                                                                                                    (force
+                                                                                                                                                      (builtin
+                                                                                                                                                        trace
+                                                                                                                                                      )
+                                                                                                                                                    )
+                                                                                                                                                    (con
+                                                                                                                                                      string
+                                                                                                                                                      "Upper bound of valid range must be finite"
+                                                                                                                                                    )
+                                                                                                                                                  ]
+                                                                                                                                                  (constr
+                                                                                                                                                    0
+                                                                                                                                                  )
+                                                                                                                                                ]
+                                                                                                                                              ]
+                                                                                                                                            )
+                                                                                                                                          )
+                                                                                                                                        ]
+                                                                                                                                      )
+                                                                                                                                    )
+                                                                                                                                  )
                                                                                                                                   [
-                                                                                                                                    `$mTxInfo`-11
-                                                                                                                                    nt-29
+                                                                                                                                    (builtin
+                                                                                                                                      unConstrData
+                                                                                                                                    )
+                                                                                                                                    [
+                                                                                                                                      (force
+                                                                                                                                        (builtin
+                                                                                                                                          headList
+                                                                                                                                        )
+                                                                                                                                      )
+                                                                                                                                      l-36
+                                                                                                                                    ]
                                                                                                                                   ]
-                                                                                                                                  txInfoValidRange-13
                                                                                                                                 ]
-                                                                                                                                txInfoValidRange-14
+                                                                                                                              )
+                                                                                                                              [
+                                                                                                                                (force
+                                                                                                                                  (force
+                                                                                                                                    (builtin
+                                                                                                                                      sndPair
+                                                                                                                                    )
+                                                                                                                                  )
+                                                                                                                                )
+                                                                                                                                [
+                                                                                                                                  (builtin
+                                                                                                                                    unConstrData
+                                                                                                                                  )
+                                                                                                                                  [
+                                                                                                                                    (force
+                                                                                                                                      (builtin
+                                                                                                                                        headList
+                                                                                                                                      )
+                                                                                                                                    )
+                                                                                                                                    [
+                                                                                                                                      (force
+                                                                                                                                        (builtin
+                                                                                                                                          tailList
+                                                                                                                                        )
+                                                                                                                                      )
+                                                                                                                                      [
+                                                                                                                                        (force
+                                                                                                                                          (force
+                                                                                                                                            (builtin
+                                                                                                                                              sndPair
+                                                                                                                                            )
+                                                                                                                                          )
+                                                                                                                                        )
+                                                                                                                                        [
+                                                                                                                                          (builtin
+                                                                                                                                            unConstrData
+                                                                                                                                          )
+                                                                                                                                          [
+                                                                                                                                            [
+                                                                                                                                              [
+                                                                                                                                                `$mTxInfo`-11
+                                                                                                                                                nt-29
+                                                                                                                                              ]
+                                                                                                                                              txInfoValidRange-13
+                                                                                                                                            ]
+                                                                                                                                            txInfoValidRange-14
+                                                                                                                                          ]
+                                                                                                                                        ]
+                                                                                                                                      ]
+                                                                                                                                    ]
+                                                                                                                                  ]
+                                                                                                                                ]
                                                                                                                               ]
                                                                                                                             ]
                                                                                                                           ]
@@ -371,33 +582,33 @@
                                                                                               (case
                                                                                                 datum-8
                                                                                                 (lam
-                                                                                                  ds-36
+                                                                                                  ds-39
                                                                                                   (lam
-                                                                                                    ds-37
+                                                                                                    ds-40
                                                                                                     (lam
-                                                                                                      ds-38
+                                                                                                      ds-41
                                                                                                       (lam
-                                                                                                        ds-39
+                                                                                                        ds-42
                                                                                                         [
                                                                                                           (lam
-                                                                                                            ownScriptHash-40
+                                                                                                            ownScriptHash-43
                                                                                                             [
                                                                                                               (lam
-                                                                                                                payerHash-41
+                                                                                                                payerHash-44
                                                                                                                 [
                                                                                                                   (lam
-                                                                                                                    nt-42
+                                                                                                                    nt-45
                                                                                                                     [
                                                                                                                       (lam
-                                                                                                                        nt-43
+                                                                                                                        nt-46
                                                                                                                         (force
                                                                                                                           (case
                                                                                                                             [
                                                                                                                               [
                                                                                                                                 txSignedBy-12
-                                                                                                                                nt-42
+                                                                                                                                nt-45
                                                                                                                               ]
-                                                                                                                              payerHash-41
+                                                                                                                              payerHash-44
                                                                                                                             ]
                                                                                                                             (delay
                                                                                                                               (force
@@ -415,16 +626,16 @@
                                                                                                                                             (builtin
                                                                                                                                               lessThanEqualsInteger
                                                                                                                                             )
-                                                                                                                                            nt-43
+                                                                                                                                            nt-46
                                                                                                                                           ]
-                                                                                                                                          ds-39
+                                                                                                                                          ds-42
                                                                                                                                         ]
                                                                                                                                       ]
                                                                                                                                       (delay
                                                                                                                                         (delay
                                                                                                                                           [
                                                                                                                                             (lam
-                                                                                                                                              x-44
+                                                                                                                                              x-47
                                                                                                                                               (error
 
                                                                                                                                               )
@@ -474,9 +685,9 @@
                                                                                                                                                     [
                                                                                                                                                       [
                                                                                                                                                         countScriptInputs-21
-                                                                                                                                                        nt-42
+                                                                                                                                                        nt-45
                                                                                                                                                       ]
-                                                                                                                                                      ownScriptHash-40
+                                                                                                                                                      ownScriptHash-43
                                                                                                                                                     ]
                                                                                                                                                   ]
                                                                                                                                                 ]
@@ -493,7 +704,7 @@
                                                                                                                                                 (delay
                                                                                                                                                   [
                                                                                                                                                     (lam
-                                                                                                                                                      x-45
+                                                                                                                                                      x-48
                                                                                                                                                       (error
 
                                                                                                                                                       )
@@ -529,7 +740,7 @@
                                                                                                                             (delay
                                                                                                                               [
                                                                                                                                 (lam
-                                                                                                                                  x-46
+                                                                                                                                  x-49
                                                                                                                                   (error
 
                                                                                                                                   )
@@ -556,16 +767,220 @@
                                                                                                                         )
                                                                                                                       )
                                                                                                                       [
-                                                                                                                        lowerBoundTime-19
-                                                                                                                        [
+                                                                                                                        (lam
+                                                                                                                          l-50
                                                                                                                           [
+                                                                                                                            (lam
+                                                                                                                              tup-51
+                                                                                                                              (force
+                                                                                                                                (force
+                                                                                                                                  [
+                                                                                                                                    [
+                                                                                                                                      [
+                                                                                                                                        (force
+                                                                                                                                          (builtin
+                                                                                                                                            ifThenElse
+                                                                                                                                          )
+                                                                                                                                        )
+                                                                                                                                        [
+                                                                                                                                          [
+                                                                                                                                            (builtin
+                                                                                                                                              equalsInteger
+                                                                                                                                            )
+                                                                                                                                            (con
+                                                                                                                                              integer
+                                                                                                                                              1
+                                                                                                                                            )
+                                                                                                                                          ]
+                                                                                                                                          [
+                                                                                                                                            (force
+                                                                                                                                              (force
+                                                                                                                                                (builtin
+                                                                                                                                                  fstPair
+                                                                                                                                                )
+                                                                                                                                              )
+                                                                                                                                            )
+                                                                                                                                            tup-51
+                                                                                                                                          ]
+                                                                                                                                        ]
+                                                                                                                                      ]
+                                                                                                                                      (delay
+                                                                                                                                        (delay
+                                                                                                                                          (force
+                                                                                                                                            (case
+                                                                                                                                              [
+                                                                                                                                                `$fUnsafeFromDataBool_$cunsafeFromBuiltinData`-19
+                                                                                                                                                [
+                                                                                                                                                  (force
+                                                                                                                                                    (builtin
+                                                                                                                                                      headList
+                                                                                                                                                    )
+                                                                                                                                                  )
+                                                                                                                                                  [
+                                                                                                                                                    (force
+                                                                                                                                                      (builtin
+                                                                                                                                                        tailList
+                                                                                                                                                      )
+                                                                                                                                                    )
+                                                                                                                                                    l-50
+                                                                                                                                                  ]
+                                                                                                                                                ]
+                                                                                                                                              ]
+                                                                                                                                              (delay
+                                                                                                                                                [
+                                                                                                                                                  (builtin
+                                                                                                                                                    unIData
+                                                                                                                                                  )
+                                                                                                                                                  [
+                                                                                                                                                    (force
+                                                                                                                                                      (builtin
+                                                                                                                                                        headList
+                                                                                                                                                      )
+                                                                                                                                                    )
+                                                                                                                                                    [
+                                                                                                                                                      (force
+                                                                                                                                                        (force
+                                                                                                                                                          (builtin
+                                                                                                                                                            sndPair
+                                                                                                                                                          )
+                                                                                                                                                        )
+                                                                                                                                                      )
+                                                                                                                                                      tup-51
+                                                                                                                                                    ]
+                                                                                                                                                  ]
+                                                                                                                                                ]
+                                                                                                                                              )
+                                                                                                                                              (delay
+                                                                                                                                                [
+                                                                                                                                                  [
+                                                                                                                                                    (builtin
+                                                                                                                                                      addInteger
+                                                                                                                                                    )
+                                                                                                                                                    (con
+                                                                                                                                                      integer
+                                                                                                                                                      1
+                                                                                                                                                    )
+                                                                                                                                                  ]
+                                                                                                                                                  [
+                                                                                                                                                    (builtin
+                                                                                                                                                      unIData
+                                                                                                                                                    )
+                                                                                                                                                    [
+                                                                                                                                                      (force
+                                                                                                                                                        (builtin
+                                                                                                                                                          headList
+                                                                                                                                                        )
+                                                                                                                                                      )
+                                                                                                                                                      [
+                                                                                                                                                        (force
+                                                                                                                                                          (force
+                                                                                                                                                            (builtin
+                                                                                                                                                              sndPair
+                                                                                                                                                            )
+                                                                                                                                                          )
+                                                                                                                                                        )
+                                                                                                                                                        tup-51
+                                                                                                                                                      ]
+                                                                                                                                                    ]
+                                                                                                                                                  ]
+                                                                                                                                                ]
+                                                                                                                                              )
+                                                                                                                                            )
+                                                                                                                                          )
+                                                                                                                                        )
+                                                                                                                                      )
+                                                                                                                                    ]
+                                                                                                                                    (delay
+                                                                                                                                      (delay
+                                                                                                                                        [
+                                                                                                                                          (lam
+                                                                                                                                            x-52
+                                                                                                                                            (error
+
+                                                                                                                                            )
+                                                                                                                                          )
+                                                                                                                                          [
+                                                                                                                                            [
+                                                                                                                                              (force
+                                                                                                                                                (builtin
+                                                                                                                                                  trace
+                                                                                                                                                )
+                                                                                                                                              )
+                                                                                                                                              (con
+                                                                                                                                                string
+                                                                                                                                                "Lower bound of valid range must be finite"
+                                                                                                                                              )
+                                                                                                                                            ]
+                                                                                                                                            (constr
+                                                                                                                                              0
+                                                                                                                                            )
+                                                                                                                                          ]
+                                                                                                                                        ]
+                                                                                                                                      )
+                                                                                                                                    )
+                                                                                                                                  ]
+                                                                                                                                )
+                                                                                                                              )
+                                                                                                                            )
                                                                                                                             [
-                                                                                                                              `$mTxInfo`-11
-                                                                                                                              nt-42
+                                                                                                                              (builtin
+                                                                                                                                unConstrData
+                                                                                                                              )
+                                                                                                                              [
+                                                                                                                                (force
+                                                                                                                                  (builtin
+                                                                                                                                    headList
+                                                                                                                                  )
+                                                                                                                                )
+                                                                                                                                l-50
+                                                                                                                              ]
                                                                                                                             ]
-                                                                                                                            txInfoValidRange-13
                                                                                                                           ]
-                                                                                                                          txInfoValidRange-14
+                                                                                                                        )
+                                                                                                                        [
+                                                                                                                          (force
+                                                                                                                            (force
+                                                                                                                              (builtin
+                                                                                                                                sndPair
+                                                                                                                              )
+                                                                                                                            )
+                                                                                                                          )
+                                                                                                                          [
+                                                                                                                            (builtin
+                                                                                                                              unConstrData
+                                                                                                                            )
+                                                                                                                            [
+                                                                                                                              (force
+                                                                                                                                (builtin
+                                                                                                                                  headList
+                                                                                                                                )
+                                                                                                                              )
+                                                                                                                              [
+                                                                                                                                (force
+                                                                                                                                  (force
+                                                                                                                                    (builtin
+                                                                                                                                      sndPair
+                                                                                                                                    )
+                                                                                                                                  )
+                                                                                                                                )
+                                                                                                                                [
+                                                                                                                                  (builtin
+                                                                                                                                    unConstrData
+                                                                                                                                  )
+                                                                                                                                  [
+                                                                                                                                    [
+                                                                                                                                      [
+                                                                                                                                        `$mTxInfo`-11
+                                                                                                                                        nt-45
+                                                                                                                                      ]
+                                                                                                                                      txInfoValidRange-13
+                                                                                                                                    ]
+                                                                                                                                    txInfoValidRange-14
+                                                                                                                                  ]
+                                                                                                                                ]
+                                                                                                                              ]
+                                                                                                                            ]
+                                                                                                                          ]
                                                                                                                         ]
                                                                                                                       ]
                                                                                                                     ]
@@ -581,7 +996,7 @@
                                                                                                               )
                                                                                                               [
                                                                                                                 extractPubKeyHash-20
-                                                                                                                ds-36
+                                                                                                                ds-39
                                                                                                               ]
                                                                                                             ]
                                                                                                           )
@@ -599,42 +1014,42 @@
                                                                                           )
                                                                                         )
                                                                                         (lam
-                                                                                          txInfo-47
+                                                                                          txInfo-53
                                                                                           (lam
-                                                                                            scriptHash-48
+                                                                                            scriptHash-54
                                                                                             [
                                                                                               [
                                                                                                 [
                                                                                                   (lam
-                                                                                                    s-49
+                                                                                                    s-55
                                                                                                     [
-                                                                                                      s-49
-                                                                                                      s-49
+                                                                                                      s-55
+                                                                                                      s-55
                                                                                                     ]
                                                                                                   )
                                                                                                   (lam
-                                                                                                    s-50
+                                                                                                    s-56
                                                                                                     (lam
-                                                                                                      acc-51
+                                                                                                      acc-57
                                                                                                       [
                                                                                                         [
                                                                                                           caseList'-9
-                                                                                                          acc-51
+                                                                                                          acc-57
                                                                                                         ]
                                                                                                         (lam
-                                                                                                          h-52
+                                                                                                          h-58
                                                                                                           (lam
-                                                                                                            t-53
+                                                                                                            t-59
                                                                                                             [
                                                                                                               [
                                                                                                                 (lam
-                                                                                                                  x-54
+                                                                                                                  x-60
                                                                                                                   [
                                                                                                                     [
-                                                                                                                      s-50
-                                                                                                                      s-50
+                                                                                                                      s-56
+                                                                                                                      s-56
                                                                                                                     ]
-                                                                                                                    x-54
+                                                                                                                    x-60
                                                                                                                   ]
                                                                                                                 )
                                                                                                                 [
@@ -665,23 +1080,23 @@
                                                                                                                               (builtin
                                                                                                                                 unConstrData
                                                                                                                               )
-                                                                                                                              h-52
+                                                                                                                              h-58
                                                                                                                             ]
                                                                                                                           ]
                                                                                                                         ]
                                                                                                                       ]
                                                                                                                     ]
                                                                                                                     (lam
-                                                                                                                      ds-55
+                                                                                                                      ds-61
                                                                                                                       (lam
-                                                                                                                        ds-56
+                                                                                                                        ds-62
                                                                                                                         (lam
-                                                                                                                          ds-57
+                                                                                                                          ds-63
                                                                                                                           (lam
-                                                                                                                            ds-58
+                                                                                                                            ds-64
                                                                                                                             [
                                                                                                                               (lam
-                                                                                                                                tup-59
+                                                                                                                                tup-65
                                                                                                                                 (force
                                                                                                                                   (force
                                                                                                                                     [
@@ -710,7 +1125,7 @@
                                                                                                                                                   )
                                                                                                                                                 )
                                                                                                                                               )
-                                                                                                                                              tup-59
+                                                                                                                                              tup-65
                                                                                                                                             ]
                                                                                                                                           ]
                                                                                                                                         ]
@@ -749,12 +1164,12 @@
                                                                                                                                                                     )
                                                                                                                                                                   )
                                                                                                                                                                 )
-                                                                                                                                                                tup-59
+                                                                                                                                                                tup-65
                                                                                                                                                               ]
                                                                                                                                                             ]
                                                                                                                                                           ]
                                                                                                                                                         ]
-                                                                                                                                                        scriptHash-48
+                                                                                                                                                        scriptHash-54
                                                                                                                                                       ]
                                                                                                                                                     ]
                                                                                                                                                     (delay
@@ -769,14 +1184,14 @@
                                                                                                                                                               1
                                                                                                                                                             )
                                                                                                                                                           ]
-                                                                                                                                                          acc-51
+                                                                                                                                                          acc-57
                                                                                                                                                         ]
                                                                                                                                                       )
                                                                                                                                                     )
                                                                                                                                                   ]
                                                                                                                                                   (delay
                                                                                                                                                     (delay
-                                                                                                                                                      acc-51
+                                                                                                                                                      acc-57
                                                                                                                                                     )
                                                                                                                                                   )
                                                                                                                                                 ]
@@ -787,7 +1202,7 @@
                                                                                                                                       ]
                                                                                                                                       (delay
                                                                                                                                         (delay
-                                                                                                                                          acc-51
+                                                                                                                                          acc-57
                                                                                                                                         )
                                                                                                                                       )
                                                                                                                                     ]
@@ -816,7 +1231,7 @@
                                                                                                                                       (builtin
                                                                                                                                         unConstrData
                                                                                                                                       )
-                                                                                                                                      ds-55
+                                                                                                                                      ds-61
                                                                                                                                     ]
                                                                                                                                   ]
                                                                                                                                 ]
@@ -828,7 +1243,7 @@
                                                                                                                     )
                                                                                                                   ]
                                                                                                                   (lam
-                                                                                                                    void-60
+                                                                                                                    void-66
                                                                                                                     (case
                                                                                                                       (error
 
@@ -840,7 +1255,7 @@
                                                                                                                   )
                                                                                                                 ]
                                                                                                               ]
-                                                                                                              t-53
+                                                                                                              t-59
                                                                                                             ]
                                                                                                           )
                                                                                                         )
@@ -857,41 +1272,41 @@
                                                                                                 [
                                                                                                   [
                                                                                                     `$mTxInfo`-11
-                                                                                                    txInfo-47
+                                                                                                    txInfo-53
                                                                                                   ]
                                                                                                   (lam
-                                                                                                    ds-61
+                                                                                                    ds-67
                                                                                                     (lam
-                                                                                                      ds-62
+                                                                                                      ds-68
                                                                                                       (lam
-                                                                                                        ds-63
+                                                                                                        ds-69
                                                                                                         (lam
-                                                                                                          ds-64
+                                                                                                          ds-70
                                                                                                           (lam
-                                                                                                            ds-65
+                                                                                                            ds-71
                                                                                                             (lam
-                                                                                                              ds-66
+                                                                                                              ds-72
                                                                                                               (lam
-                                                                                                                ds-67
+                                                                                                                ds-73
                                                                                                                 (lam
-                                                                                                                  ds-68
+                                                                                                                  ds-74
                                                                                                                   (lam
-                                                                                                                    ds-69
+                                                                                                                    ds-75
                                                                                                                     (lam
-                                                                                                                      ds-70
+                                                                                                                      ds-76
                                                                                                                       (lam
-                                                                                                                        ds-71
+                                                                                                                        ds-77
                                                                                                                         (lam
-                                                                                                                          ds-72
+                                                                                                                          ds-78
                                                                                                                           (lam
-                                                                                                                            ds-73
+                                                                                                                            ds-79
                                                                                                                             (lam
-                                                                                                                              ds-74
+                                                                                                                              ds-80
                                                                                                                               (lam
-                                                                                                                                ds-75
+                                                                                                                                ds-81
                                                                                                                                 (lam
-                                                                                                                                  ds-76
-                                                                                                                                  ds-61
+                                                                                                                                  ds-82
+                                                                                                                                  ds-67
                                                                                                                                 )
                                                                                                                               )
                                                                                                                             )
@@ -910,7 +1325,7 @@
                                                                                                   )
                                                                                                 ]
                                                                                                 (lam
-                                                                                                  void-77
+                                                                                                  void-83
                                                                                                   (error
 
                                                                                                   )
@@ -922,10 +1337,10 @@
                                                                                       ]
                                                                                     )
                                                                                     (lam
-                                                                                      ds-78
+                                                                                      ds-84
                                                                                       [
                                                                                         (lam
-                                                                                          tup-79
+                                                                                          tup-85
                                                                                           (force
                                                                                             (force
                                                                                               [
@@ -954,7 +1369,7 @@
                                                                                                             )
                                                                                                           )
                                                                                                         )
-                                                                                                        tup-79
+                                                                                                        tup-85
                                                                                                       ]
                                                                                                     ]
                                                                                                   ]
@@ -978,7 +1393,7 @@
                                                                                                                 )
                                                                                                               )
                                                                                                             )
-                                                                                                            tup-79
+                                                                                                            tup-85
                                                                                                           ]
                                                                                                         ]
                                                                                                       ]
@@ -989,7 +1404,7 @@
                                                                                                   (delay
                                                                                                     [
                                                                                                       (lam
-                                                                                                        x-80
+                                                                                                        x-86
                                                                                                         (error
 
                                                                                                         )
@@ -1039,7 +1454,7 @@
                                                                                                 (builtin
                                                                                                   unConstrData
                                                                                                 )
-                                                                                                ds-78
+                                                                                                ds-84
                                                                                               ]
                                                                                             ]
                                                                                           ]
@@ -1049,402 +1464,198 @@
                                                                                   ]
                                                                                 )
                                                                                 (lam
-                                                                                  ds-81
+                                                                                  d-87
                                                                                   [
                                                                                     (lam
-                                                                                      l-82
+                                                                                      tup-88
                                                                                       [
                                                                                         (lam
-                                                                                          tup-83
-                                                                                          (force
-                                                                                            (force
-                                                                                              [
-                                                                                                [
+                                                                                          index-89
+                                                                                          [
+                                                                                            (lam
+                                                                                              args-90
+                                                                                              (force
+                                                                                                (force
                                                                                                   [
-                                                                                                    (force
-                                                                                                      (builtin
-                                                                                                        ifThenElse
-                                                                                                      )
-                                                                                                    )
                                                                                                     [
-                                                                                                      [
-                                                                                                        (builtin
-                                                                                                          equalsInteger
-                                                                                                        )
-                                                                                                        (con
-                                                                                                          integer
-                                                                                                          1
-                                                                                                        )
-                                                                                                      ]
                                                                                                       [
                                                                                                         (force
-                                                                                                          (force
-                                                                                                            (builtin
-                                                                                                              fstPair
-                                                                                                            )
+                                                                                                          (builtin
+                                                                                                            ifThenElse
                                                                                                           )
                                                                                                         )
-                                                                                                        tup-83
-                                                                                                      ]
-                                                                                                    ]
-                                                                                                  ]
-                                                                                                  (delay
-                                                                                                    (delay
-                                                                                                      (force
-                                                                                                        (case
+                                                                                                        [
                                                                                                           [
-                                                                                                            (lam
-                                                                                                              tup-84
-                                                                                                              [
-                                                                                                                (lam
-                                                                                                                  index-85
-                                                                                                                  [
-                                                                                                                    (lam
-                                                                                                                      args-86
-                                                                                                                      (force
-                                                                                                                        (force
-                                                                                                                          [
-                                                                                                                            [
-                                                                                                                              [
-                                                                                                                                (force
-                                                                                                                                  (builtin
-                                                                                                                                    ifThenElse
-                                                                                                                                  )
-                                                                                                                                )
-                                                                                                                                [
-                                                                                                                                  [
-                                                                                                                                    (builtin
-                                                                                                                                      equalsInteger
-                                                                                                                                    )
-                                                                                                                                    (con
-                                                                                                                                      integer
-                                                                                                                                      0
-                                                                                                                                    )
-                                                                                                                                  ]
-                                                                                                                                  index-85
-                                                                                                                                ]
-                                                                                                                              ]
-                                                                                                                              (delay
-                                                                                                                                (delay
-                                                                                                                                  (constr
-                                                                                                                                    1
-                                                                                                                                  )
-                                                                                                                                )
-                                                                                                                              )
-                                                                                                                            ]
-                                                                                                                            (delay
-                                                                                                                              (delay
-                                                                                                                                (force
-                                                                                                                                  (force
-                                                                                                                                    [
-                                                                                                                                      [
-                                                                                                                                        [
-                                                                                                                                          (force
-                                                                                                                                            (builtin
-                                                                                                                                              ifThenElse
-                                                                                                                                            )
-                                                                                                                                          )
-                                                                                                                                          [
-                                                                                                                                            [
-                                                                                                                                              (builtin
-                                                                                                                                                equalsInteger
-                                                                                                                                              )
-                                                                                                                                              (con
-                                                                                                                                                integer
-                                                                                                                                                1
-                                                                                                                                              )
-                                                                                                                                            ]
-                                                                                                                                            index-85
-                                                                                                                                          ]
-                                                                                                                                        ]
-                                                                                                                                        (delay
-                                                                                                                                          (delay
-                                                                                                                                            (constr
-                                                                                                                                              0
-                                                                                                                                            )
-                                                                                                                                          )
-                                                                                                                                        )
-                                                                                                                                      ]
-                                                                                                                                      (delay
-                                                                                                                                        (delay
-                                                                                                                                          [
-                                                                                                                                            traceError-2
-                                                                                                                                            (con
-                                                                                                                                              string
-                                                                                                                                              "PT1"
-                                                                                                                                            )
-                                                                                                                                          ]
-                                                                                                                                        )
-                                                                                                                                      )
-                                                                                                                                    ]
-                                                                                                                                  )
-                                                                                                                                )
-                                                                                                                              )
-                                                                                                                            )
-                                                                                                                          ]
-                                                                                                                        )
-                                                                                                                      )
-                                                                                                                    )
-                                                                                                                    [
-                                                                                                                      (force
-                                                                                                                        (force
-                                                                                                                          (builtin
-                                                                                                                            sndPair
-                                                                                                                          )
-                                                                                                                        )
-                                                                                                                      )
-                                                                                                                      tup-84
-                                                                                                                    ]
-                                                                                                                  ]
-                                                                                                                )
-                                                                                                                [
-                                                                                                                  (force
-                                                                                                                    (force
-                                                                                                                      (builtin
-                                                                                                                        fstPair
-                                                                                                                      )
-                                                                                                                    )
-                                                                                                                  )
-                                                                                                                  tup-84
-                                                                                                                ]
-                                                                                                              ]
+                                                                                                            (builtin
+                                                                                                              equalsInteger
                                                                                                             )
-                                                                                                            [
-                                                                                                              (builtin
-                                                                                                                unConstrData
-                                                                                                              )
-                                                                                                              [
-                                                                                                                (force
-                                                                                                                  (builtin
-                                                                                                                    headList
-                                                                                                                  )
-                                                                                                                )
-                                                                                                                [
-                                                                                                                  (force
-                                                                                                                    (builtin
-                                                                                                                      tailList
-                                                                                                                    )
-                                                                                                                  )
-                                                                                                                  l-82
-                                                                                                                ]
-                                                                                                              ]
-                                                                                                            ]
+                                                                                                            (con
+                                                                                                              integer
+                                                                                                              0
+                                                                                                            )
                                                                                                           ]
-                                                                                                          (delay
-                                                                                                            [
-                                                                                                              (builtin
-                                                                                                                unIData
-                                                                                                              )
-                                                                                                              [
-                                                                                                                (force
-                                                                                                                  (builtin
-                                                                                                                    headList
-                                                                                                                  )
-                                                                                                                )
-                                                                                                                [
-                                                                                                                  (force
-                                                                                                                    (force
-                                                                                                                      (builtin
-                                                                                                                        sndPair
-                                                                                                                      )
-                                                                                                                    )
-                                                                                                                  )
-                                                                                                                  tup-83
-                                                                                                                ]
-                                                                                                              ]
-                                                                                                            ]
+                                                                                                          index-89
+                                                                                                        ]
+                                                                                                      ]
+                                                                                                      (delay
+                                                                                                        (delay
+                                                                                                          (constr
+                                                                                                            1
                                                                                                           )
-                                                                                                          (delay
+                                                                                                        )
+                                                                                                      )
+                                                                                                    ]
+                                                                                                    (delay
+                                                                                                      (delay
+                                                                                                        (force
+                                                                                                          (force
                                                                                                             [
                                                                                                               [
-                                                                                                                (builtin
-                                                                                                                  addInteger
-                                                                                                                )
-                                                                                                                (con
-                                                                                                                  integer
-                                                                                                                  1
-                                                                                                                )
-                                                                                                              ]
-                                                                                                              [
-                                                                                                                (builtin
-                                                                                                                  unIData
-                                                                                                                )
                                                                                                                 [
                                                                                                                   (force
                                                                                                                     (builtin
-                                                                                                                      headList
+                                                                                                                      ifThenElse
                                                                                                                     )
                                                                                                                   )
                                                                                                                   [
-                                                                                                                    (force
-                                                                                                                      (force
-                                                                                                                        (builtin
-                                                                                                                          sndPair
-                                                                                                                        )
+                                                                                                                    [
+                                                                                                                      (builtin
+                                                                                                                        equalsInteger
                                                                                                                       )
-                                                                                                                    )
-                                                                                                                    tup-83
+                                                                                                                      (con
+                                                                                                                        integer
+                                                                                                                        1
+                                                                                                                      )
+                                                                                                                    ]
+                                                                                                                    index-89
                                                                                                                   ]
                                                                                                                 ]
+                                                                                                                (delay
+                                                                                                                  (delay
+                                                                                                                    (constr
+                                                                                                                      0
+                                                                                                                    )
+                                                                                                                  )
+                                                                                                                )
                                                                                                               ]
+                                                                                                              (delay
+                                                                                                                (delay
+                                                                                                                  [
+                                                                                                                    traceError-2
+                                                                                                                    (con
+                                                                                                                      string
+                                                                                                                      "PT1"
+                                                                                                                    )
+                                                                                                                  ]
+                                                                                                                )
+                                                                                                              )
                                                                                                             ]
                                                                                                           )
                                                                                                         )
                                                                                                       )
                                                                                                     )
-                                                                                                  )
-                                                                                                ]
-                                                                                                (delay
-                                                                                                  (delay
-                                                                                                    [
-                                                                                                      (lam
-                                                                                                        x-87
-                                                                                                        (error
-
-                                                                                                        )
-                                                                                                      )
-                                                                                                      [
-                                                                                                        [
-                                                                                                          (force
-                                                                                                            (builtin
-                                                                                                              trace
-                                                                                                            )
-                                                                                                          )
-                                                                                                          (con
-                                                                                                            string
-                                                                                                            "Time range not Finite"
-                                                                                                          )
-                                                                                                        ]
-                                                                                                        (constr
-                                                                                                          0
-                                                                                                        )
-                                                                                                      ]
-                                                                                                    ]
-                                                                                                  )
-                                                                                                )
-                                                                                              ]
-                                                                                            )
-                                                                                          )
-                                                                                        )
-                                                                                        [
-                                                                                          (builtin
-                                                                                            unConstrData
-                                                                                          )
-                                                                                          [
-                                                                                            (force
-                                                                                              (builtin
-                                                                                                headList
-                                                                                              )
-                                                                                            )
-                                                                                            l-82
-                                                                                          ]
-                                                                                        ]
-                                                                                      ]
-                                                                                    )
-                                                                                    [
-                                                                                      (force
-                                                                                        (force
-                                                                                          (builtin
-                                                                                            sndPair
-                                                                                          )
-                                                                                        )
-                                                                                      )
-                                                                                      [
-                                                                                        (builtin
-                                                                                          unConstrData
-                                                                                        )
-                                                                                        [
-                                                                                          (force
-                                                                                            (builtin
-                                                                                              headList
-                                                                                            )
-                                                                                          )
-                                                                                          [
-                                                                                            (force
-                                                                                              (force
-                                                                                                (builtin
-                                                                                                  sndPair
+                                                                                                  ]
                                                                                                 )
                                                                                               )
                                                                                             )
                                                                                             [
-                                                                                              (builtin
-                                                                                                unConstrData
+                                                                                              (force
+                                                                                                (force
+                                                                                                  (builtin
+                                                                                                    sndPair
+                                                                                                  )
+                                                                                                )
                                                                                               )
-                                                                                              ds-81
+                                                                                              tup-88
                                                                                             ]
                                                                                           ]
+                                                                                        )
+                                                                                        [
+                                                                                          (force
+                                                                                            (force
+                                                                                              (builtin
+                                                                                                fstPair
+                                                                                              )
+                                                                                            )
+                                                                                          )
+                                                                                          tup-88
                                                                                         ]
                                                                                       ]
+                                                                                    )
+                                                                                    [
+                                                                                      (builtin
+                                                                                        unConstrData
+                                                                                      )
+                                                                                      d-87
                                                                                     ]
                                                                                   ]
                                                                                 )
                                                                               ]
                                                                             )
                                                                             (lam
-                                                                              ctx-88
+                                                                              ctx-91
                                                                               (force
                                                                                 (case
                                                                                   [
                                                                                     [
                                                                                       [
                                                                                         `$mScriptContext`-1
-                                                                                        ctx-88
+                                                                                        ctx-91
                                                                                       ]
                                                                                       (lam
-                                                                                        ds-89
+                                                                                        ds-92
                                                                                         (lam
-                                                                                          ds-90
+                                                                                          ds-93
                                                                                           (lam
-                                                                                            ds-91
+                                                                                            ds-94
                                                                                             [
                                                                                               [
                                                                                                 [
                                                                                                   `$mTxInfo`-11
-                                                                                                  ds-89
+                                                                                                  ds-92
                                                                                                 ]
                                                                                                 (lam
-                                                                                                  ds-92
+                                                                                                  ds-95
                                                                                                   (lam
-                                                                                                    ds-93
+                                                                                                    ds-96
                                                                                                     (lam
-                                                                                                      ds-94
+                                                                                                      ds-97
                                                                                                       (lam
-                                                                                                        ds-95
+                                                                                                        ds-98
                                                                                                         (lam
-                                                                                                          ds-96
+                                                                                                          ds-99
                                                                                                           (lam
-                                                                                                            ds-97
+                                                                                                            ds-100
                                                                                                             (lam
-                                                                                                              ds-98
+                                                                                                              ds-101
                                                                                                               (lam
-                                                                                                                ds-99
+                                                                                                                ds-102
                                                                                                                 (lam
-                                                                                                                  ds-100
+                                                                                                                  ds-103
                                                                                                                   (lam
-                                                                                                                    ds-101
+                                                                                                                    ds-104
                                                                                                                     (lam
-                                                                                                                      ds-102
+                                                                                                                      ds-105
                                                                                                                       (lam
-                                                                                                                        ds-103
+                                                                                                                        ds-106
                                                                                                                         (lam
-                                                                                                                          ds-104
+                                                                                                                          ds-107
                                                                                                                           (lam
-                                                                                                                            ds-105
+                                                                                                                            ds-108
                                                                                                                             (lam
-                                                                                                                              ds-106
+                                                                                                                              ds-109
                                                                                                                               (lam
-                                                                                                                                ds-107
+                                                                                                                                ds-110
                                                                                                                                 [
                                                                                                                                   [
                                                                                                                                     [
                                                                                                                                       `$mSpendingScript`-7
-                                                                                                                                      ds-91
+                                                                                                                                      ds-94
                                                                                                                                     ]
                                                                                                                                     (lam
-                                                                                                                                      txOutRef-108
+                                                                                                                                      txOutRef-111
                                                                                                                                       (lam
-                                                                                                                                        ds-109
+                                                                                                                                        ds-112
                                                                                                                                         [
                                                                                                                                           [
                                                                                                                                             [
@@ -1452,10 +1663,10 @@
                                                                                                                                               `$fUnsafeFromDataBuiltinData_$cunsafeFromBuiltinData`-5
                                                                                                                                             ]
                                                                                                                                             (lam
-                                                                                                                                              ds-110
+                                                                                                                                              ds-113
                                                                                                                                               [
                                                                                                                                                 (lam
-                                                                                                                                                  l-111
+                                                                                                                                                  l-114
                                                                                                                                                   (force
                                                                                                                                                     (force
                                                                                                                                                       [
@@ -1468,25 +1679,25 @@
                                                                                                                                                             )
                                                                                                                                                             [
                                                                                                                                                               (lam
-                                                                                                                                                                txOutRefId-112
+                                                                                                                                                                txOutRefId-115
                                                                                                                                                                 [
                                                                                                                                                                   [
                                                                                                                                                                     (builtin
                                                                                                                                                                       equalsByteString
                                                                                                                                                                     )
                                                                                                                                                                     [
-                                                                                                                                                                      txOutRefId-112
-                                                                                                                                                                      l-111
+                                                                                                                                                                      txOutRefId-115
+                                                                                                                                                                      l-114
                                                                                                                                                                     ]
                                                                                                                                                                   ]
                                                                                                                                                                   [
-                                                                                                                                                                    txOutRefId-112
-                                                                                                                                                                    txOutRef-108
+                                                                                                                                                                    txOutRefId-115
+                                                                                                                                                                    txOutRef-111
                                                                                                                                                                   ]
                                                                                                                                                                 ]
                                                                                                                                                               )
                                                                                                                                                               (lam
-                                                                                                                                                                ds-113
+                                                                                                                                                                ds-116
                                                                                                                                                                 [
                                                                                                                                                                   (builtin
                                                                                                                                                                     unBData
@@ -1509,7 +1720,7 @@
                                                                                                                                                                         (builtin
                                                                                                                                                                           unConstrData
                                                                                                                                                                         )
-                                                                                                                                                                        ds-113
+                                                                                                                                                                        ds-116
                                                                                                                                                                       ]
                                                                                                                                                                     ]
                                                                                                                                                                   ]
@@ -1529,25 +1740,25 @@
                                                                                                                                                                     )
                                                                                                                                                                     [
                                                                                                                                                                       (lam
-                                                                                                                                                                        txOutRefIdx-114
+                                                                                                                                                                        txOutRefIdx-117
                                                                                                                                                                         [
                                                                                                                                                                           [
                                                                                                                                                                             (builtin
                                                                                                                                                                               equalsInteger
                                                                                                                                                                             )
                                                                                                                                                                             [
-                                                                                                                                                                              txOutRefIdx-114
-                                                                                                                                                                              l-111
+                                                                                                                                                                              txOutRefIdx-117
+                                                                                                                                                                              l-114
                                                                                                                                                                             ]
                                                                                                                                                                           ]
                                                                                                                                                                           [
-                                                                                                                                                                            txOutRefIdx-114
-                                                                                                                                                                            txOutRef-108
+                                                                                                                                                                            txOutRefIdx-117
+                                                                                                                                                                            txOutRef-111
                                                                                                                                                                           ]
                                                                                                                                                                         ]
                                                                                                                                                                       )
                                                                                                                                                                       (lam
-                                                                                                                                                                        ds-115
+                                                                                                                                                                        ds-118
                                                                                                                                                                         [
                                                                                                                                                                           (builtin
                                                                                                                                                                             unIData
@@ -1576,7 +1787,7 @@
                                                                                                                                                                                   (builtin
                                                                                                                                                                                     unConstrData
                                                                                                                                                                                   )
-                                                                                                                                                                                  ds-115
+                                                                                                                                                                                  ds-118
                                                                                                                                                                                 ]
                                                                                                                                                                               ]
                                                                                                                                                                             ]
@@ -1625,20 +1836,20 @@
                                                                                                                                                       (builtin
                                                                                                                                                         unConstrData
                                                                                                                                                       )
-                                                                                                                                                      ds-110
+                                                                                                                                                      ds-113
                                                                                                                                                     ]
                                                                                                                                                   ]
                                                                                                                                                 ]
                                                                                                                                               ]
                                                                                                                                             )
                                                                                                                                           ]
-                                                                                                                                          ds-92
+                                                                                                                                          ds-95
                                                                                                                                         ]
                                                                                                                                       )
                                                                                                                                     )
                                                                                                                                   ]
                                                                                                                                   (lam
-                                                                                                                                    void-116
+                                                                                                                                    void-119
                                                                                                                                     (constr
                                                                                                                                       1
                                                                                                                                     )
@@ -1662,7 +1873,7 @@
                                                                                                 )
                                                                                               ]
                                                                                               (lam
-                                                                                                void-117
+                                                                                                void-120
                                                                                                 (constr
                                                                                                   1
                                                                                                 )
@@ -1673,14 +1884,14 @@
                                                                                       )
                                                                                     ]
                                                                                     (lam
-                                                                                      void-118
+                                                                                      void-121
                                                                                       (constr
                                                                                         1
                                                                                       )
                                                                                     )
                                                                                   ]
                                                                                   (lam
-                                                                                    ds-119
+                                                                                    ds-122
                                                                                     (delay
                                                                                       [
                                                                                         [
@@ -1710,23 +1921,23 @@
                                                                                                     (builtin
                                                                                                       unConstrData
                                                                                                     )
-                                                                                                    ds-119
+                                                                                                    ds-122
                                                                                                   ]
                                                                                                 ]
                                                                                               ]
                                                                                             ]
                                                                                           ]
                                                                                           (lam
-                                                                                            ds-120
+                                                                                            ds-123
                                                                                             (lam
-                                                                                              ds-121
+                                                                                              ds-124
                                                                                               (lam
-                                                                                                ds-122
+                                                                                                ds-125
                                                                                                 (lam
-                                                                                                  ds-123
+                                                                                                  ds-126
                                                                                                   [
                                                                                                     (lam
-                                                                                                      tup-124
+                                                                                                      tup-127
                                                                                                       (force
                                                                                                         (force
                                                                                                           [
@@ -1755,7 +1966,7 @@
                                                                                                                         )
                                                                                                                       )
                                                                                                                     )
-                                                                                                                    tup-124
+                                                                                                                    tup-127
                                                                                                                   ]
                                                                                                                 ]
                                                                                                               ]
@@ -1779,7 +1990,7 @@
                                                                                                                             )
                                                                                                                           )
                                                                                                                         )
-                                                                                                                        tup-124
+                                                                                                                        tup-127
                                                                                                                       ]
                                                                                                                     ]
                                                                                                                   ]
@@ -1790,7 +2001,7 @@
                                                                                                               (delay
                                                                                                                 [
                                                                                                                   (lam
-                                                                                                                    x-125
+                                                                                                                    x-128
                                                                                                                     (error
 
                                                                                                                     )
@@ -1840,7 +2051,7 @@
                                                                                                             (builtin
                                                                                                               unConstrData
                                                                                                             )
-                                                                                                            ds-120
+                                                                                                            ds-123
                                                                                                           ]
                                                                                                         ]
                                                                                                       ]
@@ -1852,7 +2063,7 @@
                                                                                           )
                                                                                         ]
                                                                                         (lam
-                                                                                          void-126
+                                                                                          void-129
                                                                                           (case
                                                                                             (error
 
@@ -1868,7 +2079,7 @@
                                                                                   (delay
                                                                                     [
                                                                                       (lam
-                                                                                        x-127
+                                                                                        x-130
                                                                                         (error
 
                                                                                         )
@@ -1897,32 +2108,32 @@
                                                                           ]
                                                                         )
                                                                         (lam
-                                                                          scrut-128
+                                                                          scrut-131
                                                                           (lam
-                                                                            cont-129
+                                                                            cont-132
                                                                             (lam
-                                                                              fail-130
+                                                                              fail-133
                                                                               [
                                                                                 (lam
-                                                                                  l-131
+                                                                                  l-134
                                                                                   [
                                                                                     (lam
-                                                                                      l-132
+                                                                                      l-135
                                                                                       [
                                                                                         (lam
-                                                                                          l-133
+                                                                                          l-136
                                                                                           [
                                                                                             [
                                                                                               [
                                                                                                 [
-                                                                                                  cont-129
+                                                                                                  cont-132
                                                                                                   [
                                                                                                     (force
                                                                                                       (builtin
                                                                                                         headList
                                                                                                       )
                                                                                                     )
-                                                                                                    l-131
+                                                                                                    l-134
                                                                                                   ]
                                                                                                 ]
                                                                                                 [
@@ -1935,7 +2146,7 @@
                                                                                                         headList
                                                                                                       )
                                                                                                     )
-                                                                                                    l-132
+                                                                                                    l-135
                                                                                                   ]
                                                                                                 ]
                                                                                               ]
@@ -1945,7 +2156,7 @@
                                                                                                     headList
                                                                                                   )
                                                                                                 )
-                                                                                                l-133
+                                                                                                l-136
                                                                                               ]
                                                                                             ]
                                                                                             [
@@ -1967,7 +2178,7 @@
                                                                                                       tailList
                                                                                                     )
                                                                                                   )
-                                                                                                  l-133
+                                                                                                  l-136
                                                                                                 ]
                                                                                               ]
                                                                                             ]
@@ -1979,7 +2190,7 @@
                                                                                               tailList
                                                                                             )
                                                                                           )
-                                                                                          l-132
+                                                                                          l-135
                                                                                         ]
                                                                                       ]
                                                                                     )
@@ -1989,7 +2200,7 @@
                                                                                           tailList
                                                                                         )
                                                                                       )
-                                                                                      l-131
+                                                                                      l-134
                                                                                     ]
                                                                                   ]
                                                                                 )
@@ -2005,7 +2216,7 @@
                                                                                     (builtin
                                                                                       unConstrData
                                                                                     )
-                                                                                    scrut-128
+                                                                                    scrut-131
                                                                                   ]
                                                                                 ]
                                                                               ]
@@ -2015,61 +2226,61 @@
                                                                       ]
                                                                     )
                                                                     (lam
-                                                                      void-134
+                                                                      void-137
                                                                       (error)
                                                                     )
                                                                   ]
                                                                 )
                                                                 (lam
-                                                                  ds-135
+                                                                  ds-138
                                                                   (lam
-                                                                    ds-136
+                                                                    ds-139
                                                                     (lam
-                                                                      ds-137
-                                                                      ds-135
+                                                                      ds-140
+                                                                      ds-138
                                                                     )
                                                                   )
                                                                 )
                                                               ]
                                                             )
                                                             (lam
-                                                              void-138 (error)
+                                                              void-141 (error)
                                                             )
                                                           ]
                                                         )
                                                         (lam
-                                                          ds-139
+                                                          ds-142
                                                           (lam
-                                                            ds-140
+                                                            ds-143
                                                             (lam
-                                                              ds-141
+                                                              ds-144
                                                               (lam
-                                                                ds-142
+                                                                ds-145
                                                                 (lam
-                                                                  ds-143
+                                                                  ds-146
                                                                   (lam
-                                                                    ds-144
+                                                                    ds-147
                                                                     (lam
-                                                                      ds-145
+                                                                      ds-148
                                                                       (lam
-                                                                        ds-146
+                                                                        ds-149
                                                                         (lam
-                                                                          ds-147
+                                                                          ds-150
                                                                           (lam
-                                                                            ds-148
+                                                                            ds-151
                                                                             (lam
-                                                                              ds-149
+                                                                              ds-152
                                                                               (lam
-                                                                                ds-150
+                                                                                ds-153
                                                                                 (lam
-                                                                                  ds-151
+                                                                                  ds-154
                                                                                   (lam
-                                                                                    ds-152
+                                                                                    ds-155
                                                                                     (lam
-                                                                                      ds-153
+                                                                                      ds-156
                                                                                       (lam
-                                                                                        ds-154
-                                                                                        ds-146
+                                                                                        ds-157
+                                                                                        ds-149
                                                                                       )
                                                                                     )
                                                                                   )
@@ -2089,47 +2300,47 @@
                                                       ]
                                                     )
                                                     (lam
-                                                      ds-155
+                                                      ds-158
                                                       (lam
-                                                        k-156
+                                                        k-159
                                                         [
                                                           [
                                                             [
                                                               `$mTxInfo`-11
-                                                              ds-155
+                                                              ds-158
                                                             ]
                                                             (lam
-                                                              ds-157
+                                                              ds-160
                                                               (lam
-                                                                ds-158
+                                                                ds-161
                                                                 (lam
-                                                                  ds-159
+                                                                  ds-162
                                                                   (lam
-                                                                    ds-160
+                                                                    ds-163
                                                                     (lam
-                                                                      ds-161
+                                                                      ds-164
                                                                       (lam
-                                                                        ds-162
+                                                                        ds-165
                                                                         (lam
-                                                                          ds-163
+                                                                          ds-166
                                                                           (lam
-                                                                            ds-164
+                                                                            ds-167
                                                                             (lam
-                                                                              ds-165
+                                                                              ds-168
                                                                               (lam
-                                                                                ds-166
+                                                                                ds-169
                                                                                 (lam
-                                                                                  ds-167
+                                                                                  ds-170
                                                                                   (lam
-                                                                                    ds-168
+                                                                                    ds-171
                                                                                     (lam
-                                                                                      ds-169
+                                                                                      ds-172
                                                                                       (lam
-                                                                                        ds-170
+                                                                                        ds-173
                                                                                         (lam
-                                                                                          ds-171
+                                                                                          ds-174
                                                                                           (lam
-                                                                                            ds-172
+                                                                                            ds-175
                                                                                             (force
                                                                                               (case
                                                                                                 [
@@ -2141,7 +2352,7 @@
                                                                                                       )
                                                                                                     ]
                                                                                                     (lam
-                                                                                                      y-173
+                                                                                                      y-176
                                                                                                       [
                                                                                                         [
                                                                                                           [
@@ -2155,9 +2366,9 @@
                                                                                                                 (builtin
                                                                                                                   equalsByteString
                                                                                                                 )
-                                                                                                                k-156
+                                                                                                                k-159
                                                                                                               ]
-                                                                                                              y-173
+                                                                                                              y-176
                                                                                                             ]
                                                                                                           ]
                                                                                                           (constr
@@ -2170,10 +2381,10 @@
                                                                                                       ]
                                                                                                     )
                                                                                                   ]
-                                                                                                  ds-165
+                                                                                                  ds-168
                                                                                                 ]
                                                                                                 (lam
-                                                                                                  ds-174
+                                                                                                  ds-177
                                                                                                   (delay
                                                                                                     (constr
                                                                                                       0
@@ -2205,7 +2416,7 @@
                                                             )
                                                           ]
                                                           (lam
-                                                            void-175
+                                                            void-178
                                                             (case
                                                               (error) (error)
                                                             )
@@ -2216,59 +2427,59 @@
                                                   ]
                                                 )
                                                 (lam
-                                                  scrut-176
+                                                  scrut-179
                                                   (lam
-                                                    cont-177
+                                                    cont-180
                                                     (lam
-                                                      fail-178
+                                                      fail-181
                                                       [
                                                         (lam
-                                                          l-179
+                                                          l-182
                                                           [
                                                             (lam
-                                                              l-180
+                                                              l-183
                                                               [
                                                                 (lam
-                                                                  l-181
+                                                                  l-184
                                                                   [
                                                                     (lam
-                                                                      l-182
+                                                                      l-185
                                                                       [
                                                                         (lam
-                                                                          l-183
+                                                                          l-186
                                                                           [
                                                                             (lam
-                                                                              l-184
+                                                                              l-187
                                                                               [
                                                                                 (lam
-                                                                                  l-185
+                                                                                  l-188
                                                                                   [
                                                                                     (lam
-                                                                                      l-186
+                                                                                      l-189
                                                                                       [
                                                                                         (lam
-                                                                                          l-187
+                                                                                          l-190
                                                                                           [
                                                                                             (lam
-                                                                                              l-188
+                                                                                              l-191
                                                                                               [
                                                                                                 (lam
-                                                                                                  l-189
+                                                                                                  l-192
                                                                                                   [
                                                                                                     (lam
-                                                                                                      l-190
+                                                                                                      l-193
                                                                                                       [
                                                                                                         (lam
-                                                                                                          l-191
+                                                                                                          l-194
                                                                                                           [
                                                                                                             (lam
-                                                                                                              l-192
+                                                                                                              l-195
                                                                                                               [
                                                                                                                 (lam
-                                                                                                                  l-193
+                                                                                                                  l-196
                                                                                                                   [
                                                                                                                     (lam
-                                                                                                                      cse-194
+                                                                                                                      cse-197
                                                                                                                       [
                                                                                                                         [
                                                                                                                           [
@@ -2285,7 +2496,7 @@
                                                                                                                                                 [
                                                                                                                                                   [
                                                                                                                                                     [
-                                                                                                                                                      cont-177
+                                                                                                                                                      cont-180
                                                                                                                                                       [
                                                                                                                                                         (builtin
                                                                                                                                                           unListData
@@ -2296,7 +2507,7 @@
                                                                                                                                                               headList
                                                                                                                                                             )
                                                                                                                                                           )
-                                                                                                                                                          l-179
+                                                                                                                                                          l-182
                                                                                                                                                         ]
                                                                                                                                                       ]
                                                                                                                                                     ]
@@ -2310,7 +2521,7 @@
                                                                                                                                                             headList
                                                                                                                                                           )
                                                                                                                                                         )
-                                                                                                                                                        l-180
+                                                                                                                                                        l-183
                                                                                                                                                       ]
                                                                                                                                                     ]
                                                                                                                                                   ]
@@ -2324,7 +2535,7 @@
                                                                                                                                                           headList
                                                                                                                                                         )
                                                                                                                                                       )
-                                                                                                                                                      l-181
+                                                                                                                                                      l-184
                                                                                                                                                     ]
                                                                                                                                                   ]
                                                                                                                                                 ]
@@ -2338,7 +2549,7 @@
                                                                                                                                                         headList
                                                                                                                                                       )
                                                                                                                                                     )
-                                                                                                                                                    l-182
+                                                                                                                                                    l-185
                                                                                                                                                   ]
                                                                                                                                                 ]
                                                                                                                                               ]
@@ -2352,7 +2563,7 @@
                                                                                                                                                       headList
                                                                                                                                                     )
                                                                                                                                                   )
-                                                                                                                                                  l-183
+                                                                                                                                                  l-186
                                                                                                                                                 ]
                                                                                                                                               ]
                                                                                                                                             ]
@@ -2366,7 +2577,7 @@
                                                                                                                                                     headList
                                                                                                                                                   )
                                                                                                                                                 )
-                                                                                                                                                l-184
+                                                                                                                                                l-187
                                                                                                                                               ]
                                                                                                                                             ]
                                                                                                                                           ]
@@ -2380,7 +2591,7 @@
                                                                                                                                                   headList
                                                                                                                                                 )
                                                                                                                                               )
-                                                                                                                                              l-185
+                                                                                                                                              l-188
                                                                                                                                             ]
                                                                                                                                           ]
                                                                                                                                         ]
@@ -2390,7 +2601,7 @@
                                                                                                                                               headList
                                                                                                                                             )
                                                                                                                                           )
-                                                                                                                                          l-186
+                                                                                                                                          l-189
                                                                                                                                         ]
                                                                                                                                       ]
                                                                                                                                       [
@@ -2403,7 +2614,7 @@
                                                                                                                                               headList
                                                                                                                                             )
                                                                                                                                           )
-                                                                                                                                          l-187
+                                                                                                                                          l-190
                                                                                                                                         ]
                                                                                                                                       ]
                                                                                                                                     ]
@@ -2417,7 +2628,7 @@
                                                                                                                                             headList
                                                                                                                                           )
                                                                                                                                         )
-                                                                                                                                        l-188
+                                                                                                                                        l-191
                                                                                                                                       ]
                                                                                                                                     ]
                                                                                                                                   ]
@@ -2431,7 +2642,7 @@
                                                                                                                                           headList
                                                                                                                                         )
                                                                                                                                       )
-                                                                                                                                      l-189
+                                                                                                                                      l-192
                                                                                                                                     ]
                                                                                                                                   ]
                                                                                                                                 ]
@@ -2445,7 +2656,7 @@
                                                                                                                                         headList
                                                                                                                                       )
                                                                                                                                     )
-                                                                                                                                    l-190
+                                                                                                                                    l-193
                                                                                                                                   ]
                                                                                                                                 ]
                                                                                                                               ]
@@ -2459,7 +2670,7 @@
                                                                                                                                       headList
                                                                                                                                     )
                                                                                                                                   )
-                                                                                                                                  l-191
+                                                                                                                                  l-194
                                                                                                                                 ]
                                                                                                                               ]
                                                                                                                             ]
@@ -2473,24 +2684,24 @@
                                                                                                                                     headList
                                                                                                                                   )
                                                                                                                                 )
-                                                                                                                                l-192
+                                                                                                                                l-195
                                                                                                                               ]
                                                                                                                             ]
                                                                                                                           ]
                                                                                                                           [
-                                                                                                                            cse-194
+                                                                                                                            cse-197
                                                                                                                             [
                                                                                                                               (force
                                                                                                                                 (builtin
                                                                                                                                   headList
                                                                                                                                 )
                                                                                                                               )
-                                                                                                                              l-193
+                                                                                                                              l-196
                                                                                                                             ]
                                                                                                                           ]
                                                                                                                         ]
                                                                                                                         [
-                                                                                                                          cse-194
+                                                                                                                          cse-197
                                                                                                                           [
                                                                                                                             (force
                                                                                                                               (builtin
@@ -2503,7 +2714,7 @@
                                                                                                                                   tailList
                                                                                                                                 )
                                                                                                                               )
-                                                                                                                              l-193
+                                                                                                                              l-196
                                                                                                                             ]
                                                                                                                           ]
                                                                                                                         ]
@@ -2523,7 +2734,7 @@
                                                                                                                       tailList
                                                                                                                     )
                                                                                                                   )
-                                                                                                                  l-192
+                                                                                                                  l-195
                                                                                                                 ]
                                                                                                               ]
                                                                                                             )
@@ -2533,7 +2744,7 @@
                                                                                                                   tailList
                                                                                                                 )
                                                                                                               )
-                                                                                                              l-191
+                                                                                                              l-194
                                                                                                             ]
                                                                                                           ]
                                                                                                         )
@@ -2543,7 +2754,7 @@
                                                                                                               tailList
                                                                                                             )
                                                                                                           )
-                                                                                                          l-190
+                                                                                                          l-193
                                                                                                         ]
                                                                                                       ]
                                                                                                     )
@@ -2553,7 +2764,7 @@
                                                                                                           tailList
                                                                                                         )
                                                                                                       )
-                                                                                                      l-189
+                                                                                                      l-192
                                                                                                     ]
                                                                                                   ]
                                                                                                 )
@@ -2563,7 +2774,7 @@
                                                                                                       tailList
                                                                                                     )
                                                                                                   )
-                                                                                                  l-188
+                                                                                                  l-191
                                                                                                 ]
                                                                                               ]
                                                                                             )
@@ -2573,7 +2784,7 @@
                                                                                                   tailList
                                                                                                 )
                                                                                               )
-                                                                                              l-187
+                                                                                              l-190
                                                                                             ]
                                                                                           ]
                                                                                         )
@@ -2583,7 +2794,7 @@
                                                                                               tailList
                                                                                             )
                                                                                           )
-                                                                                          l-186
+                                                                                          l-189
                                                                                         ]
                                                                                       ]
                                                                                     )
@@ -2593,7 +2804,7 @@
                                                                                           tailList
                                                                                         )
                                                                                       )
-                                                                                      l-185
+                                                                                      l-188
                                                                                     ]
                                                                                   ]
                                                                                 )
@@ -2603,7 +2814,7 @@
                                                                                       tailList
                                                                                     )
                                                                                   )
-                                                                                  l-184
+                                                                                  l-187
                                                                                 ]
                                                                               ]
                                                                             )
@@ -2613,7 +2824,7 @@
                                                                                   tailList
                                                                                 )
                                                                               )
-                                                                              l-183
+                                                                              l-186
                                                                             ]
                                                                           ]
                                                                         )
@@ -2623,7 +2834,7 @@
                                                                               tailList
                                                                             )
                                                                           )
-                                                                          l-182
+                                                                          l-185
                                                                         ]
                                                                       ]
                                                                     )
@@ -2633,7 +2844,7 @@
                                                                           tailList
                                                                         )
                                                                       )
-                                                                      l-181
+                                                                      l-184
                                                                     ]
                                                                   ]
                                                                 )
@@ -2643,7 +2854,7 @@
                                                                       tailList
                                                                     )
                                                                   )
-                                                                  l-180
+                                                                  l-183
                                                                 ]
                                                               ]
                                                             )
@@ -2653,7 +2864,7 @@
                                                                   tailList
                                                                 )
                                                               )
-                                                              l-179
+                                                              l-182
                                                             ]
                                                           ]
                                                         )
@@ -2667,7 +2878,7 @@
                                                             (builtin
                                                               unConstrData
                                                             )
-                                                            scrut-176
+                                                            scrut-179
                                                           ]
                                                         ]
                                                       ]
@@ -2677,22 +2888,22 @@
                                               ]
                                             )
                                             (lam
-                                              `$dUnsafeFromData`-195
+                                              `$dUnsafeFromData`-198
                                               (lam
-                                                pred'-196
+                                                pred'-199
                                                 [
                                                   (lam
-                                                    go-197
+                                                    go-200
                                                     (lam
-                                                      eta-198 [ go-197 eta-198 ]
+                                                      eta-201 [ go-200 eta-201 ]
                                                     )
                                                   )
                                                   [
-                                                    (lam s-199 [ s-199 s-199 ])
+                                                    (lam s-202 [ s-202 s-202 ])
                                                     (lam
-                                                      s-200
+                                                      s-203
                                                       (lam
-                                                        ds-201
+                                                        ds-204
                                                         [
                                                           [
                                                             [
@@ -2700,45 +2911,45 @@
                                                               (constr 1)
                                                             ]
                                                             (lam
-                                                              x-202
+                                                              x-205
                                                               (lam
-                                                                eta-203
+                                                                eta-206
                                                                 [
                                                                   (lam
-                                                                    h-204
+                                                                    h-207
                                                                     (force
                                                                       (case
                                                                         [
-                                                                          pred'-196
-                                                                          h-204
+                                                                          pred'-199
+                                                                          h-207
                                                                         ]
                                                                         (delay
                                                                           (constr
                                                                             0
-                                                                            h-204
+                                                                            h-207
                                                                           )
                                                                         )
                                                                         (delay
                                                                           [
                                                                             [
-                                                                              s-200
-                                                                              s-200
+                                                                              s-203
+                                                                              s-203
                                                                             ]
-                                                                            eta-203
+                                                                            eta-206
                                                                           ]
                                                                         )
                                                                       )
                                                                     )
                                                                   )
                                                                   [
-                                                                    `$dUnsafeFromData`-195
-                                                                    x-202
+                                                                    `$dUnsafeFromData`-198
+                                                                    x-205
                                                                   ]
                                                                 ]
                                                               )
                                                             )
                                                           ]
-                                                          ds-201
+                                                          ds-204
                                                         ]
                                                       )
                                                     )
@@ -2749,11 +2960,11 @@
                                           ]
                                         )
                                         (lam
-                                          z-205
+                                          z-208
                                           (lam
-                                            f-206
+                                            f-209
                                             (lam
-                                              xs-207
+                                              xs-210
                                               (force
                                                 [
                                                   [
@@ -2763,26 +2974,26 @@
                                                           (builtin chooseList)
                                                         )
                                                       )
-                                                      xs-207
+                                                      xs-210
                                                     ]
-                                                    (delay z-205)
+                                                    (delay z-208)
                                                   ]
                                                   (delay
                                                     [
                                                       [
-                                                        f-206
+                                                        f-209
                                                         [
                                                           (force
                                                             (builtin headList)
                                                           )
-                                                          xs-207
+                                                          xs-210
                                                         ]
                                                       ]
                                                       [
                                                         (force
                                                           (builtin tailList)
                                                         )
-                                                        xs-207
+                                                        xs-210
                                                       ]
                                                     ]
                                                   )
@@ -2796,7 +3007,7 @@
                                   )
                                   [
                                     (lam
-                                      fail-208
+                                      fail-211
                                       [
                                         [
                                           [
@@ -2805,34 +3016,34 @@
                                               [
                                                 cse-3
                                                 (lam
-                                                  ds-209
+                                                  ds-212
                                                   (lam
-                                                    ds-210 (lam ds-211 ds-211)
+                                                    ds-213 (lam ds-214 ds-214)
                                                   )
                                                 )
                                               ]
-                                              (lam void-212 (error))
+                                              (lam void-215 (error))
                                             ]
                                           ]
                                           (lam
-                                            ds-213
+                                            ds-216
                                             (lam
-                                              ds-214
+                                              ds-217
                                               (force
                                                 (case
-                                                  ds-214
+                                                  ds-217
                                                   (lam
-                                                    datum-215
+                                                    datum-218
                                                     (delay
                                                       [
                                                         (lam
-                                                          tup-216
+                                                          tup-219
                                                           [
                                                             (lam
-                                                              index-217
+                                                              index-220
                                                               [
                                                                 (lam
-                                                                  args-218
+                                                                  args-221
                                                                   (force
                                                                     (force
                                                                       [
@@ -2853,17 +3064,17 @@
                                                                                   0
                                                                                 )
                                                                               ]
-                                                                              index-217
+                                                                              index-220
                                                                             ]
                                                                           ]
                                                                           (delay
                                                                             (delay
                                                                               [
                                                                                 (lam
-                                                                                  l-219
+                                                                                  l-222
                                                                                   [
                                                                                     (lam
-                                                                                      l-220
+                                                                                      l-223
                                                                                       (constr
                                                                                         0
                                                                                         [
@@ -2872,7 +3083,7 @@
                                                                                               headList
                                                                                             )
                                                                                           )
-                                                                                          args-218
+                                                                                          args-221
                                                                                         ]
                                                                                         [
                                                                                           (force
@@ -2880,7 +3091,7 @@
                                                                                               headList
                                                                                             )
                                                                                           )
-                                                                                          l-219
+                                                                                          l-222
                                                                                         ]
                                                                                         [
                                                                                           (builtin
@@ -2892,7 +3103,7 @@
                                                                                                 headList
                                                                                               )
                                                                                             )
-                                                                                            l-220
+                                                                                            l-223
                                                                                           ]
                                                                                         ]
                                                                                         [
@@ -2911,7 +3122,7 @@
                                                                                                   tailList
                                                                                                 )
                                                                                               )
-                                                                                              l-220
+                                                                                              l-223
                                                                                             ]
                                                                                           ]
                                                                                         ]
@@ -2923,7 +3134,7 @@
                                                                                           tailList
                                                                                         )
                                                                                       )
-                                                                                      l-219
+                                                                                      l-222
                                                                                     ]
                                                                                   ]
                                                                                 )
@@ -2933,7 +3144,7 @@
                                                                                       tailList
                                                                                     )
                                                                                   )
-                                                                                  args-218
+                                                                                  args-221
                                                                                 ]
                                                                               ]
                                                                             )
@@ -2962,7 +3173,7 @@
                                                                       )
                                                                     )
                                                                   )
-                                                                  tup-216
+                                                                  tup-219
                                                                 ]
                                                               ]
                                                             )
@@ -2974,19 +3185,19 @@
                                                                   )
                                                                 )
                                                               )
-                                                              tup-216
+                                                              tup-219
                                                             ]
                                                           ]
                                                         )
                                                         [
                                                           (builtin unConstrData)
-                                                          datum-215
+                                                          datum-218
                                                         ]
                                                       ]
                                                     )
                                                   )
                                                   (delay
-                                                    [ fail-208 (con unit ()) ]
+                                                    [ fail-211 (con unit ()) ]
                                                   )
                                                 )
                                               )
@@ -2994,14 +3205,14 @@
                                           )
                                         ]
                                         (lam
-                                          void-221 [ fail-208 (con unit ()) ]
+                                          void-224 [ fail-211 (con unit ()) ]
                                         )
                                       ]
                                     )
                                     (lam
-                                      ds-222
+                                      ds-225
                                       [
-                                        (lam x-223 (error))
+                                        (lam x-226 (error))
                                         [
                                           [
                                             (force (builtin trace))
@@ -3018,14 +3229,14 @@
                                 ]
                               )
                               (lam
-                                scrut-224
+                                scrut-227
                                 (lam
-                                  cont-225
+                                  cont-228
                                   (lam
-                                    fail-226
+                                    fail-229
                                     [
                                       (lam
-                                        tup-227
+                                        tup-230
                                         (force
                                           (force
                                             [
@@ -3043,7 +3254,7 @@
                                                           (builtin fstPair)
                                                         )
                                                       )
-                                                      tup-227
+                                                      tup-230
                                                     ]
                                                   ]
                                                 ]
@@ -3051,17 +3262,17 @@
                                                   (delay
                                                     [
                                                       (lam
-                                                        l-228
+                                                        l-231
                                                         [
                                                           [
-                                                            cont-225
+                                                            cont-228
                                                             [
                                                               (force
                                                                 (builtin
                                                                   headList
                                                                 )
                                                               )
-                                                              l-228
+                                                              l-231
                                                             ]
                                                           ]
                                                           [
@@ -3081,7 +3292,7 @@
                                                                     tailList
                                                                   )
                                                                 )
-                                                                l-228
+                                                                l-231
                                                               ]
                                                             ]
                                                           ]
@@ -3093,7 +3304,7 @@
                                                             (builtin sndPair)
                                                           )
                                                         )
-                                                        tup-227
+                                                        tup-230
                                                       ]
                                                     ]
                                                   )
@@ -3101,14 +3312,14 @@
                                               ]
                                               (delay
                                                 (delay
-                                                  [ fail-226 (con unit ()) ]
+                                                  [ fail-229 (con unit ()) ]
                                                 )
                                               )
                                             ]
                                           )
                                         )
                                       )
-                                      [ (builtin unConstrData) scrut-224 ]
+                                      [ (builtin unConstrData) scrut-227 ]
                                     ]
                                   )
                                 )
@@ -3116,18 +3327,18 @@
                             ]
                           )
                           (lam
-                            `$dUnsafeFromData`-229
+                            `$dUnsafeFromData`-232
                             (lam
-                              d-230
+                              d-233
                               [
                                 (lam
-                                  tup-231
+                                  tup-234
                                   [
                                     (lam
-                                      index-232
+                                      index-235
                                       [
                                         (lam
-                                          args-233
+                                          args-236
                                           (force
                                             (force
                                               [
@@ -3139,7 +3350,7 @@
                                                         (builtin equalsInteger)
                                                         (con integer 1)
                                                       ]
-                                                      index-232
+                                                      index-235
                                                     ]
                                                   ]
                                                   (delay (delay (constr 1)))
@@ -3165,7 +3376,7 @@
                                                                     integer 0
                                                                   )
                                                                 ]
-                                                                index-232
+                                                                index-235
                                                               ]
                                                             ]
                                                             (delay
@@ -3173,14 +3384,14 @@
                                                                 (constr
                                                                   0
                                                                   [
-                                                                    `$dUnsafeFromData`-229
+                                                                    `$dUnsafeFromData`-232
                                                                     [
                                                                       (force
                                                                         (builtin
                                                                           headList
                                                                         )
                                                                       )
-                                                                      args-233
+                                                                      args-236
                                                                     ]
                                                                   ]
                                                                 )
@@ -3208,33 +3419,33 @@
                                         )
                                         [
                                           (force (force (builtin sndPair)))
-                                          tup-231
+                                          tup-234
                                         ]
                                       ]
                                     )
                                     [
-                                      (force (force (builtin fstPair))) tup-231
+                                      (force (force (builtin fstPair))) tup-234
                                     ]
                                   ]
                                 )
-                                [ (builtin unConstrData) d-230 ]
+                                [ (builtin unConstrData) d-233 ]
                               ]
                             )
                           )
                         ]
                       )
-                      (lam d-234 d-234)
+                      (lam d-237 d-237)
                     ]
                   )
                   [
                     (lam
-                      tup-235
+                      tup-238
                       [
                         (lam
-                          index-236
+                          index-239
                           [
                             (lam
-                              args-237
+                              args-240
                               (force
                                 (force
                                   [
@@ -3246,7 +3457,7 @@
                                             (builtin equalsInteger)
                                             (con integer 0)
                                           ]
-                                          index-236
+                                          index-239
                                         ]
                                       ]
                                       (delay
@@ -3257,7 +3468,7 @@
                                               (builtin unBData)
                                               [
                                                 (force (builtin headList))
-                                                args-237
+                                                args-240
                                               ]
                                             ]
                                           )
@@ -3277,7 +3488,7 @@
                                                       (builtin equalsInteger)
                                                       (con integer 1)
                                                     ]
-                                                    index-236
+                                                    index-239
                                                   ]
                                                 ]
                                                 (delay (delay (constr 1)))
@@ -3299,17 +3510,17 @@
                                 )
                               )
                             )
-                            [ (force (force (builtin sndPair))) tup-235 ]
+                            [ (force (force (builtin sndPair))) tup-238 ]
                           ]
                         )
-                        [ (force (force (builtin fstPair))) tup-235 ]
+                        [ (force (force (builtin fstPair))) tup-238 ]
                       ]
                     )
                     [
                       (builtin unConstrData)
                       [
-                        [ cse-3 (lam ds-238 (lam ds-239 (lam ds-240 ds-239))) ]
-                        (lam void-241 (error))
+                        [ cse-3 (lam ds-241 (lam ds-242 (lam ds-243 ds-242))) ]
+                        (lam void-244 (error))
                       ]
                     ]
                   ]
@@ -3319,43 +3530,43 @@
             ]
           )
           (lam
-            str-242
+            str-245
             [
-              (lam x-243 (error))
-              [ [ (force (builtin trace)) str-242 ] (constr 0) ]
+              (lam x-246 (error))
+              [ [ (force (builtin trace)) str-245 ] (constr 0) ]
             ]
           )
         ]
       )
       (lam
-        scrut-244
+        scrut-247
         (lam
-          cont-245
+          cont-248
           (lam
-            fail-246
+            fail-249
             [
               (lam
-                l-247
+                l-250
                 [
                   (lam
-                    l-248
+                    l-251
                     [
                       [
-                        [ cont-245 [ (force (builtin headList)) l-247 ] ]
-                        [ (force (builtin headList)) l-248 ]
+                        [ cont-248 [ (force (builtin headList)) l-250 ] ]
+                        [ (force (builtin headList)) l-251 ]
                       ]
                       [
                         (force (builtin headList))
-                        [ (force (builtin tailList)) l-248 ]
+                        [ (force (builtin tailList)) l-251 ]
                       ]
                     ]
                   )
-                  [ (force (builtin tailList)) l-247 ]
+                  [ (force (builtin tailList)) l-250 ]
                 ]
               )
               [
                 (force (force (builtin sndPair)))
-                [ (builtin unConstrData) scrut-244 ]
+                [ (builtin unConstrData) scrut-247 ]
               ]
             ]
           )

--- a/submissions/htlc/Plinth_1.45.0.0_Unisay/metrics.json
+++ b/submissions/htlc/Plinth_1.45.0.0_Unisay/metrics.json
@@ -36,17 +36,17 @@
       "name": "redeemer_claim_without_preimage"
     },
     {
-      "cpu_units": 76772862,
+      "cpu_units": 76902525,
       "description": "Claim at time=50 with correct preimage and recipient signature should succeed",
       "execution_result": "success",
-      "memory_units": 284696,
+      "memory_units": 285028,
       "name": "claim_well_before_timeout"
     },
     {
-      "cpu_units": 76772862,
+      "cpu_units": 76902525,
       "description": "Claim at time=99 (just before timeout=100) with correct preimage should succeed",
       "execution_result": "success",
-      "memory_units": 284696,
+      "memory_units": 285028,
       "name": "claim_just_before_timeout"
     },
     {
@@ -64,59 +64,66 @@
       "name": "refund_well_after_timeout"
     },
     {
-      "cpu_units": 57430480,
+      "cpu_units": 57512143,
       "description": "Claim without recipient signature should fail",
       "execution_result": "success",
-      "memory_units": 209616,
+      "memory_units": 209648,
       "name": "claim_missing_signature"
     },
     {
-      "cpu_units": 57854128,
+      "cpu_units": 57935791,
       "description": "Claim with only payer signature (not recipient) should fail",
       "execution_result": "success",
-      "memory_units": 209746,
+      "memory_units": 209778,
       "name": "claim_wrong_signature_payer"
     },
     {
-      "cpu_units": 57854128,
+      "cpu_units": 57935791,
       "description": "Claim with only impostor signature (not recipient) should fail",
       "execution_result": "success",
-      "memory_units": 209746,
+      "memory_units": 209778,
       "name": "claim_wrong_signature_impostor"
     },
     {
-      "cpu_units": 58120073,
+      "cpu_units": 58201736,
       "description": "Claim with preimage #cafebabe (hash does not match) should fail",
       "execution_result": "success",
-      "memory_units": 209720,
+      "memory_units": 209752,
       "name": "claim_wrong_preimage"
     },
     {
-      "cpu_units": 58120073,
+      "cpu_units": 58201736,
       "description": "Claim with empty preimage (hash does not match) should fail",
       "execution_result": "success",
-      "memory_units": 209720,
+      "memory_units": 209752,
       "name": "claim_empty_preimage"
     },
     {
-      "cpu_units": 58239959,
+      "cpu_units": 58321622,
       "description": "Claim at time=100 (boundary, must be strictly before timeout) should fail",
       "execution_result": "success",
-      "memory_units": 209722,
+      "memory_units": 209754,
       "name": "claim_at_timeout"
     },
     {
-      "cpu_units": 58239959,
+      "cpu_units": 58321622,
       "description": "Claim at time=150 (after timeout) should fail even with correct preimage",
       "execution_result": "success",
-      "memory_units": 209722,
+      "memory_units": 209754,
       "name": "claim_after_timeout"
     },
     {
-      "cpu_units": 80880147,
+      "cpu_units": 56826859,
+      "description": "Claim with from_time=50 and no upper bound (+inf) should fail; the upper bound must be finite",
+      "execution_result": "success",
+      "memory_units": 209486,
+      "name": "claim_infinite_upper_bound"
+    },
+    {
+      "cpu_units": 80961810,
       "description": "Claim with two script inputs should fail (double satisfaction attack)",
       "execution_result": "success",
-      "memory_units": 293232,
+      "memory_units": 293264,
       "name": "claim_double_satisfaction"
     },
     {
@@ -155,6 +162,13 @@
       "name": "refund_at_timeout"
     },
     {
+      "cpu_units": 46031400,
+      "description": "Refund with no lower bound (-inf) should fail; the lower bound must be finite",
+      "execution_result": "success",
+      "memory_units": 167594,
+      "name": "refund_infinite_lower_bound"
+    },
+    {
       "cpu_units": 80506298,
       "description": "Refund with two script inputs should fail (double satisfaction attack)",
       "execution_result": "success",
@@ -166,36 +180,36 @@
     "evaluator": "unknown"
   },
   "measurements": {
-    "block_cpu_budget_pct": 0.2022003675,
-    "block_memory_budget_pct": 0.4729548387096774,
+    "block_cpu_budget_pct": 0.20240452499999997,
+    "block_memory_budget_pct": 0.47300645161290317,
     "cpu_units": {
-      "maximum": 80880147,
+      "maximum": 80961810,
       "median": 57879218,
       "minimum": 24688,
-      "sum": 1163349436,
+      "sum": 1267120325,
       "sum_negative": 0,
-      "sum_positive": 1163349436
+      "sum_positive": 1267120325
     },
-    "execution_fee_lovelace": 328517,
+    "execution_fee_lovelace": 357810,
     "memory_units": {
-      "maximum": 293232,
-      "median": 209720,
+      "maximum": 293264,
+      "median": 209684,
       "minimum": 132,
-      "sum": 4239848,
+      "sum": 4617848,
       "sum_negative": 0,
-      "sum_positive": 4239848
+      "sum_positive": 4617848
     },
-    "reference_script_fee_lovelace": 25980,
-    "script_size_bytes": 1732,
+    "reference_script_fee_lovelace": 28080,
+    "script_size_bytes": 1872,
     "scripts_per_block": 211,
     "scripts_per_tx": 47,
-    "term_size": 1629,
-    "total_fee_lovelace": 354497,
-    "tx_cpu_budget_pct": 0.80880147,
-    "tx_memory_budget_pct": 2.0945142857142858
+    "term_size": 1721,
+    "total_fee_lovelace": 385890,
+    "tx_cpu_budget_pct": 0.8096180999999999,
+    "tx_memory_budget_pct": 2.0947428571428572
   },
   "scenario": "htlc",
-  "timestamp": "2026-04-23T15:00:53Z",
+  "timestamp": "2026-04-24T10:40:24Z",
   "version": "1.0.0",
   "notes": "Generated using UPLC-CAPE measure tool"
 }

--- a/submissions/htlc/Plinth_1.61.0.0_Unisay/htlc.uplc
+++ b/submissions/htlc/Plinth_1.61.0.0_Unisay/htlc.uplc
@@ -53,7 +53,7 @@
                                                                       ownInputScriptHash-16
                                                                       [
                                                                         (lam
-                                                                          lowerBoundTime-17
+                                                                          `$fUnsafeFromDataBool_$cunsafeFromBuiltinData`-17
                                                                           [
                                                                             (lam
                                                                               extractPubKeyHash-18
@@ -158,15 +158,178 @@
                                                                                                                       )
                                                                                                                     )
                                                                                                                     [
-                                                                                                                      lowerBoundTime-17
+                                                                                                                      (lam
+                                                                                                                        l-30
+                                                                                                                        [
+                                                                                                                          (lam
+                                                                                                                            tup-31
+                                                                                                                            (case
+                                                                                                                              [
+                                                                                                                                [
+                                                                                                                                  (builtin
+                                                                                                                                    equalsInteger
+                                                                                                                                  )
+                                                                                                                                  (con
+                                                                                                                                    integer
+                                                                                                                                    1
+                                                                                                                                  )
+                                                                                                                                ]
+                                                                                                                                (case
+                                                                                                                                  tup-31
+                                                                                                                                  (lam
+                                                                                                                                    l-32
+                                                                                                                                    (lam
+                                                                                                                                      r-33
+                                                                                                                                      l-32
+                                                                                                                                    )
+                                                                                                                                  )
+                                                                                                                                )
+                                                                                                                              ]
+                                                                                                                              (error
+
+                                                                                                                              )
+                                                                                                                              (case
+                                                                                                                                [
+                                                                                                                                  `$fUnsafeFromDataBool_$cunsafeFromBuiltinData`-17
+                                                                                                                                  [
+                                                                                                                                    (force
+                                                                                                                                      (builtin
+                                                                                                                                        headList
+                                                                                                                                      )
+                                                                                                                                    )
+                                                                                                                                    [
+                                                                                                                                      (force
+                                                                                                                                        (builtin
+                                                                                                                                          tailList
+                                                                                                                                        )
+                                                                                                                                      )
+                                                                                                                                      l-30
+                                                                                                                                    ]
+                                                                                                                                  ]
+                                                                                                                                ]
+                                                                                                                                [
+                                                                                                                                  [
+                                                                                                                                    (builtin
+                                                                                                                                      subtractInteger
+                                                                                                                                    )
+                                                                                                                                    [
+                                                                                                                                      (builtin
+                                                                                                                                        unIData
+                                                                                                                                      )
+                                                                                                                                      [
+                                                                                                                                        (force
+                                                                                                                                          (builtin
+                                                                                                                                            headList
+                                                                                                                                          )
+                                                                                                                                        )
+                                                                                                                                        (case
+                                                                                                                                          tup-31
+                                                                                                                                          (lam
+                                                                                                                                            l-34
+                                                                                                                                            (lam
+                                                                                                                                              r-35
+                                                                                                                                              r-35
+                                                                                                                                            )
+                                                                                                                                          )
+                                                                                                                                        )
+                                                                                                                                      ]
+                                                                                                                                    ]
+                                                                                                                                  ]
+                                                                                                                                  (con
+                                                                                                                                    integer
+                                                                                                                                    1
+                                                                                                                                  )
+                                                                                                                                ]
+                                                                                                                                [
+                                                                                                                                  (builtin
+                                                                                                                                    unIData
+                                                                                                                                  )
+                                                                                                                                  [
+                                                                                                                                    (force
+                                                                                                                                      (builtin
+                                                                                                                                        headList
+                                                                                                                                      )
+                                                                                                                                    )
+                                                                                                                                    (case
+                                                                                                                                      tup-31
+                                                                                                                                      (lam
+                                                                                                                                        l-36
+                                                                                                                                        (lam
+                                                                                                                                          r-37
+                                                                                                                                          r-37
+                                                                                                                                        )
+                                                                                                                                      )
+                                                                                                                                    )
+                                                                                                                                  ]
+                                                                                                                                ]
+                                                                                                                              )
+                                                                                                                            )
+                                                                                                                          )
+                                                                                                                          [
+                                                                                                                            (builtin
+                                                                                                                              unConstrData
+                                                                                                                            )
+                                                                                                                            [
+                                                                                                                              (force
+                                                                                                                                (builtin
+                                                                                                                                  headList
+                                                                                                                                )
+                                                                                                                              )
+                                                                                                                              l-30
+                                                                                                                            ]
+                                                                                                                          ]
+                                                                                                                        ]
+                                                                                                                      )
                                                                                                                       (case
-                                                                                                                        (constr
-                                                                                                                          0
-                                                                                                                          nt-27
-                                                                                                                          txInfoValidRange-11
-                                                                                                                          txInfoValidRange-12
+                                                                                                                        [
+                                                                                                                          (builtin
+                                                                                                                            unConstrData
+                                                                                                                          )
+                                                                                                                          [
+                                                                                                                            (force
+                                                                                                                              (builtin
+                                                                                                                                headList
+                                                                                                                              )
+                                                                                                                            )
+                                                                                                                            [
+                                                                                                                              (force
+                                                                                                                                (builtin
+                                                                                                                                  tailList
+                                                                                                                                )
+                                                                                                                              )
+                                                                                                                              (case
+                                                                                                                                [
+                                                                                                                                  (builtin
+                                                                                                                                    unConstrData
+                                                                                                                                  )
+                                                                                                                                  (case
+                                                                                                                                    (constr
+                                                                                                                                      0
+                                                                                                                                      nt-27
+                                                                                                                                      txInfoValidRange-11
+                                                                                                                                      txInfoValidRange-12
+                                                                                                                                    )
+                                                                                                                                    `$mTxInfo`-9
+                                                                                                                                  )
+                                                                                                                                ]
+                                                                                                                                (lam
+                                                                                                                                  l-38
+                                                                                                                                  (lam
+                                                                                                                                    r-39
+                                                                                                                                    r-39
+                                                                                                                                  )
+                                                                                                                                )
+                                                                                                                              )
+                                                                                                                            ]
+                                                                                                                          ]
+                                                                                                                        ]
+                                                                                                                        (lam
+                                                                                                                          l-40
+                                                                                                                          (lam
+                                                                                                                            r-41
+                                                                                                                            r-41
+                                                                                                                          )
                                                                                                                         )
-                                                                                                                        `$mTxInfo`-9
                                                                                                                       )
                                                                                                                     ]
                                                                                                                   ]
@@ -211,32 +374,32 @@
                                                                                       (case
                                                                                         datum-7
                                                                                         (lam
-                                                                                          ds-30
+                                                                                          ds-42
                                                                                           (lam
-                                                                                            ds-31
+                                                                                            ds-43
                                                                                             (lam
-                                                                                              ds-32
+                                                                                              ds-44
                                                                                               (lam
-                                                                                                ds-33
+                                                                                                ds-45
                                                                                                 [
                                                                                                   (lam
-                                                                                                    ownScriptHash-34
+                                                                                                    ownScriptHash-46
                                                                                                     [
                                                                                                       (lam
-                                                                                                        payerHash-35
+                                                                                                        payerHash-47
                                                                                                         [
                                                                                                           (lam
-                                                                                                            nt-36
+                                                                                                            nt-48
                                                                                                             [
                                                                                                               (lam
-                                                                                                                nt-37
+                                                                                                                nt-49
                                                                                                                 (case
                                                                                                                   [
                                                                                                                     [
                                                                                                                       txSignedBy-10
-                                                                                                                      nt-36
+                                                                                                                      nt-48
                                                                                                                     ]
-                                                                                                                    payerHash-35
+                                                                                                                    payerHash-47
                                                                                                                   ]
                                                                                                                   (error
 
@@ -247,9 +410,9 @@
                                                                                                                         (builtin
                                                                                                                           lessThanEqualsInteger
                                                                                                                         )
-                                                                                                                        nt-37
+                                                                                                                        nt-49
                                                                                                                       ]
-                                                                                                                      ds-33
+                                                                                                                      ds-45
                                                                                                                     ]
                                                                                                                     (case
                                                                                                                       [
@@ -265,9 +428,9 @@
                                                                                                                         [
                                                                                                                           [
                                                                                                                             countScriptInputs-19
-                                                                                                                            nt-36
+                                                                                                                            nt-48
                                                                                                                           ]
-                                                                                                                          ownScriptHash-34
+                                                                                                                          ownScriptHash-46
                                                                                                                         ]
                                                                                                                       ]
                                                                                                                       (error
@@ -285,15 +448,171 @@
                                                                                                                 )
                                                                                                               )
                                                                                                               [
-                                                                                                                lowerBoundTime-17
+                                                                                                                (lam
+                                                                                                                  l-50
+                                                                                                                  [
+                                                                                                                    (lam
+                                                                                                                      tup-51
+                                                                                                                      (case
+                                                                                                                        [
+                                                                                                                          [
+                                                                                                                            (builtin
+                                                                                                                              equalsInteger
+                                                                                                                            )
+                                                                                                                            (con
+                                                                                                                              integer
+                                                                                                                              1
+                                                                                                                            )
+                                                                                                                          ]
+                                                                                                                          (case
+                                                                                                                            tup-51
+                                                                                                                            (lam
+                                                                                                                              l-52
+                                                                                                                              (lam
+                                                                                                                                r-53
+                                                                                                                                l-52
+                                                                                                                              )
+                                                                                                                            )
+                                                                                                                          )
+                                                                                                                        ]
+                                                                                                                        (error
+
+                                                                                                                        )
+                                                                                                                        (case
+                                                                                                                          [
+                                                                                                                            `$fUnsafeFromDataBool_$cunsafeFromBuiltinData`-17
+                                                                                                                            [
+                                                                                                                              (force
+                                                                                                                                (builtin
+                                                                                                                                  headList
+                                                                                                                                )
+                                                                                                                              )
+                                                                                                                              [
+                                                                                                                                (force
+                                                                                                                                  (builtin
+                                                                                                                                    tailList
+                                                                                                                                  )
+                                                                                                                                )
+                                                                                                                                l-50
+                                                                                                                              ]
+                                                                                                                            ]
+                                                                                                                          ]
+                                                                                                                          [
+                                                                                                                            [
+                                                                                                                              (builtin
+                                                                                                                                addInteger
+                                                                                                                              )
+                                                                                                                              (con
+                                                                                                                                integer
+                                                                                                                                1
+                                                                                                                              )
+                                                                                                                            ]
+                                                                                                                            [
+                                                                                                                              (builtin
+                                                                                                                                unIData
+                                                                                                                              )
+                                                                                                                              [
+                                                                                                                                (force
+                                                                                                                                  (builtin
+                                                                                                                                    headList
+                                                                                                                                  )
+                                                                                                                                )
+                                                                                                                                (case
+                                                                                                                                  tup-51
+                                                                                                                                  (lam
+                                                                                                                                    l-54
+                                                                                                                                    (lam
+                                                                                                                                      r-55
+                                                                                                                                      r-55
+                                                                                                                                    )
+                                                                                                                                  )
+                                                                                                                                )
+                                                                                                                              ]
+                                                                                                                            ]
+                                                                                                                          ]
+                                                                                                                          [
+                                                                                                                            (builtin
+                                                                                                                              unIData
+                                                                                                                            )
+                                                                                                                            [
+                                                                                                                              (force
+                                                                                                                                (builtin
+                                                                                                                                  headList
+                                                                                                                                )
+                                                                                                                              )
+                                                                                                                              (case
+                                                                                                                                tup-51
+                                                                                                                                (lam
+                                                                                                                                  l-56
+                                                                                                                                  (lam
+                                                                                                                                    r-57
+                                                                                                                                    r-57
+                                                                                                                                  )
+                                                                                                                                )
+                                                                                                                              )
+                                                                                                                            ]
+                                                                                                                          ]
+                                                                                                                        )
+                                                                                                                      )
+                                                                                                                    )
+                                                                                                                    [
+                                                                                                                      (builtin
+                                                                                                                        unConstrData
+                                                                                                                      )
+                                                                                                                      [
+                                                                                                                        (force
+                                                                                                                          (builtin
+                                                                                                                            headList
+                                                                                                                          )
+                                                                                                                        )
+                                                                                                                        l-50
+                                                                                                                      ]
+                                                                                                                    ]
+                                                                                                                  ]
+                                                                                                                )
                                                                                                                 (case
-                                                                                                                  (constr
-                                                                                                                    0
-                                                                                                                    nt-36
-                                                                                                                    txInfoValidRange-11
-                                                                                                                    txInfoValidRange-12
+                                                                                                                  [
+                                                                                                                    (builtin
+                                                                                                                      unConstrData
+                                                                                                                    )
+                                                                                                                    [
+                                                                                                                      (force
+                                                                                                                        (builtin
+                                                                                                                          headList
+                                                                                                                        )
+                                                                                                                      )
+                                                                                                                      (case
+                                                                                                                        [
+                                                                                                                          (builtin
+                                                                                                                            unConstrData
+                                                                                                                          )
+                                                                                                                          (case
+                                                                                                                            (constr
+                                                                                                                              0
+                                                                                                                              nt-48
+                                                                                                                              txInfoValidRange-11
+                                                                                                                              txInfoValidRange-12
+                                                                                                                            )
+                                                                                                                            `$mTxInfo`-9
+                                                                                                                          )
+                                                                                                                        ]
+                                                                                                                        (lam
+                                                                                                                          l-58
+                                                                                                                          (lam
+                                                                                                                            r-59
+                                                                                                                            r-59
+                                                                                                                          )
+                                                                                                                        )
+                                                                                                                      )
+                                                                                                                    ]
+                                                                                                                  ]
+                                                                                                                  (lam
+                                                                                                                    l-60
+                                                                                                                    (lam
+                                                                                                                      r-61
+                                                                                                                      r-61
+                                                                                                                    )
                                                                                                                   )
-                                                                                                                  `$mTxInfo`-9
                                                                                                                 )
                                                                                                               ]
                                                                                                             ]
@@ -309,7 +628,7 @@
                                                                                                       )
                                                                                                       [
                                                                                                         extractPubKeyHash-18
-                                                                                                        ds-30
+                                                                                                        ds-42
                                                                                                       ]
                                                                                                     ]
                                                                                                   )
@@ -327,28 +646,28 @@
                                                                                   )
                                                                                 )
                                                                                 (lam
-                                                                                  txInfo-38
+                                                                                  txInfo-62
                                                                                   (lam
-                                                                                    scriptHash-39
+                                                                                    scriptHash-63
                                                                                     (case
                                                                                       (constr
                                                                                         0
                                                                                         (lam
-                                                                                          s-40
+                                                                                          s-64
                                                                                           (lam
-                                                                                            acc-41
+                                                                                            acc-65
                                                                                             (lam
-                                                                                              xs-42
+                                                                                              xs-66
                                                                                               (case
-                                                                                                xs-42
+                                                                                                xs-66
                                                                                                 (lam
-                                                                                                  h-43
+                                                                                                  h-67
                                                                                                   (lam
-                                                                                                    t-44
+                                                                                                    t-68
                                                                                                     (case
                                                                                                       (constr
                                                                                                         0
-                                                                                                        s-40
+                                                                                                        s-64
                                                                                                         (case
                                                                                                           (constr
                                                                                                             0
@@ -369,29 +688,29 @@
                                                                                                                     (builtin
                                                                                                                       unConstrData
                                                                                                                     )
-                                                                                                                    h-43
+                                                                                                                    h-67
                                                                                                                   ]
                                                                                                                   (lam
-                                                                                                                    l-45
+                                                                                                                    l-69
                                                                                                                     (lam
-                                                                                                                      r-46
-                                                                                                                      r-46
+                                                                                                                      r-70
+                                                                                                                      r-70
                                                                                                                     )
                                                                                                                   )
                                                                                                                 )
                                                                                                               ]
                                                                                                             ]
                                                                                                             (lam
-                                                                                                              ds-47
+                                                                                                              ds-71
                                                                                                               (lam
-                                                                                                                ds-48
+                                                                                                                ds-72
                                                                                                                 (lam
-                                                                                                                  ds-49
+                                                                                                                  ds-73
                                                                                                                   (lam
-                                                                                                                    ds-50
+                                                                                                                    ds-74
                                                                                                                     [
                                                                                                                       (lam
-                                                                                                                        tup-51
+                                                                                                                        tup-75
                                                                                                                         (case
                                                                                                                           [
                                                                                                                             [
@@ -404,17 +723,17 @@
                                                                                                                               )
                                                                                                                             ]
                                                                                                                             (case
-                                                                                                                              tup-51
+                                                                                                                              tup-75
                                                                                                                               (lam
-                                                                                                                                l-52
+                                                                                                                                l-76
                                                                                                                                 (lam
-                                                                                                                                  r-53
-                                                                                                                                  l-52
+                                                                                                                                  r-77
+                                                                                                                                  l-76
                                                                                                                                 )
                                                                                                                               )
                                                                                                                             )
                                                                                                                           ]
-                                                                                                                          acc-41
+                                                                                                                          acc-65
                                                                                                                           (case
                                                                                                                             [
                                                                                                                               [
@@ -432,21 +751,21 @@
                                                                                                                                       )
                                                                                                                                     )
                                                                                                                                     (case
-                                                                                                                                      tup-51
+                                                                                                                                      tup-75
                                                                                                                                       (lam
-                                                                                                                                        l-54
+                                                                                                                                        l-78
                                                                                                                                         (lam
-                                                                                                                                          r-55
-                                                                                                                                          r-55
+                                                                                                                                          r-79
+                                                                                                                                          r-79
                                                                                                                                         )
                                                                                                                                       )
                                                                                                                                     )
                                                                                                                                   ]
                                                                                                                                 ]
                                                                                                                               ]
-                                                                                                                              scriptHash-39
+                                                                                                                              scriptHash-63
                                                                                                                             ]
-                                                                                                                            acc-41
+                                                                                                                            acc-65
                                                                                                                             [
                                                                                                                               [
                                                                                                                                 (builtin
@@ -457,7 +776,7 @@
                                                                                                                                   1
                                                                                                                                 )
                                                                                                                               ]
-                                                                                                                              acc-41
+                                                                                                                              acc-65
                                                                                                                             ]
                                                                                                                           )
                                                                                                                         )
@@ -477,13 +796,13 @@
                                                                                                                               (builtin
                                                                                                                                 unConstrData
                                                                                                                               )
-                                                                                                                              ds-47
+                                                                                                                              ds-71
                                                                                                                             ]
                                                                                                                             (lam
-                                                                                                                              l-56
+                                                                                                                              l-80
                                                                                                                               (lam
-                                                                                                                                r-57
-                                                                                                                                r-57
+                                                                                                                                r-81
+                                                                                                                                r-81
                                                                                                                               )
                                                                                                                             )
                                                                                                                           )
@@ -495,7 +814,7 @@
                                                                                                               )
                                                                                                             )
                                                                                                             (lam
-                                                                                                              void-58
+                                                                                                              void-82
                                                                                                               (case
                                                                                                                 (error
 
@@ -508,13 +827,13 @@
                                                                                                           )
                                                                                                           `$mTxOut`-15
                                                                                                         )
-                                                                                                        t-44
+                                                                                                        t-68
                                                                                                       )
-                                                                                                      s-40
+                                                                                                      s-64
                                                                                                     )
                                                                                                   )
                                                                                                 )
-                                                                                                acc-41
+                                                                                                acc-65
                                                                                               )
                                                                                             )
                                                                                           )
@@ -526,40 +845,40 @@
                                                                                         (case
                                                                                           (constr
                                                                                             0
-                                                                                            txInfo-38
+                                                                                            txInfo-62
                                                                                             (lam
-                                                                                              ds-59
+                                                                                              ds-83
                                                                                               (lam
-                                                                                                ds-60
+                                                                                                ds-84
                                                                                                 (lam
-                                                                                                  ds-61
+                                                                                                  ds-85
                                                                                                   (lam
-                                                                                                    ds-62
+                                                                                                    ds-86
                                                                                                     (lam
-                                                                                                      ds-63
+                                                                                                      ds-87
                                                                                                       (lam
-                                                                                                        ds-64
+                                                                                                        ds-88
                                                                                                         (lam
-                                                                                                          ds-65
+                                                                                                          ds-89
                                                                                                           (lam
-                                                                                                            ds-66
+                                                                                                            ds-90
                                                                                                             (lam
-                                                                                                              ds-67
+                                                                                                              ds-91
                                                                                                               (lam
-                                                                                                                ds-68
+                                                                                                                ds-92
                                                                                                                 (lam
-                                                                                                                  ds-69
+                                                                                                                  ds-93
                                                                                                                   (lam
-                                                                                                                    ds-70
+                                                                                                                    ds-94
                                                                                                                     (lam
-                                                                                                                      ds-71
+                                                                                                                      ds-95
                                                                                                                       (lam
-                                                                                                                        ds-72
+                                                                                                                        ds-96
                                                                                                                         (lam
-                                                                                                                          ds-73
+                                                                                                                          ds-97
                                                                                                                           (lam
-                                                                                                                            ds-74
-                                                                                                                            ds-59
+                                                                                                                            ds-98
+                                                                                                                            ds-83
                                                                                                                           )
                                                                                                                         )
                                                                                                                       )
@@ -577,7 +896,7 @@
                                                                                               )
                                                                                             )
                                                                                             (lam
-                                                                                              void-75
+                                                                                              void-99
                                                                                               (error
 
                                                                                               )
@@ -587,10 +906,10 @@
                                                                                         )
                                                                                       )
                                                                                       (lam
-                                                                                        s-76
+                                                                                        s-100
                                                                                         [
-                                                                                          s-76
-                                                                                          s-76
+                                                                                          s-100
+                                                                                          s-100
                                                                                         ]
                                                                                       )
                                                                                     )
@@ -599,10 +918,10 @@
                                                                               ]
                                                                             )
                                                                             (lam
-                                                                              ds-77
+                                                                              ds-101
                                                                               [
                                                                                 (lam
-                                                                                  tup-78
+                                                                                  tup-102
                                                                                   (case
                                                                                     [
                                                                                       [
@@ -615,12 +934,12 @@
                                                                                         )
                                                                                       ]
                                                                                       (case
-                                                                                        tup-78
+                                                                                        tup-102
                                                                                         (lam
-                                                                                          l-79
+                                                                                          l-103
                                                                                           (lam
-                                                                                            r-80
-                                                                                            l-79
+                                                                                            r-104
+                                                                                            l-103
                                                                                           )
                                                                                         )
                                                                                       )
@@ -639,12 +958,12 @@
                                                                                           )
                                                                                         )
                                                                                         (case
-                                                                                          tup-78
+                                                                                          tup-102
                                                                                           (lam
-                                                                                            l-81
+                                                                                            l-105
                                                                                             (lam
-                                                                                              r-82
-                                                                                              r-82
+                                                                                              r-106
+                                                                                              r-106
                                                                                             )
                                                                                           )
                                                                                         )
@@ -667,13 +986,13 @@
                                                                                         (builtin
                                                                                           unConstrData
                                                                                         )
-                                                                                        ds-77
+                                                                                        ds-101
                                                                                       ]
                                                                                       (lam
-                                                                                        l-83
+                                                                                        l-107
                                                                                         (lam
-                                                                                          r-84
-                                                                                          r-84
+                                                                                          r-108
+                                                                                          r-108
                                                                                         )
                                                                                       )
                                                                                     )
@@ -684,263 +1003,107 @@
                                                                           ]
                                                                         )
                                                                         (lam
-                                                                          ds-85
-                                                                          [
+                                                                          d-109
+                                                                          (case
+                                                                            [
+                                                                              (builtin
+                                                                                unConstrData
+                                                                              )
+                                                                              d-109
+                                                                            ]
                                                                             (lam
-                                                                              l-86
-                                                                              [
-                                                                                (lam
-                                                                                  tup-87
-                                                                                  (case
-                                                                                    [
-                                                                                      [
-                                                                                        (builtin
-                                                                                          equalsInteger
-                                                                                        )
-                                                                                        (con
-                                                                                          integer
-                                                                                          1
-                                                                                        )
-                                                                                      ]
-                                                                                      (case
-                                                                                        tup-87
-                                                                                        (lam
-                                                                                          l-88
-                                                                                          (lam
-                                                                                            r-89
-                                                                                            l-88
-                                                                                          )
-                                                                                        )
-                                                                                      )
-                                                                                    ]
-                                                                                    (error
-
-                                                                                    )
-                                                                                    (case
-                                                                                      (case
-                                                                                        [
-                                                                                          (builtin
-                                                                                            unConstrData
-                                                                                          )
-                                                                                          [
-                                                                                            (force
-                                                                                              (builtin
-                                                                                                headList
-                                                                                              )
-                                                                                            )
-                                                                                            [
-                                                                                              (force
-                                                                                                (builtin
-                                                                                                  tailList
-                                                                                                )
-                                                                                              )
-                                                                                              l-86
-                                                                                            ]
-                                                                                          ]
-                                                                                        ]
-                                                                                        (lam
-                                                                                          index-90
-                                                                                          (lam
-                                                                                            args-91
-                                                                                            [
-                                                                                              (case
-                                                                                                index-90
-                                                                                                (lam
-                                                                                                  ds-92
-                                                                                                  (con
-                                                                                                    bool
-                                                                                                    False
-                                                                                                  )
-                                                                                                )
-                                                                                                (lam
-                                                                                                  ds-93
-                                                                                                  (con
-                                                                                                    bool
-                                                                                                    True
-                                                                                                  )
-                                                                                                )
-                                                                                              )
-                                                                                              args-91
-                                                                                            ]
-                                                                                          )
-                                                                                        )
-                                                                                      )
-                                                                                      [
-                                                                                        [
-                                                                                          (builtin
-                                                                                            addInteger
-                                                                                          )
-                                                                                          (con
-                                                                                            integer
-                                                                                            1
-                                                                                          )
-                                                                                        ]
-                                                                                        [
-                                                                                          (builtin
-                                                                                            unIData
-                                                                                          )
-                                                                                          [
-                                                                                            (force
-                                                                                              (builtin
-                                                                                                headList
-                                                                                              )
-                                                                                            )
-                                                                                            (case
-                                                                                              tup-87
-                                                                                              (lam
-                                                                                                l-94
-                                                                                                (lam
-                                                                                                  r-95
-                                                                                                  r-95
-                                                                                                )
-                                                                                              )
-                                                                                            )
-                                                                                          ]
-                                                                                        ]
-                                                                                      ]
-                                                                                      [
-                                                                                        (builtin
-                                                                                          unIData
-                                                                                        )
-                                                                                        [
-                                                                                          (force
-                                                                                            (builtin
-                                                                                              headList
-                                                                                            )
-                                                                                          )
-                                                                                          (case
-                                                                                            tup-87
-                                                                                            (lam
-                                                                                              l-96
-                                                                                              (lam
-                                                                                                r-97
-                                                                                                r-97
-                                                                                              )
-                                                                                            )
-                                                                                          )
-                                                                                        ]
-                                                                                      ]
-                                                                                    )
-                                                                                  )
-                                                                                )
-                                                                                [
-                                                                                  (builtin
-                                                                                    unConstrData
-                                                                                  )
-                                                                                  [
-                                                                                    (force
-                                                                                      (builtin
-                                                                                        headList
-                                                                                      )
-                                                                                    )
-                                                                                    l-86
-                                                                                  ]
-                                                                                ]
-                                                                              ]
-                                                                            )
-                                                                            (case
-                                                                              [
-                                                                                (builtin
-                                                                                  unConstrData
-                                                                                )
-                                                                                [
-                                                                                  (force
-                                                                                    (builtin
-                                                                                      headList
-                                                                                    )
-                                                                                  )
-                                                                                  (case
-                                                                                    [
-                                                                                      (builtin
-                                                                                        unConstrData
-                                                                                      )
-                                                                                      ds-85
-                                                                                    ]
-                                                                                    (lam
-                                                                                      l-98
-                                                                                      (lam
-                                                                                        r-99
-                                                                                        r-99
-                                                                                      )
-                                                                                    )
-                                                                                  )
-                                                                                ]
-                                                                              ]
+                                                                              index-110
                                                                               (lam
-                                                                                l-100
-                                                                                (lam
-                                                                                  r-101
-                                                                                  r-101
-                                                                                )
+                                                                                args-111
+                                                                                [
+                                                                                  (case
+                                                                                    index-110
+                                                                                    (lam
+                                                                                      ds-112
+                                                                                      (con
+                                                                                        bool
+                                                                                        False
+                                                                                      )
+                                                                                    )
+                                                                                    (lam
+                                                                                      ds-113
+                                                                                      (con
+                                                                                        bool
+                                                                                        True
+                                                                                      )
+                                                                                    )
+                                                                                  )
+                                                                                  args-111
+                                                                                ]
                                                                               )
                                                                             )
-                                                                          ]
+                                                                          )
                                                                         )
                                                                       ]
                                                                     )
                                                                     (lam
-                                                                      ctx-102
+                                                                      ctx-114
                                                                       (case
                                                                         (case
                                                                           (constr
                                                                             0
-                                                                            ctx-102
+                                                                            ctx-114
                                                                             (lam
-                                                                              ds-103
+                                                                              ds-115
                                                                               (lam
-                                                                                ds-104
+                                                                                ds-116
                                                                                 (lam
-                                                                                  ds-105
+                                                                                  ds-117
                                                                                   (case
                                                                                     (constr
                                                                                       0
-                                                                                      ds-103
+                                                                                      ds-115
                                                                                       (lam
-                                                                                        ds-106
+                                                                                        ds-118
                                                                                         (lam
-                                                                                          ds-107
+                                                                                          ds-119
                                                                                           (lam
-                                                                                            ds-108
+                                                                                            ds-120
                                                                                             (lam
-                                                                                              ds-109
+                                                                                              ds-121
                                                                                               (lam
-                                                                                                ds-110
+                                                                                                ds-122
                                                                                                 (lam
-                                                                                                  ds-111
+                                                                                                  ds-123
                                                                                                   (lam
-                                                                                                    ds-112
+                                                                                                    ds-124
                                                                                                     (lam
-                                                                                                      ds-113
+                                                                                                      ds-125
                                                                                                       (lam
-                                                                                                        ds-114
+                                                                                                        ds-126
                                                                                                         (lam
-                                                                                                          ds-115
+                                                                                                          ds-127
                                                                                                           (lam
-                                                                                                            ds-116
+                                                                                                            ds-128
                                                                                                             (lam
-                                                                                                              ds-117
+                                                                                                              ds-129
                                                                                                               (lam
-                                                                                                                ds-118
+                                                                                                                ds-130
                                                                                                                 (lam
-                                                                                                                  ds-119
+                                                                                                                  ds-131
                                                                                                                   (lam
-                                                                                                                    ds-120
+                                                                                                                    ds-132
                                                                                                                     (lam
-                                                                                                                      ds-121
+                                                                                                                      ds-133
                                                                                                                       (case
                                                                                                                         (constr
                                                                                                                           0
-                                                                                                                          ds-105
+                                                                                                                          ds-117
                                                                                                                           (lam
-                                                                                                                            txOutRef-122
+                                                                                                                            txOutRef-134
                                                                                                                             (lam
-                                                                                                                              ds-123
+                                                                                                                              ds-135
                                                                                                                               (case
                                                                                                                                 (constr
                                                                                                                                   0
                                                                                                                                   `$fUnsafeFromDataBuiltinData_$cunsafeFromBuiltinData`-4
                                                                                                                                   (lam
-                                                                                                                                    ds-124
+                                                                                                                                    ds-136
                                                                                                                                     [
                                                                                                                                       [
                                                                                                                                         (builtin
@@ -957,29 +1120,29 @@
                                                                                                                                               (builtin
                                                                                                                                                 unConstrData
                                                                                                                                               )
-                                                                                                                                              ds-124
+                                                                                                                                              ds-136
                                                                                                                                             ]
                                                                                                                                             (lam
-                                                                                                                                              l-125
+                                                                                                                                              l-137
                                                                                                                                               (lam
-                                                                                                                                                r-126
-                                                                                                                                                r-126
+                                                                                                                                                r-138
+                                                                                                                                                r-138
                                                                                                                                               )
                                                                                                                                             )
                                                                                                                                           )
                                                                                                                                         ]
                                                                                                                                       ]
-                                                                                                                                      txOutRef-122
+                                                                                                                                      txOutRef-134
                                                                                                                                     ]
                                                                                                                                   )
-                                                                                                                                  ds-106
+                                                                                                                                  ds-118
                                                                                                                                 )
                                                                                                                                 find-8
                                                                                                                               )
                                                                                                                             )
                                                                                                                           )
                                                                                                                           (lam
-                                                                                                                            void-127
+                                                                                                                            void-139
                                                                                                                             (constr
                                                                                                                               1
                                                                                                                             )
@@ -1004,7 +1167,7 @@
                                                                                         )
                                                                                       )
                                                                                       (lam
-                                                                                        void-128
+                                                                                        void-140
                                                                                         (constr
                                                                                           1
                                                                                         )
@@ -1016,7 +1179,7 @@
                                                                               )
                                                                             )
                                                                             (lam
-                                                                              void-129
+                                                                              void-141
                                                                               (constr
                                                                                 1
                                                                               )
@@ -1025,7 +1188,7 @@
                                                                           `$mScriptContext`-1
                                                                         )
                                                                         (lam
-                                                                          ds-130
+                                                                          ds-142
                                                                           (case
                                                                             (constr
                                                                               0
@@ -1046,29 +1209,29 @@
                                                                                       (builtin
                                                                                         unConstrData
                                                                                       )
-                                                                                      ds-130
+                                                                                      ds-142
                                                                                     ]
                                                                                     (lam
-                                                                                      l-131
+                                                                                      l-143
                                                                                       (lam
-                                                                                        r-132
-                                                                                        r-132
+                                                                                        r-144
+                                                                                        r-144
                                                                                       )
                                                                                     )
                                                                                   )
                                                                                 ]
                                                                               ]
                                                                               (lam
-                                                                                ds-133
+                                                                                ds-145
                                                                                 (lam
-                                                                                  ds-134
+                                                                                  ds-146
                                                                                   (lam
-                                                                                    ds-135
+                                                                                    ds-147
                                                                                     (lam
-                                                                                      ds-136
+                                                                                      ds-148
                                                                                       [
                                                                                         (lam
-                                                                                          tup-137
+                                                                                          tup-149
                                                                                           (case
                                                                                             [
                                                                                               [
@@ -1081,12 +1244,12 @@
                                                                                                 )
                                                                                               ]
                                                                                               (case
-                                                                                                tup-137
+                                                                                                tup-149
                                                                                                 (lam
-                                                                                                  l-138
+                                                                                                  l-150
                                                                                                   (lam
-                                                                                                    r-139
-                                                                                                    l-138
+                                                                                                    r-151
+                                                                                                    l-150
                                                                                                   )
                                                                                                 )
                                                                                               )
@@ -1105,12 +1268,12 @@
                                                                                                   )
                                                                                                 )
                                                                                                 (case
-                                                                                                  tup-137
+                                                                                                  tup-149
                                                                                                   (lam
-                                                                                                    l-140
+                                                                                                    l-152
                                                                                                     (lam
-                                                                                                      r-141
-                                                                                                      r-141
+                                                                                                      r-153
+                                                                                                      r-153
                                                                                                     )
                                                                                                   )
                                                                                                 )
@@ -1133,13 +1296,13 @@
                                                                                                 (builtin
                                                                                                   unConstrData
                                                                                                 )
-                                                                                                ds-133
+                                                                                                ds-145
                                                                                               ]
                                                                                               (lam
-                                                                                                l-142
+                                                                                                l-154
                                                                                                 (lam
-                                                                                                  r-143
-                                                                                                  r-143
+                                                                                                  r-155
+                                                                                                  r-155
                                                                                                 )
                                                                                               )
                                                                                             )
@@ -1151,7 +1314,7 @@
                                                                                 )
                                                                               )
                                                                               (lam
-                                                                                void-144
+                                                                                void-156
                                                                                 (case
                                                                                   (error
 
@@ -1171,20 +1334,20 @@
                                                                   ]
                                                                 )
                                                                 (lam
-                                                                  scrut-145
+                                                                  scrut-157
                                                                   (lam
-                                                                    cont-146
+                                                                    cont-158
                                                                     (lam
-                                                                      fail-147
+                                                                      fail-159
                                                                       [
                                                                         (lam
-                                                                          l-148
+                                                                          l-160
                                                                           [
                                                                             (lam
-                                                                              l-149
+                                                                              l-161
                                                                               [
                                                                                 (lam
-                                                                                  l-150
+                                                                                  l-162
                                                                                   (case
                                                                                     (constr
                                                                                       0
@@ -1194,7 +1357,7 @@
                                                                                             headList
                                                                                           )
                                                                                         )
-                                                                                        l-148
+                                                                                        l-160
                                                                                       ]
                                                                                       [
                                                                                         (builtin
@@ -1206,7 +1369,7 @@
                                                                                               headList
                                                                                             )
                                                                                           )
-                                                                                          l-149
+                                                                                          l-161
                                                                                         ]
                                                                                       ]
                                                                                       [
@@ -1215,7 +1378,7 @@
                                                                                             headList
                                                                                           )
                                                                                         )
-                                                                                        l-150
+                                                                                        l-162
                                                                                       ]
                                                                                       [
                                                                                         [
@@ -1236,12 +1399,12 @@
                                                                                                 tailList
                                                                                               )
                                                                                             )
-                                                                                            l-150
+                                                                                            l-162
                                                                                           ]
                                                                                         ]
                                                                                       ]
                                                                                     )
-                                                                                    cont-146
+                                                                                    cont-158
                                                                                   )
                                                                                 )
                                                                                 [
@@ -1250,7 +1413,7 @@
                                                                                       tailList
                                                                                     )
                                                                                   )
-                                                                                  l-149
+                                                                                  l-161
                                                                                 ]
                                                                               ]
                                                                             )
@@ -1260,7 +1423,7 @@
                                                                                   tailList
                                                                                 )
                                                                               )
-                                                                              l-148
+                                                                              l-160
                                                                             ]
                                                                           ]
                                                                         )
@@ -1269,13 +1432,13 @@
                                                                             (builtin
                                                                               unConstrData
                                                                             )
-                                                                            scrut-145
+                                                                            scrut-157
                                                                           ]
                                                                           (lam
-                                                                            l-151
+                                                                            l-163
                                                                             (lam
-                                                                              r-152
-                                                                              r-152
+                                                                              r-164
+                                                                              r-164
                                                                             )
                                                                           )
                                                                         )
@@ -1286,55 +1449,55 @@
                                                               ]
                                                             )
                                                             (lam
-                                                              void-153 (error)
+                                                              void-165 (error)
                                                             )
                                                           ]
                                                         )
                                                         (lam
-                                                          ds-154
+                                                          ds-166
                                                           (lam
-                                                            ds-155
-                                                            (lam ds-156 ds-154)
+                                                            ds-167
+                                                            (lam ds-168 ds-166)
                                                           )
                                                         )
                                                       ]
                                                     )
-                                                    (lam void-157 (error))
+                                                    (lam void-169 (error))
                                                   ]
                                                 )
                                                 (lam
-                                                  ds-158
+                                                  ds-170
                                                   (lam
-                                                    ds-159
+                                                    ds-171
                                                     (lam
-                                                      ds-160
+                                                      ds-172
                                                       (lam
-                                                        ds-161
+                                                        ds-173
                                                         (lam
-                                                          ds-162
+                                                          ds-174
                                                           (lam
-                                                            ds-163
+                                                            ds-175
                                                             (lam
-                                                              ds-164
+                                                              ds-176
                                                               (lam
-                                                                ds-165
+                                                                ds-177
                                                                 (lam
-                                                                  ds-166
+                                                                  ds-178
                                                                   (lam
-                                                                    ds-167
+                                                                    ds-179
                                                                     (lam
-                                                                      ds-168
+                                                                      ds-180
                                                                       (lam
-                                                                        ds-169
+                                                                        ds-181
                                                                         (lam
-                                                                          ds-170
+                                                                          ds-182
                                                                           (lam
-                                                                            ds-171
+                                                                            ds-183
                                                                             (lam
-                                                                              ds-172
+                                                                              ds-184
                                                                               (lam
-                                                                                ds-173
-                                                                                ds-165
+                                                                                ds-185
+                                                                                ds-177
                                                                               )
                                                                             )
                                                                           )
@@ -1354,45 +1517,45 @@
                                               ]
                                             )
                                             (lam
-                                              ds-174
+                                              ds-186
                                               (lam
-                                                k-175
+                                                k-187
                                                 (case
                                                   (constr
                                                     0
-                                                    ds-174
+                                                    ds-186
                                                     (lam
-                                                      ds-176
+                                                      ds-188
                                                       (lam
-                                                        ds-177
+                                                        ds-189
                                                         (lam
-                                                          ds-178
+                                                          ds-190
                                                           (lam
-                                                            ds-179
+                                                            ds-191
                                                             (lam
-                                                              ds-180
+                                                              ds-192
                                                               (lam
-                                                                ds-181
+                                                                ds-193
                                                                 (lam
-                                                                  ds-182
+                                                                  ds-194
                                                                   (lam
-                                                                    ds-183
+                                                                    ds-195
                                                                     (lam
-                                                                      ds-184
+                                                                      ds-196
                                                                       (lam
-                                                                        ds-185
+                                                                        ds-197
                                                                         (lam
-                                                                          ds-186
+                                                                          ds-198
                                                                           (lam
-                                                                            ds-187
+                                                                            ds-199
                                                                             (lam
-                                                                              ds-188
+                                                                              ds-200
                                                                               (lam
-                                                                                ds-189
+                                                                                ds-201
                                                                                 (lam
-                                                                                  ds-190
+                                                                                  ds-202
                                                                                   (lam
-                                                                                    ds-191
+                                                                                    ds-203
                                                                                     (case
                                                                                       (case
                                                                                         (constr
@@ -1401,23 +1564,23 @@
                                                                                             unBData
                                                                                           )
                                                                                           (lam
-                                                                                            y-192
+                                                                                            y-204
                                                                                             [
                                                                                               [
                                                                                                 (builtin
                                                                                                   equalsByteString
                                                                                                 )
-                                                                                                k-175
+                                                                                                k-187
                                                                                               ]
-                                                                                              y-192
+                                                                                              y-204
                                                                                             ]
                                                                                           )
-                                                                                          ds-184
+                                                                                          ds-196
                                                                                         )
                                                                                         find-8
                                                                                       )
                                                                                       (lam
-                                                                                        ds-193
+                                                                                        ds-205
                                                                                         (con
                                                                                           bool
                                                                                           True
@@ -1445,7 +1608,7 @@
                                                       )
                                                     )
                                                     (lam
-                                                      void-194
+                                                      void-206
                                                       (case (error) (error))
                                                     )
                                                   )
@@ -1456,216 +1619,65 @@
                                           ]
                                         )
                                         (lam
-                                          scrut-195
+                                          scrut-207
                                           (lam
-                                            cont-196
+                                            cont-208
                                             (lam
-                                              fail-197
+                                              fail-209
                                               [
                                                 (lam
-                                                  l-198
+                                                  l-210
                                                   [
                                                     (lam
-                                                      l-199
+                                                      l-211
                                                       [
                                                         (lam
-                                                          l-200
+                                                          l-212
                                                           [
                                                             (lam
-                                                              l-201
+                                                              l-213
                                                               [
                                                                 (lam
-                                                                  l-202
+                                                                  l-214
                                                                   [
                                                                     (lam
-                                                                      l-203
+                                                                      l-215
                                                                       [
                                                                         (lam
-                                                                          l-204
+                                                                          l-216
                                                                           [
                                                                             (lam
-                                                                              l-205
+                                                                              l-217
                                                                               [
                                                                                 (lam
-                                                                                  l-206
+                                                                                  l-218
                                                                                   [
                                                                                     (lam
-                                                                                      l-207
+                                                                                      l-219
                                                                                       [
                                                                                         (lam
-                                                                                          l-208
+                                                                                          l-220
                                                                                           [
                                                                                             (lam
-                                                                                              l-209
+                                                                                              l-221
                                                                                               [
                                                                                                 (lam
-                                                                                                  l-210
+                                                                                                  l-222
                                                                                                   [
                                                                                                     (lam
-                                                                                                      l-211
+                                                                                                      l-223
                                                                                                       [
                                                                                                         (lam
-                                                                                                          l-212
+                                                                                                          l-224
                                                                                                           [
                                                                                                             (lam
-                                                                                                              cse-213
+                                                                                                              cse-225
                                                                                                               (case
                                                                                                                 (constr
                                                                                                                   0
                                                                                                                   [
                                                                                                                     (builtin
                                                                                                                       unListData
-                                                                                                                    )
-                                                                                                                    [
-                                                                                                                      (force
-                                                                                                                        (builtin
-                                                                                                                          headList
-                                                                                                                        )
-                                                                                                                      )
-                                                                                                                      l-198
-                                                                                                                    ]
-                                                                                                                  ]
-                                                                                                                  [
-                                                                                                                    (builtin
-                                                                                                                      unListData
-                                                                                                                    )
-                                                                                                                    [
-                                                                                                                      (force
-                                                                                                                        (builtin
-                                                                                                                          headList
-                                                                                                                        )
-                                                                                                                      )
-                                                                                                                      l-199
-                                                                                                                    ]
-                                                                                                                  ]
-                                                                                                                  [
-                                                                                                                    (builtin
-                                                                                                                      unListData
-                                                                                                                    )
-                                                                                                                    [
-                                                                                                                      (force
-                                                                                                                        (builtin
-                                                                                                                          headList
-                                                                                                                        )
-                                                                                                                      )
-                                                                                                                      l-200
-                                                                                                                    ]
-                                                                                                                  ]
-                                                                                                                  [
-                                                                                                                    (builtin
-                                                                                                                      unIData
-                                                                                                                    )
-                                                                                                                    [
-                                                                                                                      (force
-                                                                                                                        (builtin
-                                                                                                                          headList
-                                                                                                                        )
-                                                                                                                      )
-                                                                                                                      l-201
-                                                                                                                    ]
-                                                                                                                  ]
-                                                                                                                  [
-                                                                                                                    (builtin
-                                                                                                                      unMapData
-                                                                                                                    )
-                                                                                                                    [
-                                                                                                                      (force
-                                                                                                                        (builtin
-                                                                                                                          headList
-                                                                                                                        )
-                                                                                                                      )
-                                                                                                                      l-202
-                                                                                                                    ]
-                                                                                                                  ]
-                                                                                                                  [
-                                                                                                                    (builtin
-                                                                                                                      unListData
-                                                                                                                    )
-                                                                                                                    [
-                                                                                                                      (force
-                                                                                                                        (builtin
-                                                                                                                          headList
-                                                                                                                        )
-                                                                                                                      )
-                                                                                                                      l-203
-                                                                                                                    ]
-                                                                                                                  ]
-                                                                                                                  [
-                                                                                                                    (builtin
-                                                                                                                      unMapData
-                                                                                                                    )
-                                                                                                                    [
-                                                                                                                      (force
-                                                                                                                        (builtin
-                                                                                                                          headList
-                                                                                                                        )
-                                                                                                                      )
-                                                                                                                      l-204
-                                                                                                                    ]
-                                                                                                                  ]
-                                                                                                                  [
-                                                                                                                    (force
-                                                                                                                      (builtin
-                                                                                                                        headList
-                                                                                                                      )
-                                                                                                                    )
-                                                                                                                    l-205
-                                                                                                                  ]
-                                                                                                                  [
-                                                                                                                    (builtin
-                                                                                                                      unListData
-                                                                                                                    )
-                                                                                                                    [
-                                                                                                                      (force
-                                                                                                                        (builtin
-                                                                                                                          headList
-                                                                                                                        )
-                                                                                                                      )
-                                                                                                                      l-206
-                                                                                                                    ]
-                                                                                                                  ]
-                                                                                                                  [
-                                                                                                                    (builtin
-                                                                                                                      unMapData
-                                                                                                                    )
-                                                                                                                    [
-                                                                                                                      (force
-                                                                                                                        (builtin
-                                                                                                                          headList
-                                                                                                                        )
-                                                                                                                      )
-                                                                                                                      l-207
-                                                                                                                    ]
-                                                                                                                  ]
-                                                                                                                  [
-                                                                                                                    (builtin
-                                                                                                                      unMapData
-                                                                                                                    )
-                                                                                                                    [
-                                                                                                                      (force
-                                                                                                                        (builtin
-                                                                                                                          headList
-                                                                                                                        )
-                                                                                                                      )
-                                                                                                                      l-208
-                                                                                                                    ]
-                                                                                                                  ]
-                                                                                                                  [
-                                                                                                                    (builtin
-                                                                                                                      unBData
-                                                                                                                    )
-                                                                                                                    [
-                                                                                                                      (force
-                                                                                                                        (builtin
-                                                                                                                          headList
-                                                                                                                        )
-                                                                                                                      )
-                                                                                                                      l-209
-                                                                                                                    ]
-                                                                                                                  ]
-                                                                                                                  [
-                                                                                                                    (builtin
-                                                                                                                      unMapData
                                                                                                                     )
                                                                                                                     [
                                                                                                                       (force
@@ -1690,7 +1702,9 @@
                                                                                                                     ]
                                                                                                                   ]
                                                                                                                   [
-                                                                                                                    cse-213
+                                                                                                                    (builtin
+                                                                                                                      unListData
+                                                                                                                    )
                                                                                                                     [
                                                                                                                       (force
                                                                                                                         (builtin
@@ -1701,7 +1715,156 @@
                                                                                                                     ]
                                                                                                                   ]
                                                                                                                   [
-                                                                                                                    cse-213
+                                                                                                                    (builtin
+                                                                                                                      unIData
+                                                                                                                    )
+                                                                                                                    [
+                                                                                                                      (force
+                                                                                                                        (builtin
+                                                                                                                          headList
+                                                                                                                        )
+                                                                                                                      )
+                                                                                                                      l-213
+                                                                                                                    ]
+                                                                                                                  ]
+                                                                                                                  [
+                                                                                                                    (builtin
+                                                                                                                      unMapData
+                                                                                                                    )
+                                                                                                                    [
+                                                                                                                      (force
+                                                                                                                        (builtin
+                                                                                                                          headList
+                                                                                                                        )
+                                                                                                                      )
+                                                                                                                      l-214
+                                                                                                                    ]
+                                                                                                                  ]
+                                                                                                                  [
+                                                                                                                    (builtin
+                                                                                                                      unListData
+                                                                                                                    )
+                                                                                                                    [
+                                                                                                                      (force
+                                                                                                                        (builtin
+                                                                                                                          headList
+                                                                                                                        )
+                                                                                                                      )
+                                                                                                                      l-215
+                                                                                                                    ]
+                                                                                                                  ]
+                                                                                                                  [
+                                                                                                                    (builtin
+                                                                                                                      unMapData
+                                                                                                                    )
+                                                                                                                    [
+                                                                                                                      (force
+                                                                                                                        (builtin
+                                                                                                                          headList
+                                                                                                                        )
+                                                                                                                      )
+                                                                                                                      l-216
+                                                                                                                    ]
+                                                                                                                  ]
+                                                                                                                  [
+                                                                                                                    (force
+                                                                                                                      (builtin
+                                                                                                                        headList
+                                                                                                                      )
+                                                                                                                    )
+                                                                                                                    l-217
+                                                                                                                  ]
+                                                                                                                  [
+                                                                                                                    (builtin
+                                                                                                                      unListData
+                                                                                                                    )
+                                                                                                                    [
+                                                                                                                      (force
+                                                                                                                        (builtin
+                                                                                                                          headList
+                                                                                                                        )
+                                                                                                                      )
+                                                                                                                      l-218
+                                                                                                                    ]
+                                                                                                                  ]
+                                                                                                                  [
+                                                                                                                    (builtin
+                                                                                                                      unMapData
+                                                                                                                    )
+                                                                                                                    [
+                                                                                                                      (force
+                                                                                                                        (builtin
+                                                                                                                          headList
+                                                                                                                        )
+                                                                                                                      )
+                                                                                                                      l-219
+                                                                                                                    ]
+                                                                                                                  ]
+                                                                                                                  [
+                                                                                                                    (builtin
+                                                                                                                      unMapData
+                                                                                                                    )
+                                                                                                                    [
+                                                                                                                      (force
+                                                                                                                        (builtin
+                                                                                                                          headList
+                                                                                                                        )
+                                                                                                                      )
+                                                                                                                      l-220
+                                                                                                                    ]
+                                                                                                                  ]
+                                                                                                                  [
+                                                                                                                    (builtin
+                                                                                                                      unBData
+                                                                                                                    )
+                                                                                                                    [
+                                                                                                                      (force
+                                                                                                                        (builtin
+                                                                                                                          headList
+                                                                                                                        )
+                                                                                                                      )
+                                                                                                                      l-221
+                                                                                                                    ]
+                                                                                                                  ]
+                                                                                                                  [
+                                                                                                                    (builtin
+                                                                                                                      unMapData
+                                                                                                                    )
+                                                                                                                    [
+                                                                                                                      (force
+                                                                                                                        (builtin
+                                                                                                                          headList
+                                                                                                                        )
+                                                                                                                      )
+                                                                                                                      l-222
+                                                                                                                    ]
+                                                                                                                  ]
+                                                                                                                  [
+                                                                                                                    (builtin
+                                                                                                                      unListData
+                                                                                                                    )
+                                                                                                                    [
+                                                                                                                      (force
+                                                                                                                        (builtin
+                                                                                                                          headList
+                                                                                                                        )
+                                                                                                                      )
+                                                                                                                      l-223
+                                                                                                                    ]
+                                                                                                                  ]
+                                                                                                                  [
+                                                                                                                    cse-225
+                                                                                                                    [
+                                                                                                                      (force
+                                                                                                                        (builtin
+                                                                                                                          headList
+                                                                                                                        )
+                                                                                                                      )
+                                                                                                                      l-224
+                                                                                                                    ]
+                                                                                                                  ]
+                                                                                                                  [
+                                                                                                                    cse-225
                                                                                                                     [
                                                                                                                       (force
                                                                                                                         (builtin
@@ -1714,12 +1877,12 @@
                                                                                                                             tailList
                                                                                                                           )
                                                                                                                         )
-                                                                                                                        l-212
+                                                                                                                        l-224
                                                                                                                       ]
                                                                                                                     ]
                                                                                                                   ]
                                                                                                                 )
-                                                                                                                cont-196
+                                                                                                                cont-208
                                                                                                               )
                                                                                                             )
                                                                                                             [
@@ -1736,7 +1899,7 @@
                                                                                                               tailList
                                                                                                             )
                                                                                                           )
-                                                                                                          l-211
+                                                                                                          l-223
                                                                                                         ]
                                                                                                       ]
                                                                                                     )
@@ -1746,7 +1909,7 @@
                                                                                                           tailList
                                                                                                         )
                                                                                                       )
-                                                                                                      l-210
+                                                                                                      l-222
                                                                                                     ]
                                                                                                   ]
                                                                                                 )
@@ -1756,7 +1919,7 @@
                                                                                                       tailList
                                                                                                     )
                                                                                                   )
-                                                                                                  l-209
+                                                                                                  l-221
                                                                                                 ]
                                                                                               ]
                                                                                             )
@@ -1766,7 +1929,7 @@
                                                                                                   tailList
                                                                                                 )
                                                                                               )
-                                                                                              l-208
+                                                                                              l-220
                                                                                             ]
                                                                                           ]
                                                                                         )
@@ -1776,7 +1939,7 @@
                                                                                               tailList
                                                                                             )
                                                                                           )
-                                                                                          l-207
+                                                                                          l-219
                                                                                         ]
                                                                                       ]
                                                                                     )
@@ -1786,7 +1949,7 @@
                                                                                           tailList
                                                                                         )
                                                                                       )
-                                                                                      l-206
+                                                                                      l-218
                                                                                     ]
                                                                                   ]
                                                                                 )
@@ -1796,7 +1959,7 @@
                                                                                       tailList
                                                                                     )
                                                                                   )
-                                                                                  l-205
+                                                                                  l-217
                                                                                 ]
                                                                               ]
                                                                             )
@@ -1806,7 +1969,7 @@
                                                                                   tailList
                                                                                 )
                                                                               )
-                                                                              l-204
+                                                                              l-216
                                                                             ]
                                                                           ]
                                                                         )
@@ -1816,7 +1979,7 @@
                                                                               tailList
                                                                             )
                                                                           )
-                                                                          l-203
+                                                                          l-215
                                                                         ]
                                                                       ]
                                                                     )
@@ -1826,7 +1989,7 @@
                                                                           tailList
                                                                         )
                                                                       )
-                                                                      l-202
+                                                                      l-214
                                                                     ]
                                                                   ]
                                                                 )
@@ -1836,7 +1999,7 @@
                                                                       tailList
                                                                     )
                                                                   )
-                                                                  l-201
+                                                                  l-213
                                                                 ]
                                                               ]
                                                             )
@@ -1846,7 +2009,7 @@
                                                                   tailList
                                                                 )
                                                               )
-                                                              l-200
+                                                              l-212
                                                             ]
                                                           ]
                                                         )
@@ -1854,22 +2017,22 @@
                                                           (force
                                                             (builtin tailList)
                                                           )
-                                                          l-199
+                                                          l-211
                                                         ]
                                                       ]
                                                     )
                                                     [
                                                       (force (builtin tailList))
-                                                      l-198
+                                                      l-210
                                                     ]
                                                   ]
                                                 )
                                                 (case
                                                   [
                                                     (builtin unConstrData)
-                                                    scrut-195
+                                                    scrut-207
                                                   ]
-                                                  (lam l-214 (lam r-215 r-215))
+                                                  (lam l-226 (lam r-227 r-227))
                                                 )
                                               ]
                                             )
@@ -1878,41 +2041,41 @@
                                       ]
                                     )
                                     (lam
-                                      `$dUnsafeFromData`-216
+                                      `$dUnsafeFromData`-228
                                       (lam
-                                        pred'-217
+                                        pred'-229
                                         [
                                           (lam
-                                            go-218
-                                            (lam eta-219 [ go-218 eta-219 ])
+                                            go-230
+                                            (lam eta-231 [ go-230 eta-231 ])
                                           )
                                           [
-                                            (lam s-220 [ s-220 s-220 ])
+                                            (lam s-232 [ s-232 s-232 ])
                                             (lam
-                                              s-221
+                                              s-233
                                               (lam
-                                                ds-222
+                                                ds-234
                                                 (case
-                                                  ds-222
+                                                  ds-234
                                                   (lam
-                                                    x-223
+                                                    x-235
                                                     (lam
-                                                      eta-224
+                                                      eta-236
                                                       [
                                                         (lam
-                                                          h-225
+                                                          h-237
                                                           (case
-                                                            [ pred'-217 h-225 ]
+                                                            [ pred'-229 h-237 ]
                                                             [
-                                                              [ s-221 s-221 ]
-                                                              eta-224
+                                                              [ s-233 s-233 ]
+                                                              eta-236
                                                             ]
-                                                            (constr 0 h-225)
+                                                            (constr 0 h-237)
                                                           )
                                                         )
                                                         [
-                                                          `$dUnsafeFromData`-216
-                                                          x-223
+                                                          `$dUnsafeFromData`-228
+                                                          x-235
                                                         ]
                                                       ]
                                                     )
@@ -1935,36 +2098,36 @@
                                     [
                                       cse-2
                                       (lam
-                                        ds-226 (lam ds-227 (lam ds-228 ds-228))
+                                        ds-238 (lam ds-239 (lam ds-240 ds-240))
                                       )
                                     ]
-                                    (lam void-229 (error))
+                                    (lam void-241 (error))
                                   ]
                                   (lam
-                                    ds-230
+                                    ds-242
                                     (lam
-                                      ds-231
+                                      ds-243
                                       (case
-                                        ds-231
+                                        ds-243
                                         (lam
-                                          datum-232
+                                          datum-244
                                           (case
-                                            [ (builtin unConstrData) datum-232 ]
+                                            [ (builtin unConstrData) datum-244 ]
                                             (lam
-                                              index-233
+                                              index-245
                                               (lam
-                                                args-234
+                                                args-246
                                                 [
                                                   (case
-                                                    index-233
+                                                    index-245
                                                     (lam
-                                                      ds-235
+                                                      ds-247
                                                       [
                                                         (lam
-                                                          l-236
+                                                          l-248
                                                           [
                                                             (lam
-                                                              l-237
+                                                              l-249
                                                               (constr
                                                                 0
                                                                 [
@@ -1973,7 +2136,7 @@
                                                                       headList
                                                                     )
                                                                   )
-                                                                  ds-235
+                                                                  ds-247
                                                                 ]
                                                                 [
                                                                   (force
@@ -1981,7 +2144,7 @@
                                                                       headList
                                                                     )
                                                                   )
-                                                                  l-236
+                                                                  l-248
                                                                 ]
                                                                 [
                                                                   (builtin
@@ -1993,7 +2156,7 @@
                                                                         headList
                                                                       )
                                                                     )
-                                                                    l-237
+                                                                    l-249
                                                                   ]
                                                                 ]
                                                                 [
@@ -2012,7 +2175,7 @@
                                                                           tailList
                                                                         )
                                                                       )
-                                                                      l-237
+                                                                      l-249
                                                                     ]
                                                                   ]
                                                                 ]
@@ -2024,7 +2187,7 @@
                                                                   tailList
                                                                 )
                                                               )
-                                                              l-236
+                                                              l-248
                                                             ]
                                                           ]
                                                         )
@@ -2032,12 +2195,12 @@
                                                           (force
                                                             (builtin tailList)
                                                           )
-                                                          ds-235
+                                                          ds-247
                                                         ]
                                                       ]
                                                     )
                                                   )
-                                                  args-234
+                                                  args-246
                                                 ]
                                               )
                                             )
@@ -2047,21 +2210,21 @@
                                       )
                                     )
                                   )
-                                  (lam void-238 (error))
+                                  (lam void-250 (error))
                                 )
                                 `$mSpendingScript`-6
                               )
                             ]
                           )
                           (lam
-                            scrut-239
+                            scrut-251
                             (lam
-                              cont-240
+                              cont-252
                               (lam
-                                fail-241
+                                fail-253
                                 [
                                   (lam
-                                    tup-242
+                                    tup-254
                                     (case
                                       [
                                         [
@@ -2069,18 +2232,18 @@
                                           (con integer 1)
                                         ]
                                         (case
-                                          tup-242 (lam l-243 (lam r-244 l-243))
+                                          tup-254 (lam l-255 (lam r-256 l-255))
                                         )
                                       ]
-                                      [ fail-241 (con unit ()) ]
+                                      [ fail-253 (con unit ()) ]
                                       [
                                         (lam
-                                          l-245
+                                          l-257
                                           [
                                             [
-                                              cont-240
+                                              cont-252
                                               [
-                                                (force (builtin headList)) l-245
+                                                (force (builtin headList)) l-257
                                               ]
                                             ]
                                             [
@@ -2092,19 +2255,19 @@
                                                 (force (builtin headList))
                                                 [
                                                   (force (builtin tailList))
-                                                  l-245
+                                                  l-257
                                                 ]
                                               ]
                                             ]
                                           ]
                                         )
                                         (case
-                                          tup-242 (lam l-246 (lam r-247 r-247))
+                                          tup-254 (lam l-258 (lam r-259 r-259))
                                         )
                                       ]
                                     )
                                   )
-                                  [ (builtin unConstrData) scrut-239 ]
+                                  [ (builtin unConstrData) scrut-251 ]
                                 ]
                               )
                             )
@@ -2112,31 +2275,31 @@
                         ]
                       )
                       (lam
-                        `$dUnsafeFromData`-248
+                        `$dUnsafeFromData`-260
                         (lam
-                          d-249
+                          d-261
                           (case
-                            [ (builtin unConstrData) d-249 ]
+                            [ (builtin unConstrData) d-261 ]
                             (lam
-                              index-250
+                              index-262
                               (lam
-                                args-251
+                                args-263
                                 [
                                   (case
-                                    index-250
+                                    index-262
                                     (lam
-                                      ds-252
+                                      ds-264
                                       (constr
                                         0
                                         [
-                                          `$dUnsafeFromData`-248
-                                          [ (force (builtin headList)) ds-252 ]
+                                          `$dUnsafeFromData`-260
+                                          [ (force (builtin headList)) ds-264 ]
                                         ]
                                       )
                                     )
-                                    (lam ds-253 (constr 1))
+                                    (lam ds-265 (constr 1))
                                   )
-                                  args-251
+                                  args-263
                                 ]
                               )
                             )
@@ -2145,37 +2308,37 @@
                       )
                     ]
                   )
-                  (lam d-254 d-254)
+                  (lam d-266 d-266)
                 ]
               )
               (case
                 [
                   (builtin unConstrData)
                   [
-                    [ cse-2 (lam ds-255 (lam ds-256 (lam ds-257 ds-256))) ]
-                    (lam void-258 (error))
+                    [ cse-2 (lam ds-267 (lam ds-268 (lam ds-269 ds-268))) ]
+                    (lam void-270 (error))
                   ]
                 ]
                 (lam
-                  index-259
+                  index-271
                   (lam
-                    args-260
+                    args-272
                     [
                       (case
-                        index-259
+                        index-271
                         (lam
-                          ds-261
+                          ds-273
                           (constr
                             0
                             [
                               (builtin unBData)
-                              [ (force (builtin headList)) ds-261 ]
+                              [ (force (builtin headList)) ds-273 ]
                             ]
                           )
                         )
-                        (lam ds-262 (constr 1))
+                        (lam ds-274 (constr 1))
                       )
-                      args-260
+                      args-272
                     ]
                   )
                 )
@@ -2186,36 +2349,36 @@
         ]
       )
       (lam
-        scrut-263
+        scrut-275
         (lam
-          cont-264
+          cont-276
           (lam
-            fail-265
+            fail-277
             [
               (lam
-                l-266
+                l-278
                 [
                   (lam
-                    l-267
+                    l-279
                     (case
                       (constr
                         0
-                        [ (force (builtin headList)) l-266 ]
-                        [ (force (builtin headList)) l-267 ]
+                        [ (force (builtin headList)) l-278 ]
+                        [ (force (builtin headList)) l-279 ]
                         [
                           (force (builtin headList))
-                          [ (force (builtin tailList)) l-267 ]
+                          [ (force (builtin tailList)) l-279 ]
                         ]
                       )
-                      cont-264
+                      cont-276
                     )
                   )
-                  [ (force (builtin tailList)) l-266 ]
+                  [ (force (builtin tailList)) l-278 ]
                 ]
               )
               (case
-                [ (builtin unConstrData) scrut-263 ]
-                (lam l-268 (lam r-269 r-269))
+                [ (builtin unConstrData) scrut-275 ]
+                (lam l-280 (lam r-281 r-281))
               )
             ]
           )

--- a/submissions/htlc/Plinth_1.61.0.0_Unisay/metrics.json
+++ b/submissions/htlc/Plinth_1.61.0.0_Unisay/metrics.json
@@ -36,17 +36,17 @@
       "name": "redeemer_claim_without_preimage"
     },
     {
-      "cpu_units": 51674305,
+      "cpu_units": 51803968,
       "description": "Claim at time=50 with correct preimage and recipient signature should succeed",
       "execution_result": "success",
-      "memory_units": 204330,
+      "memory_units": 204662,
       "name": "claim_well_before_timeout"
     },
     {
-      "cpu_units": 51674305,
+      "cpu_units": 51803968,
       "description": "Claim at time=99 (just before timeout=100) with correct preimage should succeed",
       "execution_result": "success",
-      "memory_units": 204330,
+      "memory_units": 204662,
       "name": "claim_just_before_timeout"
     },
     {
@@ -64,59 +64,66 @@
       "name": "refund_well_after_timeout"
     },
     {
-      "cpu_units": 38212995,
+      "cpu_units": 38294658,
       "description": "Claim without recipient signature should fail",
       "execution_result": "success",
-      "memory_units": 147306,
+      "memory_units": 147338,
       "name": "claim_missing_signature"
     },
     {
-      "cpu_units": 38262787,
+      "cpu_units": 38344450,
       "description": "Claim with only payer signature (not recipient) should fail",
       "execution_result": "success",
-      "memory_units": 147339,
+      "memory_units": 147371,
       "name": "claim_wrong_signature_payer"
     },
     {
-      "cpu_units": 38262787,
+      "cpu_units": 38344450,
       "description": "Claim with only impostor signature (not recipient) should fail",
       "execution_result": "success",
-      "memory_units": 147339,
+      "memory_units": 147371,
       "name": "claim_wrong_signature_impostor"
     },
     {
-      "cpu_units": 38585677,
+      "cpu_units": 38667340,
       "description": "Claim with preimage #cafebabe (hash does not match) should fail",
       "execution_result": "success",
-      "memory_units": 147344,
+      "memory_units": 147376,
       "name": "claim_wrong_preimage"
     },
     {
-      "cpu_units": 38585677,
+      "cpu_units": 38667340,
       "description": "Claim with empty preimage (hash does not match) should fail",
       "execution_result": "success",
-      "memory_units": 147344,
+      "memory_units": 147376,
       "name": "claim_empty_preimage"
     },
     {
-      "cpu_units": 38629514,
+      "cpu_units": 38711177,
       "description": "Claim at time=100 (boundary, must be strictly before timeout) should fail",
       "execution_result": "success",
-      "memory_units": 147345,
+      "memory_units": 147377,
       "name": "claim_at_timeout"
     },
     {
-      "cpu_units": 38629514,
+      "cpu_units": 38711177,
       "description": "Claim at time=150 (after timeout) should fail even with correct preimage",
       "execution_result": "success",
-      "memory_units": 147345,
+      "memory_units": 147377,
       "name": "claim_after_timeout"
     },
     {
-      "cpu_units": 53750055,
+      "cpu_units": 38051155,
+      "description": "Claim with from_time=50 and no upper bound (+inf) should fail; the upper bound must be finite",
+      "execution_result": "success",
+      "memory_units": 147211,
+      "name": "claim_infinite_upper_bound"
+    },
+    {
+      "cpu_units": 53831718,
       "description": "Claim with two script inputs should fail (double satisfaction attack)",
       "execution_result": "success",
-      "memory_units": 210010,
+      "memory_units": 210042,
       "name": "claim_double_satisfaction"
     },
     {
@@ -155,6 +162,13 @@
       "name": "refund_at_timeout"
     },
     {
+      "cpu_units": 28467700,
+      "description": "Refund with no lower bound (-inf) should fail; the lower bound must be finite",
+      "execution_result": "success",
+      "memory_units": 105578,
+      "name": "refund_infinite_lower_bound"
+    },
+    {
       "cpu_units": 53323873,
       "description": "Refund with two script inputs should fail (double satisfaction attack)",
       "execution_result": "success",
@@ -166,35 +180,35 @@
     "evaluator": "PlutusTx.Eval-1.52.0.0"
   },
   "measurements": {
-    "block_cpu_budget_pct": 0.1343751375,
-    "block_memory_budget_pct": 0.33872580645161293,
+    "block_cpu_budget_pct": 0.13457929500000002,
+    "block_memory_budget_pct": 0.3387774193548387,
     "cpu_units": {
-      "maximum": 53750055,
-      "median": 38262787,
+      "maximum": 53831718,
+      "median": 38294658,
       "minimum": 24688,
-      "sum": 772991046,
+      "sum": 840422531,
       "sum_negative": 0,
-      "sum_positive": 772991046
+      "sum_positive": 840422531
     },
-    "execution_fee_lovelace": 228956,
+    "execution_fee_lovelace": 248456,
     "memory_units": {
-      "maximum": 210010,
-      "median": 147339,
+      "maximum": 210042,
+      "median": 147338,
       "minimum": 132,
-      "sum": 3002123,
+      "sum": 3255832,
       "sum_negative": 0,
-      "sum_positive": 3002123
+      "sum_positive": 3255832
     },
-    "reference_script_fee_lovelace": 14580,
-    "script_size_bytes": 972,
+    "reference_script_fee_lovelace": 15525,
+    "script_size_bytes": 1035,
     "scripts_per_block": 295,
     "scripts_per_tx": 66,
-    "term_size": 1090,
-    "total_fee_lovelace": 243536,
-    "tx_cpu_budget_pct": 0.53750055,
-    "tx_memory_budget_pct": 1.5000714285714285
+    "term_size": 1161,
+    "total_fee_lovelace": 263981,
+    "tx_cpu_budget_pct": 0.5383171800000001,
+    "tx_memory_budget_pct": 1.5003
   },
   "scenario": "htlc",
-  "timestamp": "2026-04-23T15:01:30Z",
+  "timestamp": "2026-04-24T10:40:46Z",
   "version": "1.0.0"
 }

--- a/test/HTLCSpec.hs
+++ b/test/HTLCSpec.hs
@@ -50,14 +50,14 @@ spec = do
       let ctx = claimContext 150 Fixed.correctPreimage
       expectFailure evaluateValidator ctx
 
-    -- Exercises the exclusive-lowerBound branch of lowerBoundTime:
-    -- LowerBound Finite 99 Exclusive is equivalent to inclusive time=100,
+    -- Exercises the exclusive-upperBound branch of upperBoundTime:
+    -- UpperBound Finite 101 Exclusive is equivalent to inclusive upperBound=100,
     -- which equals the timeout and must be rejected.
-    it "fails with exclusive lower bound at timeout-1 (effective time=100)" do
+    it "fails with exclusive upper bound at timeout+1 (effective upperBound=100)" do
       let range =
             Interval
-              (LowerBound (Finite (POSIXTime 99)) False)
-              (UpperBound PosInf True)
+              (LowerBound NegInf True)
+              (UpperBound (Finite (POSIXTime 101)) False)
           ctx =
             buildContextData $
               ScriptContextBuilder
@@ -70,10 +70,10 @@ spec = do
                 ]
       expectFailure evaluateValidator ctx
 
-    it "fails with non-finite (NegInf) lower bound" do
+    it "fails with non-finite (PosInf) upper bound" do
       let range =
             Interval
-              (LowerBound NegInf True)
+              (LowerBound (Finite (POSIXTime 50)) True)
               (UpperBound PosInf True)
           ctx =
             buildContextData $
@@ -102,7 +102,7 @@ spec = do
                 SpendingBaseline
                 [ SetRedeemer Fixed.claimRedeemer
                 , SetScriptDatum Fixed.htlcDatum
-                , SetValidRange (Just (POSIXTime 50)) Nothing
+                , SetValidRange (Just (POSIXTime 50)) (Just (POSIXTime 50))
                 , AddInputUTXO Fixed.txOutRef Fixed.lockedValue True (OutputDatum Fixed.htlcDatum)
                 ]
       expectFailure evaluateValidator ctx
@@ -115,7 +115,7 @@ spec = do
                 [ SetRedeemer Fixed.claimRedeemer
                 , SetScriptDatum Fixed.htlcDatum
                 , AddSignature Fixed.payerKeyHash
-                , SetValidRange (Just (POSIXTime 50)) Nothing
+                , SetValidRange (Just (POSIXTime 50)) (Just (POSIXTime 50))
                 , AddInputUTXO Fixed.txOutRef Fixed.lockedValue True (OutputDatum Fixed.htlcDatum)
                 ]
       expectFailure evaluateValidator ctx
@@ -128,7 +128,7 @@ spec = do
                 [ SetRedeemer Fixed.claimRedeemer
                 , SetScriptDatum Fixed.htlcDatum
                 , AddSignature Fixed.impostorPubkey
-                , SetValidRange (Just (POSIXTime 50)) Nothing
+                , SetValidRange (Just (POSIXTime 50)) (Just (POSIXTime 50))
                 , AddInputUTXO Fixed.txOutRef Fixed.lockedValue True (OutputDatum Fixed.htlcDatum)
                 ]
       expectFailure evaluateValidator ctx
@@ -141,7 +141,7 @@ spec = do
                 [ SetRedeemer Fixed.claimRedeemer
                 , SetScriptDatum Fixed.htlcDatum
                 , AddSignature Fixed.recipientKeyHash
-                , SetValidRange (Just (POSIXTime 50)) Nothing
+                , SetValidRange (Just (POSIXTime 50)) (Just (POSIXTime 50))
                 , AddInputUTXO Fixed.txOutRef Fixed.lockedValue True (OutputDatum Fixed.htlcDatum)
                 , AddInputUTXO
                     Fixed.txOutRef2
@@ -178,7 +178,7 @@ spec = do
                 [ SetRedeemer Fixed.claimRedeemer
                 , SetScriptDatum Fixed.htlcDatum
                 , AddSignature Fixed.recipientKeyHash
-                , SetValidRange (Just (POSIXTime 50)) Nothing
+                , SetValidRange (Just (POSIXTime 50)) (Just (POSIXTime 50))
                 , AddInputUTXO Fixed.txOutRef Fixed.lockedValue True (OutputDatum Fixed.htlcDatum)
                 , AddInputUTXORaw otherScriptIn
                 ]
@@ -219,6 +219,23 @@ spec = do
 
     it "fails before timeout (time=50)" do
       let ctx = refundContext 50
+      expectFailure evaluateValidator ctx
+
+    it "fails with non-finite (NegInf) lower bound" do
+      let range =
+            Interval
+              (LowerBound NegInf True)
+              (UpperBound PosInf True)
+          ctx =
+            buildContextData $
+              ScriptContextBuilder
+                SpendingBaseline
+                [ SetRedeemer Fixed.refundRedeemer
+                , SetScriptDatum Fixed.htlcDatum
+                , AddSignature Fixed.payerKeyHash
+                , SetValidRangeRaw range
+                , AddInputUTXO Fixed.txOutRef Fixed.lockedValue True (OutputDatum Fixed.htlcDatum)
+                ]
       expectFailure evaluateValidator ctx
 
     it "fails without payer signature" do
@@ -307,7 +324,9 @@ spec = do
 --------------------------------------------------------------------------------
 -- Helpers ---------------------------------------------------------------------
 
--- | Build a Claim context with given time and preimage.
+-- | Build a Claim context with given time and preimage. The validity range
+--   is a point interval @[time, time]@ so the upper bound equals @time@
+--   (claim reads the upper bound of the valid range).
 claimContext :: Integer -> BuiltinByteString -> BuiltinData
 claimContext time preimage =
   buildContextData $
@@ -316,7 +335,7 @@ claimContext time preimage =
       [ SetRedeemer (Fixed.claimRedeemerWith preimage)
       , SetScriptDatum Fixed.htlcDatum
       , AddSignature Fixed.recipientKeyHash
-      , SetValidRange (Just (POSIXTime time)) Nothing
+      , SetValidRange (Just (POSIXTime time)) (Just (POSIXTime time))
       , AddInputUTXO Fixed.txOutRef Fixed.lockedValue True (OutputDatum Fixed.htlcDatum)
       ]
 


### PR DESCRIPTION
## Summary

- Reading the lower bound of `txInfoValidRange` for the HTLC claim path is unsound — an unbounded upper bound (e.g. `[50, +∞)`) lets a tx pass `lowerBound < timeout` even if it is accepted by the node well after the deadline. This PR switches the claim path to the production-safe convention (finite upper bound strictly less than `timeout`); refund keeps the symmetric finite-lower-bound check.
- Spec (`scenarios/htlc/htlc.md`), reference validator (`lib/HTLC.hs`), fixtures (`scenarios/htlc/cape-tests.json`), Hspec suite (`test/HTLCSpec.hs`) are all migrated together. Two new rejection tests land alongside: `claim_infinite_upper_bound` and `refund_infinite_lower_bound`.
- Existing Plinth submissions (1.45 mainnet + 1.61 preview) are regenerated from the updated reference; scripts grow ~140 B (1.45: 1732 → 1872, 1.61: similar) due to the extra upper-bound inspection. No other scenarios' submissions are touched.
- Follow-up issue (to be opened right after): migrate Linear Vesting and Two-Party Escrow to the same convention — they share the old "lower bound for everything" semantics and likely have the same unsoundness on their "before deadline" checks.

## Test plan

- [x] `cabal test cape-tests --test-option='--match=HTLC'` — 27/27 pass
- [x] `cape submission verify submissions/htlc/Plinth_1.45.0.0_Unisay` — 25/25 tests pass
- [x] `cape submission measure --preview submissions/htlc/Plinth_1.61.0.0_Unisay` — completes successfully
- [x] CI green on this PR