### PR TITLE
HTLC: add two coverage tests found by mutation sweep

### DIFF
--- a/test/HTLCSpec.hs
+++ b/test/HTLCSpec.hs
@@ -70,7 +70,11 @@ spec = do
                 ]
       expectFailure evaluateValidator ctx
 
-    it "succeeds with exclusive upper bound just before timeout+1 (effective upperBound=99)" do
+    -- Companion to the test above: same exclusive-upperBound branch,
+    -- but with raw value = timeout (not timeout+1), so the effective
+    -- upper is 99 and the claim must succeed. Pins the `t - 1` offset
+    -- inside upperBoundTime.
+    it "succeeds with exclusive upper bound at timeout (effective upperBound=99)" do
       let range =
             Interval
               (LowerBound NegInf True)

--- a/test/HTLCSpec.hs
+++ b/test/HTLCSpec.hs
@@ -70,6 +70,23 @@ spec = do
                 ]
       expectFailure evaluateValidator ctx
 
+    it "succeeds with exclusive upper bound just before timeout+1 (effective upperBound=99)" do
+      let range =
+            Interval
+              (LowerBound NegInf True)
+              (UpperBound (Finite (POSIXTime 100)) False)
+          ctx =
+            buildContextData $
+              ScriptContextBuilder
+                SpendingBaseline
+                [ SetRedeemer Fixed.claimRedeemer
+                , SetScriptDatum Fixed.htlcDatum
+                , AddSignature Fixed.recipientKeyHash
+                , SetValidRangeRaw range
+                , AddInputUTXO Fixed.txOutRef Fixed.lockedValue True (OutputDatum Fixed.htlcDatum)
+                ]
+      expectSuccess evaluateValidator ctx
+
     it "fails with non-finite (PosInf) upper bound" do
       let range =
             Interval
@@ -181,6 +198,36 @@ spec = do
                 , SetValidRange (Just (POSIXTime 50)) (Just (POSIXTime 50))
                 , AddInputUTXO Fixed.txOutRef Fixed.lockedValue True (OutputDatum Fixed.htlcDatum)
                 , AddInputUTXORaw otherScriptIn
+                ]
+      expectSuccess evaluateValidator ctx
+
+    -- Mirror of the unrelated-script-input test for pubkey co-spends.
+    -- A pubkey input must not trip the double-satisfaction guard; the
+    -- counter only considers ScriptCredential addresses. If the
+    -- credential type-check were dropped, a pubkey input would be
+    -- counted against our script hash and the validator would wrongly
+    -- reject a legitimate multi-input tx.
+    it "succeeds when tx co-spends a pubkey input (non-script)" do
+      let pubkeyAddr =
+            Address (PubKeyCredential Fixed.recipientKeyHash) Nothing
+          pubkeyIn =
+            TxInInfo
+              ( TxOutRef
+                  (TxId "6666666666666666666666666666666666666666666666666666666666666666")
+                  0
+              )
+              ( TxOut pubkeyAddr (lovelaceValue (Lovelace 1_000_000)) NoOutputDatum Nothing
+              )
+          ctx =
+            buildContextData $
+              ScriptContextBuilder
+                SpendingBaseline
+                [ SetRedeemer Fixed.claimRedeemer
+                , SetScriptDatum Fixed.htlcDatum
+                , AddSignature Fixed.recipientKeyHash
+                , SetValidRange (Just (POSIXTime 50)) (Just (POSIXTime 50))
+                , AddInputUTXO Fixed.txOutRef Fixed.lockedValue True (OutputDatum Fixed.htlcDatum)
+                , AddInputUTXORaw pubkeyIn
                 ]
       expectSuccess evaluateValidator ctx
 


### PR DESCRIPTION
## Summary

Follow-up to #170. A Haiku mutation-testing pass (16 mutations across `validateClaim` / `validateRefund` / `upperBoundTime` / `lowerBoundTime` / `countScriptInputs` / `extractPubKeyHash`) surfaced two survived mutants that weren't pinned by the existing suite:

- `upperBoundTime` mapping `Finite t False → t - 1`: dropping the `-1` kept the existing tests green because they only exercised the exactly-at-timeout case. Add a positive test where an exclusive upper bound one step below timeout (effective `upperBound = 99`) must succeed — asymmetric to the existing `(Finite 101) False → effective 100 → fail` test.
- `countScriptInputs` fallthrough `_ -> acc`: flipping to `_ -> acc + 1` would miscount pubkey inputs as our script input. Add a positive test where a pubkey input is co-spent alongside the script input and the claim must still succeed.

Net: 27 → 29 HTLC tests. No validator changes.

## Test plan

- [x] `cabal test cape-tests --test-option='--match=HTLC'` — 29/29 pass
- [x] CI green on this PR