### PR TITLE
feat(submissions): add Scalus 0.16.0 HTLC submission by Unisay

### DIFF
--- a/submissions/htlc/Scalus_0.16.0_Unisay/README.md
+++ b/submissions/htlc/Scalus_0.16.0_Unisay/README.md
@@ -1,0 +1,23 @@
+# Benchmark Implementation Notes
+
+**Scenario**: `htlc`
+
+**Submission ID**: `Scalus_0.16.0_Unisay`
+
+## Implementation Details
+
+- **Compiler**: `Scalus 0.16.0`
+- **Implementation Approach**: `idiomatic @Compile spending validator, Data -> Unit, derived FromData/ToData`
+- **Compilation Flags**: `default`
+
+## Performance Results
+
+- See [metrics.json](metrics.json) for detailed performance measurements
+
+## Source Code
+
+- See [source/README.md](source/README.md) for source code and reproducibility instructions
+
+## Notes
+
+Scalus spending validator matching the production-safe validity-range convention introduced in #170: claim reads the upper bound of `txInfoValidRange` (finite, strictly `< timeout`); refund reads the lower bound (finite, strictly `> timeout`). Datum and redeemer shapes are identical to the Plinth reference (`HTLCDatum = 0(payer, recipient, secretHash, timeout)`; `Claim(preimage) = 0(preimage)`, `Refund = 1()`). The source is maintained in a separate repository to avoid duplication.

--- a/submissions/htlc/Scalus_0.16.0_Unisay/htlc.uplc
+++ b/submissions/htlc/Scalus_0.16.0_Unisay/htlc.uplc
@@ -1,594 +1,439 @@
-(program 1.1.0 [(lam __Z
-      [(lam scalus_cardano_onchain_plutus_prelude_List__find28
-          [(lam scalus_cardano_onchain_plutus_prelude_Option__isEmpty44
-              [(lam scalus_cardano_onchain_plutus_prelude_List__contains55
-                  [(lam scalus_uplc_builtin_ByteString__given_Eq_ByteString59
-                      [(lam scalus_cardano_onchain_plutus_v1_PubKeyHash__given_Eq_PubKeyHash63
-                          [(lam scalus_cardano_onchain_plutus_v3_TxInfo__isSignedBy79
-                              [(lam htlc_HtlcValidator__extractPkh88
-                                  [(lam htlc_HtlcValidator__upperBoundExclusive100
-                                      [(lam scalus_cardano_onchain_plutus_prelude_List__foldLeft101
-                                          [(lam scalus_cardano_onchain_plutus_prelude_List__count141
-                                              [(lam htlc_HtlcValidator__countScriptInputs162
-                                                  [(lam scalus_cardano_onchain_plutus_v3_TxId__given_Eq_TxId166
-                                                      [(lam scalus_cardano_onchain_plutus_prelude_Eq__given_Eq_BigInt170
-                                                          [(lam scalus_cardano_onchain_plutus_v3_TxOutRef__given_Eq_TxOutRef175
-                                                              [(lam scalus_cardano_onchain_plutus_v3_Utils__findInput186
-                                                                  [(lam scalus_cardano_onchain_plutus_v3_TxInfo__findOwnInput190
-                                                                      [(lam htlc_HtlcValidator__extractScriptHash199
-                                                                          [(lam htlc_HtlcValidator__ownScriptHash211
-                                                                              [(lam htlc_HtlcValidator__validateClaim225
-                                                                                  [(lam htlc_HtlcValidator__lowerBoundInclusive237
-                                                                                      [(lam htlc_HtlcValidator__validateRefund248
-                                                                                          [(lam htlc_HtlcValidator__validate283
-                                                                                              (lam scData-30465284
-                                                                                                [htlc_HtlcValidator__validate283
-                                                                                                  scData-30465284]))
-                                                                                            (lam scData-15677249
-                                                                                              [(lam ctx-15678250
-                                                                                                  [(lam _match_scrutinee253
-                                                                                                      (force [(force (builtin ifThenElse))
-                                                                                                        [(builtin equalsInteger)
-                                                                                                          [(force (force (builtin fstPair)))
-                                                                                                            _match_scrutinee253]
-                                                                                                          (con integer 1)]
-                                                                                                        (delay [(lam _match_datalist256
-                                                                                                            [(lam datum-27523265
-                                                                                                                [(lam _match_scrutinee267
-                                                                                                                    (force [(force (builtin ifThenElse))
-                                                                                                                      [(builtin equalsInteger)
-                                                                                                                        [(force (force (builtin fstPair)))
-                                                                                                                          _match_scrutinee267]
-                                                                                                                        (con integer 0)]
-                                                                                                                      (delay [htlc_HtlcValidator__validateClaim225
-                                                                                                                        [(force (force (builtin sndPair)))
-                                                                                                                          [(builtin unConstrData)
-                                                                                                                            [(force (builtin headList))
-                                                                                                                              [(force (force (builtin sndPair)))
-                                                                                                                                [(builtin unConstrData)
-                                                                                                                                  ctx-15678250]]]]]
-                                                                                                                        [(force (force (builtin sndPair)))
-                                                                                                                          [(builtin unConstrData)
-                                                                                                                            [(force (builtin headList))
-                                                                                                                              _match_datalist256]]]
-                                                                                                                        datum-27523265
-                                                                                                                        [(builtin unBData)
-                                                                                                                          [(force (builtin headList))
-                                                                                                                            [(force (force (builtin sndPair)))
-                                                                                                                              _match_scrutinee267]]]])
-                                                                                                                      (delay [htlc_HtlcValidator__validateRefund248
-                                                                                                                        [(force (force (builtin sndPair)))
-                                                                                                                          [(builtin unConstrData)
-                                                                                                                            [(force (builtin headList))
-                                                                                                                              [(force (force (builtin sndPair)))
-                                                                                                                                [(builtin unConstrData)
-                                                                                                                                  ctx-15678250]]]]]
-                                                                                                                        [(force (force (builtin sndPair)))
-                                                                                                                          [(builtin unConstrData)
-                                                                                                                            [(force (builtin headList))
-                                                                                                                              _match_datalist256]]]
-                                                                                                                        datum-27523265])]))
-                                                                                                                  [(builtin unConstrData)
-                                                                                                                    [(force (builtin headList))
-                                                                                                                      [(force (builtin tailList))
-                                                                                                                        [(force (force (builtin sndPair)))
-                                                                                                                          [(builtin unConstrData)
-                                                                                                                            ctx-15678250]]]]]])
-                                                                                                              [(lam _match_scrutinee260
-                                                                                                                  [(lam _match_datalist256_t
-                                                                                                                      (force [(force (builtin ifThenElse))
-                                                                                                                        [(builtin equalsInteger)
-                                                                                                                          [(force (force (builtin fstPair)))
-                                                                                                                            _match_scrutinee260]
-                                                                                                                          (con integer 0)]
-                                                                                                                        (delay [(force (force (builtin sndPair)))
-                                                                                                                          [(builtin unConstrData)
-                                                                                                                            [(force (builtin headList))
-                                                                                                                              [(force (force (builtin sndPair)))
-                                                                                                                                _match_scrutinee260]]]])
-                                                                                                                        (delay (force [(force (builtin trace))
-                                                                                                                          (con string "Missing HTLC datum")
-                                                                                                                          (delay (error))]))]))
-                                                                                                                    [(force (builtin tailList))
-                                                                                                                      _match_datalist256]])
-                                                                                                                [(builtin unConstrData)
-                                                                                                                  [(force (builtin headList))
-                                                                                                                    [(force (builtin tailList))
-                                                                                                                      _match_datalist256]]]]])
-                                                                                                          [(force (force (builtin sndPair)))
-                                                                                                            _match_scrutinee253]])
-                                                                                                        (delay (force [(force (builtin trace))
-                                                                                                          (con string "Expected SpendingScript")
-                                                                                                          (delay (error))]))]))
-                                                                                                    [(builtin unConstrData)
-                                                                                                      [(force (builtin headList))
-                                                                                                        [(force (builtin tailList))
-                                                                                                          [(force (builtin tailList))
-                                                                                                            [(force (force (builtin sndPair)))
-                                                                                                              [(builtin unConstrData)
-                                                                                                                ctx-15678250]]]]]]])
-                                                                                                scData-15677249])])
-                                                                                        (lam tx-27590238
-                                                                                          (lam ownRef-27591239
-                                                                                            (lam d-27592240
-                                                                                              [(lam __HTLC_line_88-0242
-                                                                                                  [(lam __HTLC_line_89-0244
-                                                                                                      (force [(force (builtin ifThenElse))
-                                                                                                        [(builtin equalsInteger)
-                                                                                                          [htlc_HtlcValidator__countScriptInputs162
-                                                                                                            tx-27590238
-                                                                                                            [htlc_HtlcValidator__ownScriptHash211
-                                                                                                              tx-27590238
-                                                                                                              ownRef-27591239]]
-                                                                                                          (con integer 1)]
-                                                                                                        (delay (con unit ()))
-                                                                                                        (delay (force [(force (builtin trace))
-                                                                                                          (con string "Double satisfaction")
-                                                                                                          (delay (error))]))]))
-                                                                                                    (force [(force (builtin ifThenElse))
-                                                                                                      [(builtin lessThanInteger)
-                                                                                                        [(builtin unIData)
-                                                                                                          [(force (builtin headList))
-                                                                                                            [(force (builtin tailList))
-                                                                                                              [(force (builtin tailList))
-                                                                                                                [(force (builtin tailList))
-                                                                                                                  d-27592240]]]]]
-                                                                                                        [htlc_HtlcValidator__lowerBoundInclusive237
-                                                                                                          [(force (force (builtin sndPair)))
-                                                                                                            [(builtin unConstrData)
-                                                                                                              [(force (builtin headList))
-                                                                                                                [(force (builtin tailList))
-                                                                                                                  [(force (builtin tailList))
-                                                                                                                    [(force (builtin tailList))
-                                                                                                                      [(force (builtin tailList))
-                                                                                                                        [(force (builtin tailList))
-                                                                                                                          [(force (builtin tailList))
-                                                                                                                            [(force (builtin tailList))
-                                                                                                                              tx-27590238]]]]]]]]]]]]
-                                                                                                      (delay (con unit ()))
-                                                                                                      (delay (force [(force (builtin trace))
-                                                                                                        (con string "Refund not permitted at or before timeout")
-                                                                                                        (delay (error))]))])])
-                                                                                                (force [(force (builtin ifThenElse))
-                                                                                                  [scalus_cardano_onchain_plutus_v3_TxInfo__isSignedBy79
-                                                                                                    tx-27590238
-                                                                                                    [htlc_HtlcValidator__extractPkh88
-                                                                                                      [(force (force (builtin sndPair)))
-                                                                                                        [(builtin unConstrData)
-                                                                                                          [(force (builtin headList))
-                                                                                                            d-27592240]]]]]
-                                                                                                  (delay (con unit ()))
-                                                                                                  (delay (force [(force (builtin trace))
-                                                                                                    (con string "Missing payer signature")
-                                                                                                    (delay (error))]))])])))])
-                                                                                    (lam r-27747226
-                                                                                      [(lam _match_scrutinee229
-                                                                                          (force [(force (builtin ifThenElse))
-                                                                                            [(builtin equalsInteger)
-                                                                                              [(force (force (builtin fstPair)))
-                                                                                                _match_scrutinee229]
-                                                                                              (con integer 1)]
-                                                                                            (delay [(lam _match_datalist232
-                                                                                                (force [(force (builtin ifThenElse))
-                                                                                                  (force [(force (builtin ifThenElse))
-                                                                                                    [(builtin equalsInteger)
-                                                                                                      [(force (force (builtin fstPair)))
-                                                                                                        [(builtin unConstrData)
-                                                                                                          [(force (builtin headList))
-                                                                                                            [(force (builtin tailList))
-                                                                                                              [(force (force (builtin sndPair)))
-                                                                                                                [(builtin unConstrData)
-                                                                                                                  [(force (builtin headList))
-                                                                                                                    r-27747226]]]]]]]
-                                                                                                      (con integer 0)]
-                                                                                                    (delay (con bool False))
-                                                                                                    (delay (con bool True))])
-                                                                                                  (delay [(builtin unIData)
-                                                                                                    [(force (builtin headList))
-                                                                                                      _match_datalist232]])
-                                                                                                  (delay [(builtin addInteger)
-                                                                                                    [(builtin unIData)
-                                                                                                      [(force (builtin headList))
-                                                                                                        _match_datalist232]]
-                                                                                                    (con integer 1)])]))
-                                                                                              [(force (force (builtin sndPair)))
-                                                                                                _match_scrutinee229]])
-                                                                                            (delay (force [(force (builtin trace))
-                                                                                              (con string "Refund requires a finite lower bound")
-                                                                                              (delay (error))]))]))
-                                                                                        [(builtin unConstrData)
-                                                                                          [(force (builtin headList))
-                                                                                            [(force (force (builtin sndPair)))
-                                                                                              [(builtin unConstrData)
-                                                                                                [(force (builtin headList))
-                                                                                                  r-27747226]]]]]])])
-                                                                                (lam tx-27586212
-                                                                                  (lam ownRef-27587213
-                                                                                    (lam d-27588214
-                                                                                      (lam preimage-27589215
-                                                                                        [(lam __HTLC_line_79-0217
-                                                                                            [(lam __HTLC_line_80-0219
-                                                                                                [(lam __HTLC_line_81-0221
-                                                                                                    (force [(force (builtin ifThenElse))
-                                                                                                      [(builtin equalsInteger)
-                                                                                                        [htlc_HtlcValidator__countScriptInputs162
-                                                                                                          tx-27586212
-                                                                                                          [htlc_HtlcValidator__ownScriptHash211
-                                                                                                            tx-27586212
-                                                                                                            ownRef-27587213]]
-                                                                                                        (con integer 1)]
-                                                                                                      (delay (con unit ()))
-                                                                                                      (delay (force [(force (builtin trace))
-                                                                                                        (con string "Double satisfaction")
-                                                                                                        (delay (error))]))]))
-                                                                                                  (force [(force (builtin ifThenElse))
-                                                                                                    [(builtin lessThanInteger)
-                                                                                                      [htlc_HtlcValidator__upperBoundExclusive100
-                                                                                                        [(force (force (builtin sndPair)))
-                                                                                                          [(builtin unConstrData)
-                                                                                                            [(force (builtin headList))
-                                                                                                              [(force (builtin tailList))
-                                                                                                                [(force (builtin tailList))
-                                                                                                                  [(force (builtin tailList))
-                                                                                                                    [(force (builtin tailList))
-                                                                                                                      [(force (builtin tailList))
-                                                                                                                        [(force (builtin tailList))
-                                                                                                                          [(force (builtin tailList))
-                                                                                                                            tx-27586212]]]]]]]]]]]
-                                                                                                      [(builtin unIData)
-                                                                                                        [(force (builtin headList))
-                                                                                                          [(force (builtin tailList))
-                                                                                                            [(force (builtin tailList))
-                                                                                                              [(force (builtin tailList))
-                                                                                                                d-27588214]]]]]]
-                                                                                                    (delay (con unit ()))
-                                                                                                    (delay (force [(force (builtin trace))
-                                                                                                      (con string "Claim not permitted at or after timeout")
-                                                                                                      (delay (error))]))])])
-                                                                                              (force [(force (builtin ifThenElse))
-                                                                                                [scalus_cardano_onchain_plutus_v3_TxInfo__isSignedBy79
-                                                                                                  tx-27586212
-                                                                                                  [htlc_HtlcValidator__extractPkh88
-                                                                                                    [(force (force (builtin sndPair)))
-                                                                                                      [(builtin unConstrData)
-                                                                                                        [(force (builtin headList))
-                                                                                                          [(force (builtin tailList))
-                                                                                                            d-27588214]]]]]]
-                                                                                                (delay (con unit ()))
-                                                                                                (delay (force [(force (builtin trace))
-                                                                                                  (con string "Missing recipient signature")
-                                                                                                  (delay (error))]))])])
-                                                                                          (force [(force (builtin ifThenElse))
-                                                                                            [(builtin equalsByteString)
-                                                                                              [(builtin sha2_256)
-                                                                                                preimage-27589215]
-                                                                                              [(builtin unBData)
-                                                                                                [(force (builtin headList))
-                                                                                                  [(force (builtin tailList))
-                                                                                                    [(force (builtin tailList))
-                                                                                                      d-27588214]]]]]
-                                                                                            (delay (con unit ()))
-                                                                                            (delay (force [(force (builtin trace))
-                                                                                              (con string "Preimage does not match stored hash")
-                                                                                              (delay (error))]))])]))))])
-                                                                            (lam tx-27695200
-                                                                              (lam ownRef-27696201
-                                                                                [(lam _match_scrutinee204
-                                                                                    (force [(force (builtin ifThenElse))
-                                                                                      [(builtin equalsInteger)
-                                                                                        [(force (force (builtin fstPair)))
-                                                                                          _match_scrutinee204]
-                                                                                        (con integer 0)]
-                                                                                      (delay [htlc_HtlcValidator__extractScriptHash199
-                                                                                        [(force (force (builtin sndPair)))
-                                                                                          [(builtin unConstrData)
-                                                                                            [(force (builtin headList))
-                                                                                              [(force (force (builtin sndPair)))
-                                                                                                [(builtin unConstrData)
-                                                                                                  [(force (builtin headList))
-                                                                                                    [(force (builtin tailList))
-                                                                                                      [(force (force (builtin sndPair)))
-                                                                                                        [(builtin unConstrData)
-                                                                                                          [(force (builtin headList))
-                                                                                                            [(force (force (builtin sndPair)))
-                                                                                                              _match_scrutinee204]]]]]]]]]]]])
-                                                                                      (delay (force [(force (builtin trace))
-                                                                                        (con string "Own input not found")
-                                                                                        (delay (error))]))]))
-                                                                                  [(builtin unConstrData)
-                                                                                    [scalus_cardano_onchain_plutus_v3_TxInfo__findOwnInput190
-                                                                                      tx-27695200
-                                                                                      ownRef-27696201]]]))])
-                                                                        (lam addr-27836191
-                                                                          [(lam _match_scrutinee193
-                                                                              (force [(force (builtin ifThenElse))
-                                                                                [(builtin equalsInteger)
-                                                                                  [(force (force (builtin fstPair)))
-                                                                                    _match_scrutinee193]
-                                                                                  (con integer 1)]
-                                                                                (delay [(builtin unBData)
-                                                                                  [(force (builtin headList))
-                                                                                    [(force (force (builtin sndPair)))
-                                                                                      _match_scrutinee193]]])
-                                                                                (delay (force [(force (builtin trace))
-                                                                                  (con string "Expected ScriptCredential")
-                                                                                  (delay (error))]))]))
-                                                                            [(builtin unConstrData)
-                                                                              [(force (builtin headList))
-                                                                                addr-27836191]]])])
-                                                                    (lam self-305431187
-                                                                      (lam outRef-305432188
-                                                                        [scalus_cardano_onchain_plutus_v3_Utils__findInput186
-                                                                          [(builtin unListData)
-                                                                            [(force (builtin headList))
-                                                                              self-305431187]]
-                                                                          outRef-305432188]))])
-                                                                (lam inputs-305446176
-                                                                  (lam outRef-305447177
-                                                                    [(lam xIn178
-                                                                        [scalus_cardano_onchain_plutus_prelude_List__find28
-                                                                          inputs-305446176
-                                                                          (lam xIn179
-                                                                            [xIn178
-                                                                              [(force (force (builtin sndPair)))
+(program 1.1.0 (case (constr 0 (force (force (builtin chooseList)))
+      (force (force (builtin fstPair))) (force (builtin headList))
+      (force (builtin ifThenElse)) (force (builtin mkCons))
+      (force (force (builtin sndPair))) (force (builtin tailList))
+      (force (builtin trace))) (lam a
+      (lam b
+        (lam c
+          (lam d
+            (lam e
+              (lam f
+                (lam g
+                  (lam h
+                    [(lam i
+                        [(lam j
+                            [(lam k
+                                [(lam l
+                                    [(lam m
+                                        [(lam n
+                                            [(lam o
+                                                (lam p
+                                                  [(lam q
+                                                      (force (case (constr 0 [(builtin equalsInteger)
+                                                            [b q]
+                                                            (con integer 1)]
+                                                          (delay [(lam r
+                                                              [(lam s
+                                                                  [(lam t
+                                                                      (force (case (constr 0 [(builtin equalsInteger)
+                                                                            [b
+                                                                              t]
+                                                                            (con integer 0)]
+                                                                          (delay (case (constr 0 [f
                                                                                 [(builtin unConstrData)
-                                                                                  xIn179]]])])
-                                                                      (lam __12-305531183
-                                                                        [scalus_cardano_onchain_plutus_v3_TxOutRef__given_Eq_TxOutRef175
-                                                                          [(force (force (builtin sndPair)))
+                                                                                  [c
+                                                                                    [f
+                                                                                      [(builtin unConstrData)
+                                                                                        p]]]]]
+                                                                              [f
+                                                                                [(builtin unConstrData)
+                                                                                  [c
+                                                                                    r]]]
+                                                                              s
+                                                                              [(builtin unBData)
+                                                                                [c
+                                                                                  [f
+                                                                                    t]]]) (lam u
+                                                                              (lam v
+                                                                                (lam w
+                                                                                  (lam x
+                                                                                    [(lam y
+                                                                                        [(lam z
+                                                                                            [(lam aa
+                                                                                                (force (case (constr 0 [(builtin equalsInteger)
+                                                                                                      [n
+                                                                                                        u
+                                                                                                        [o
+                                                                                                          u
+                                                                                                          v]]
+                                                                                                      (con integer 1)]
+                                                                                                    (delay (con unit ()))
+                                                                                                    (delay (force [h
+                                                                                                      (con string "Double satisfaction")
+                                                                                                      (delay (error))]))) d)))
+                                                                                              (force (case (constr 0 [(builtin lessThanInteger)
+                                                                                                    [(lam ab
+                                                                                                        [(lam ac
+                                                                                                            (force (case (constr 0 [(builtin equalsInteger)
+                                                                                                                  [b
+                                                                                                                    ac]
+                                                                                                                  (con integer 1)]
+                                                                                                                (delay [(lam ad
+                                                                                                                    (force (case (constr 0 (case (constr 0 [(builtin equalsInteger)
+                                                                                                                              [b
+                                                                                                                                [(builtin unConstrData)
+                                                                                                                                  [c
+                                                                                                                                    [g
+                                                                                                                                      [f
+                                                                                                                                        [(builtin unConstrData)
+                                                                                                                                          [c
+                                                                                                                                            [g
+                                                                                                                                              ab]]]]]]]]
+                                                                                                                              (con integer 0)]
+                                                                                                                            (con bool False)
+                                                                                                                            (con bool True)) d)
+                                                                                                                        (delay [(builtin unIData)
+                                                                                                                          [c
+                                                                                                                            ad]])
+                                                                                                                        (delay [(builtin subtractInteger)
+                                                                                                                          [(builtin unIData)
+                                                                                                                            [c
+                                                                                                                              ad]]
+                                                                                                                          (con integer 1)])) d)))
+                                                                                                                  [f
+                                                                                                                    ac]])
+                                                                                                                (delay (force [h
+                                                                                                                  (con string "Claim requires a finite upper bound")
+                                                                                                                  (delay (error))]))) d)))
+                                                                                                          [(builtin unConstrData)
+                                                                                                            [c
+                                                                                                              [f
+                                                                                                                [(builtin unConstrData)
+                                                                                                                  [c
+                                                                                                                    [g
+                                                                                                                      ab]]]]]]])
+                                                                                                      [f
+                                                                                                        [(builtin unConstrData)
+                                                                                                          [c
+                                                                                                            [g
+                                                                                                              [g
+                                                                                                                [g
+                                                                                                                  [g
+                                                                                                                    [g
+                                                                                                                      [g
+                                                                                                                        [g
+                                                                                                                          u]]]]]]]]]]]
+                                                                                                    [(builtin unIData)
+                                                                                                      [c
+                                                                                                        [g
+                                                                                                          [g
+                                                                                                            [g
+                                                                                                              w]]]]]]
+                                                                                                  (delay (con unit ()))
+                                                                                                  (delay (force [h
+                                                                                                    (con string "Claim not permitted at or after timeout")
+                                                                                                    (delay (error))]))) d))])
+                                                                                          (force (case (constr 0 [k
+                                                                                                u
+                                                                                                [l
+                                                                                                  [f
+                                                                                                    [(builtin unConstrData)
+                                                                                                      [c
+                                                                                                        [g
+                                                                                                          w]]]]]]
+                                                                                              (delay (con unit ()))
+                                                                                              (delay (force [h
+                                                                                                (con string "Missing recipient signature")
+                                                                                                (delay (error))]))) d))])
+                                                                                      (force (case (constr 0 [(builtin equalsByteString)
+                                                                                            [(builtin sha2_256)
+                                                                                              x]
+                                                                                            [(builtin unBData)
+                                                                                              [c
+                                                                                                [g
+                                                                                                  [g
+                                                                                                    w]]]]]
+                                                                                          (delay (con unit ()))
+                                                                                          (delay (force [h
+                                                                                            (con string "Preimage does not match stored hash")
+                                                                                            (delay (error))]))) d))]))))))
+                                                                          (delay (case (constr 0 [f
+                                                                                [(builtin unConstrData)
+                                                                                  [c
+                                                                                    [f
+                                                                                      [(builtin unConstrData)
+                                                                                        p]]]]]
+                                                                              [f
+                                                                                [(builtin unConstrData)
+                                                                                  [c
+                                                                                    r]]]
+                                                                              s) (lam ae
+                                                                              (lam af
+                                                                                (lam ag
+                                                                                  [(lam ah
+                                                                                      [(lam ai
+                                                                                          (force (case (constr 0 [(builtin equalsInteger)
+                                                                                                [n
+                                                                                                  ae
+                                                                                                  [o
+                                                                                                    ae
+                                                                                                    af]]
+                                                                                                (con integer 1)]
+                                                                                              (delay (con unit ()))
+                                                                                              (delay (force [h
+                                                                                                (con string "Double satisfaction")
+                                                                                                (delay (error))]))) d)))
+                                                                                        (force (case (constr 0 [(builtin lessThanInteger)
+                                                                                              [(builtin unIData)
+                                                                                                [c
+                                                                                                  [g
+                                                                                                    [g
+                                                                                                      [g
+                                                                                                        ag]]]]]
+                                                                                              [(lam aj
+                                                                                                  [(lam ak
+                                                                                                      (force (case (constr 0 [(builtin equalsInteger)
+                                                                                                            [b
+                                                                                                              ak]
+                                                                                                            (con integer 1)]
+                                                                                                          (delay [(lam al
+                                                                                                              (force (case (constr 0 (case (constr 0 [(builtin equalsInteger)
+                                                                                                                        [b
+                                                                                                                          [(builtin unConstrData)
+                                                                                                                            [c
+                                                                                                                              [g
+                                                                                                                                [f
+                                                                                                                                  [(builtin unConstrData)
+                                                                                                                                    [c
+                                                                                                                                      aj]]]]]]]
+                                                                                                                        (con integer 0)]
+                                                                                                                      (con bool False)
+                                                                                                                      (con bool True)) d)
+                                                                                                                  (delay [(builtin unIData)
+                                                                                                                    [c
+                                                                                                                      al]])
+                                                                                                                  (delay [(builtin addInteger)
+                                                                                                                    [(builtin unIData)
+                                                                                                                      [c
+                                                                                                                        al]]
+                                                                                                                    (con integer 1)])) d)))
+                                                                                                            [f
+                                                                                                              ak]])
+                                                                                                          (delay (force [h
+                                                                                                            (con string "Refund requires a finite lower bound")
+                                                                                                            (delay (error))]))) d)))
+                                                                                                    [(builtin unConstrData)
+                                                                                                      [c
+                                                                                                        [f
+                                                                                                          [(builtin unConstrData)
+                                                                                                            [c
+                                                                                                              aj]]]]]])
+                                                                                                [f
+                                                                                                  [(builtin unConstrData)
+                                                                                                    [c
+                                                                                                      [g
+                                                                                                        [g
+                                                                                                          [g
+                                                                                                            [g
+                                                                                                              [g
+                                                                                                                [g
+                                                                                                                  [g
+                                                                                                                    ae]]]]]]]]]]]]
+                                                                                            (delay (con unit ()))
+                                                                                            (delay (force [h
+                                                                                              (con string "Refund not permitted at or before timeout")
+                                                                                              (delay (error))]))) d))])
+                                                                                    (force (case (constr 0 [k
+                                                                                          ae
+                                                                                          [l
+                                                                                            [f
+                                                                                              [(builtin unConstrData)
+                                                                                                [c
+                                                                                                  ag]]]]]
+                                                                                        (delay (con unit ()))
+                                                                                        (delay (force [h
+                                                                                          (con string "Missing payer signature")
+                                                                                          (delay (error))]))) d))])))))) d)))
+                                                                    [(builtin unConstrData)
+                                                                      [c [g [f
                                                                             [(builtin unConstrData)
-                                                                              [(force (builtin headList))
-                                                                                __12-305531183]]]
-                                                                          outRef-305447177])]))])
-                                                            (lam a-303790171
-                                                              (lam b-303791172
-                                                                (force [(force (builtin ifThenElse))
-                                                                  [scalus_cardano_onchain_plutus_v3_TxId__given_Eq_TxId166
-                                                                    [(builtin unBData)
-                                                                      [(force (builtin headList))
-                                                                        a-303790171]]
-                                                                    [(builtin unBData)
-                                                                      [(force (builtin headList))
-                                                                        b-303791172]]]
-                                                                  (delay [scalus_cardano_onchain_plutus_prelude_Eq__given_Eq_BigInt170
-                                                                    [(builtin unIData)
-                                                                      [(force (builtin headList))
-                                                                        [(force (builtin tailList))
-                                                                          a-303790171]]]
-                                                                    [(builtin unIData)
-                                                                      [(force (builtin headList))
-                                                                        [(force (builtin tailList))
-                                                                          b-303791172]]]])
-                                                                  (delay (con bool False))])))])
-                                                        (lam x-88106167
-                                                          (lam y-88107168
-                                                            [(builtin equalsInteger)
-                                                              x-88106167
-                                                              y-88107168]))])
-                                                    (lam a-303746163
-                                                      (lam b-303747164
-                                                        [scalus_uplc_builtin_ByteString__given_Eq_ByteString59
-                                                          a-303746163
-                                                          b-303747164]))])
-                                                (lam tx-27693142
-                                                  (lam scriptHash-27694143
-                                                    [(lam xIn144
-                                                        [scalus_cardano_onchain_plutus_prelude_List__count141
-                                                          [(builtin unListData)
-                                                            [(force (builtin headList))
-                                                              tx-27693142]]
-                                                          (lam xIn145
-                                                            [xIn144
-                                                              [(force (force (builtin sndPair)))
-                                                                [(builtin unConstrData)
-                                                                  xIn145]]])])
-                                                      (lam i-28278149
-                                                        [(lam _match_scrutinee153
-                                                            (force [(force (builtin ifThenElse))
-                                                              [(builtin equalsInteger)
-                                                                [(force (force (builtin fstPair)))
-                                                                  _match_scrutinee153]
-                                                                (con integer 1)]
-                                                              (delay [(builtin equalsByteString)
-                                                                [(builtin unBData)
-                                                                  [(force (builtin headList))
-                                                                    [(force (force (builtin sndPair)))
-                                                                      _match_scrutinee153]]]
-                                                                scriptHash-27694143])
-                                                              (delay (con bool False))]))
+                                                                              p]]]]]])
+                                                                [(lam am
+                                                                    [(lam an
+                                                                        (force (case (constr 0 [(builtin equalsInteger)
+                                                                              [b
+                                                                                am]
+                                                                              (con integer 0)]
+                                                                            (delay [f
+                                                                              [(builtin unConstrData)
+                                                                                [c
+                                                                                  [f
+                                                                                    am]]]])
+                                                                            (delay (force [h
+                                                                              (con string "Missing HTLC datum")
+                                                                              (delay (error))]))) d)))
+                                                                      [g r]])
+                                                                  [(builtin unConstrData)
+                                                                    [c [g
+                                                                        r]]]]])
+                                                            [f q]])
+                                                          (delay (force [h
+                                                            (con string "Expected SpendingScript")
+                                                            (delay (error))]))) d)))
+                                                    [(builtin unConstrData) [c
+                                                        [g [g [f
+                                                              [(builtin unConstrData)
+                                                                p]]]]]]]))
+                                              (lam ao
+                                                (lam ap
+                                                  [(lam aq
+                                                      (force (case (constr 0 [(builtin equalsInteger)
+                                                            [b aq]
+                                                            (con integer 0)]
+                                                          (delay [(lam ar
+                                                              (force (case (constr 0 [(builtin equalsInteger)
+                                                                    [b ar]
+                                                                    (con integer 1)]
+                                                                  (delay [(builtin unBData)
+                                                                    [c [f ar]]])
+                                                                  (delay (force [h
+                                                                    (con string "Expected ScriptCredential")
+                                                                    (delay (error))]))) d)))
+                                                            [(builtin unConstrData)
+                                                              [c [f
+                                                                  [(builtin unConstrData)
+                                                                    [c [f
+                                                                        [(builtin unConstrData)
+                                                                          [c [g
+                                                                              [f
+                                                                                [(builtin unConstrData)
+                                                                                  [c
+                                                                                    [f
+                                                                                      aq]]]]]]]]]]]]]])
+                                                          (delay (force [h
+                                                            (con string "Own input not found")
+                                                            (delay (error))]))) d)))
+                                                    [(builtin unConstrData)
+                                                      [(lam as
+                                                          (lam at
+                                                            [j as (lam au
+                                                                [(lam av
+                                                                    (lam aw
+                                                                      (force (case (constr 0 [(builtin equalsByteString)
+                                                                            [(builtin unBData)
+                                                                              [c
+                                                                                av]]
+                                                                            [(builtin unBData)
+                                                                              [c
+                                                                                aw]]]
+                                                                          (delay [(builtin equalsInteger)
+                                                                            [(builtin unIData)
+                                                                              [c
+                                                                                [g
+                                                                                  av]]]
+                                                                            [(builtin unIData)
+                                                                              [c
+                                                                                [g
+                                                                                  aw]]]])
+                                                                          (delay (con bool False))) d))))
+                                                                  [f
+                                                                    [(builtin unConstrData)
+                                                                      [c [f
+                                                                          [(builtin unConstrData)
+                                                                            au]]]]]
+                                                                  at])]))
+                                                        [(builtin unListData) [c
+                                                            ao]] ap]]]))])
+                                          (lam ax
+                                            (lam ay
+                                              [(lam az
+                                                  (lam ba
+                                                    [(builtin unIData)
+                                                      (case (constr 0 az
+                                                          (con data (I 0))
+                                                          (lam bb
+                                                            (lam bc
+                                                              [(lam bd
+                                                                  (lam be
+                                                                    [(builtin iData)
+                                                                      (force (case (constr 0 [ba
+                                                                            be]
+                                                                          (delay [(builtin addInteger)
+                                                                            bd
+                                                                            (con integer 1)])
+                                                                          (delay bd)) d))]))
+                                                                [(builtin unIData)
+                                                                  bb]
+                                                                bc]))) m)]))
+                                                [(builtin unListData) [c ax]]
+                                                (lam bf
+                                                  [(lam bg
+                                                      (force (case (constr 0 [(builtin equalsInteger)
+                                                            [b bg]
+                                                            (con integer 1)]
+                                                          (delay [(builtin equalsByteString)
+                                                            [(builtin unBData)
+                                                              [c [f bg]]] ay])
+                                                          (delay (con bool False))) d)))
+                                                    [(builtin unConstrData) [c
+                                                        [f
                                                           [(builtin unConstrData)
-                                                            [(force (builtin headList))
-                                                              [(force (force (builtin sndPair)))
+                                                            [c [f
                                                                 [(builtin unConstrData)
-                                                                  [(force (builtin headList))
-                                                                    [(force (force (builtin sndPair)))
-                                                                      [(builtin unConstrData)
-                                                                        [(force (builtin headList))
-                                                                          [(force (builtin tailList))
-                                                                            i-28278149]]]]]]]]]])]))])
-                                            (lam self-90574120
-                                              (lam p-90575121
-                                                [(lam xIn127
-                                                    [(builtin unIData)
-                                                      [(lam xIn122
-                                                          (lam xIn123
-                                                            [scalus_cardano_onchain_plutus_prelude_List__foldLeft101
-                                                              self-90574120
-                                                              xIn122 xIn123]))
-                                                        (con data (I 0))
-                                                        (lam x131132
-                                                          (lam x134135
-                                                            [(lam xIn128
-                                                                [(lam xIn128r129
-                                                                    (lam xIn130
-                                                                      [(builtin iData)
-                                                                        [xIn127
-                                                                          xIn128r129
-                                                                          xIn130]]))
-                                                                  [(builtin unIData)
-                                                                    xIn128]])
-                                                              x131132
-                                                              x134135]))]])
-                                                  (lam counter-90577136
-                                                    (lam elem-90578137
-                                                      (force [(force (builtin ifThenElse))
-                                                        [p-90575121
-                                                          elem-90578137]
-                                                        (delay [(builtin addInteger)
-                                                          counter-90577136
-                                                          (con integer 1)])
-                                                        (delay counter-90577136)])))]))])
-                                        [__Z
-                                          (lam scalus_cardano_onchain_plutus_prelude_List__foldLeft101
-                                            (lam self-86666102
-                                              (lam init-86668103
-                                                (lam combiner-86669104
-                                                  [(lam listInput105
-                                                      (force [(force (force (builtin chooseList)))
-                                                        listInput105
-                                                        (delay init-86668103)
-                                                        (delay [(lam consTail107
-                                                            [(lam consHead106
-                                                                (lam xIn114
-                                                                  [(lam xIn108
-                                                                      (lam xIn109
-                                                                        [scalus_cardano_onchain_plutus_prelude_List__foldLeft101
-                                                                          consTail107
-                                                                          xIn108
-                                                                          xIn109]))
-                                                                    [combiner-86669104
-                                                                      init-86668103
-                                                                      consHead106]
-                                                                    xIn114]))
-                                                              [(force (builtin headList))
-                                                                listInput105]])
-                                                          [(force (builtin tailList))
-                                                            listInput105]
-                                                          combiner-86669104])]))
-                                                    self-86666102]))))]])
-                                    (lam r-2769289
-                                      [(lam _match_scrutinee92
-                                          (force [(force (builtin ifThenElse))
-                                            [(builtin equalsInteger)
-                                              [(force (force (builtin fstPair)))
-                                                _match_scrutinee92]
-                                              (con integer 1)]
-                                            (delay [(lam _match_datalist95
-                                                (force [(force (builtin ifThenElse))
-                                                  (force [(force (builtin ifThenElse))
-                                                    [(builtin equalsInteger)
-                                                      [(force (force (builtin fstPair)))
-                                                        [(builtin unConstrData)
-                                                          [(force (builtin headList))
-                                                            [(force (builtin tailList))
-                                                              [(force (force (builtin sndPair)))
-                                                                [(builtin unConstrData)
-                                                                  [(force (builtin headList))
-                                                                    [(force (builtin tailList))
-                                                                      r-2769289]]]]]]]]
-                                                      (con integer 0)]
-                                                    (delay (con bool False))
-                                                    (delay (con bool True))])
-                                                  (delay [(builtin unIData)
-                                                    [(force (builtin headList))
-                                                      _match_datalist95]])
-                                                  (delay [(builtin subtractInteger)
-                                                    [(builtin unIData)
-                                                      [(force (builtin headList))
-                                                        _match_datalist95]]
-                                                    (con integer 1)])]))
-                                              [(force (force (builtin sndPair)))
-                                                _match_scrutinee92]])
-                                            (delay (force [(force (builtin trace))
-                                              (con string "Claim requires a finite upper bound")
-                                              (delay (error))]))]))
-                                        [(builtin unConstrData)
-                                          [(force (builtin headList))
-                                            [(force (force (builtin sndPair)))
-                                              [(builtin unConstrData)
-                                                [(force (builtin headList))
-                                                  [(force (builtin tailList))
-                                                    r-2769289]]]]]]])])
-                                (lam addr-2769180
-                                  [(lam _match_scrutinee82
-                                      (force [(force (builtin ifThenElse))
-                                        [(builtin equalsInteger)
-                                          [(force (force (builtin fstPair)))
-                                            _match_scrutinee82] (con integer 0)]
-                                        (delay [(builtin unBData)
-                                          [(force (builtin headList))
-                                            [(force (force (builtin sndPair)))
-                                              _match_scrutinee82]]])
-                                        (delay (force [(force (builtin trace))
-                                          (con string "Expected PubKeyCredential")
-                                          (delay (error))]))]))
-                                    [(builtin unConstrData)
-                                      [(force (builtin headList))
-                                        addr-2769180]]])]) (lam self-30547764
-                              (lam pubKeyHash-30547865
-                                [(lam pubKeyHash_305478r71
-                                    (lam xIn72
-                                      [(lam xIn66
-                                          (lam xIn67
-                                            [scalus_cardano_onchain_plutus_prelude_List__contains55
-                                              [(builtin unListData)
-                                                [(force (builtin headList))
-                                                  [(force (builtin tailList))
-                                                    [(force (builtin tailList))
-                                                      [(force (builtin tailList))
-                                                        [(force (builtin tailList))
-                                                          [(force (builtin tailList))
-                                                            [(force (builtin tailList))
-                                                              [(force (builtin tailList))
-                                                                [(force (builtin tailList))
-                                                                  self-30547764]]]]]]]]]]
-                                              xIn66 xIn67]))
-                                        pubKeyHash_305478r71 (lam xIn73
-                                          [(lam xIn73r74
-                                              (lam xIn75
-                                                [xIn72 xIn73r74
-                                                  [(builtin unBData) xIn75]]))
-                                            [(builtin unBData) xIn73]])]))
-                                  [(builtin bData) pubKeyHash-30547865]
-                                  scalus_cardano_onchain_plutus_v1_PubKeyHash__given_Eq_PubKeyHash63]))])
-                        (lam a-30281160
-                          (lam b-30281261
-                            [scalus_uplc_builtin_ByteString__given_Eq_ByteString59
-                              a-30281160 b-30281261]))]) (lam x-13839556
-                      (lam y-13839657
-                        [(builtin equalsByteString) x-13839556 y-13839657]))])
-                (lam self-9039345
-                  (lam elem-9039546
-                    (lam eq-9039647
-                      [(lam self_proxy6-21259854
-                          (force [(force (builtin ifThenElse))
-                            [scalus_cardano_onchain_plutus_prelude_Option__isEmpty44
-                              self_proxy6-21259854] (delay (con bool False))
-                            (delay (con bool True))])) [(lam xIn48
-                            [scalus_cardano_onchain_plutus_prelude_List__find28
-                              self-9039345 xIn48]) (lam __1-21260051
-                            [eq-9039647 __1-21260051 elem-9039546])]])))])
-            (lam self-9098438
-              (force [(force (builtin ifThenElse)) [(builtin equalsInteger)
-                  [(force (force (builtin fstPair))) [(builtin unConstrData)
-                      self-9098438]] (con integer 0)] (delay (con bool False))
-                (delay (con bool True))]))]) [__Z
-          (lam scalus_cardano_onchain_plutus_prelude_List__find28
-            (lam self-9039929
-              (lam predicate-9040030
-                [(lam listInput31
-                    (force [(force (force (builtin chooseList))) listInput31
-                      (delay [(builtin constrData) (con integer 1)
-                        (con (list data) [])])
-                      (delay (force [(force (builtin ifThenElse))
-                        [predicate-9040030 [(force (builtin headList))
-                            listInput31]] (delay [(builtin constrData)
-                          (con integer 0) [(force (builtin mkCons))
-                            [(force (builtin headList)) listInput31]
-                            (con (list data) [])]]) (delay [(lam consTail33
-                            (lam xIn34
-                              [scalus_cardano_onchain_plutus_prelude_List__find28
-                                consTail33 xIn34])) [(force (builtin tailList))
-                            listInput31] predicate-9040030])]))]))
-                  self-9039929])))]]) (lam ff
-      [(lam xx [ff (lam vv [xx xx vv])]) (lam xx [ff (lam vv [xx xx vv])])])])
+                                                                  [c [g [f
+                                                                        [(builtin unConstrData)
+                                                                          bf]]]]]]]]]]]])]))])
+                                      [i (lam m
+                                          (lam bh
+                                            (lam bi
+                                              (lam bj
+                                                (force (case (constr 0 bh
+                                                    (delay bi) (delay [(lam bk
+                                                        [(lam bl
+                                                            (lam bm
+                                                              [(lam bn
+                                                                  (lam bo
+                                                                    (case (constr 0 bk
+                                                                        bn
+                                                                        bo) m)))
+                                                                [bj bi bl] bm]))
+                                                          [c bh]]) [g bh]
+                                                      bj])) a))))))]]) (lam bp
+                                    [(lam bq
+                                        (force (case (constr 0 [(builtin equalsInteger)
+                                              [b bq] (con integer 0)]
+                                            (delay [(builtin unBData) [c [f
+                                                  bq]]]) (delay (force [h
+                                              (con string "Expected PubKeyCredential")
+                                              (delay (error))]))) d)))
+                                      [(builtin unConstrData) [c bp]]])])
+                              (lam br
+                                (lam bs
+                                  [(lam bt
+                                      (lam bu
+                                        (case (constr 0 [(builtin unListData) [c
+                                                [g [g [g [g [g [g [g [g
+                                                                br]]]]]]]]]] bt
+                                            (lam bv
+                                              [(lam bw
+                                                  (lam bx
+                                                    [bu bw [(builtin unBData)
+                                                        bx]]))
+                                                [(builtin unBData)
+                                                  bv]])) (lam by
+                                            (lam bz
+                                              (lam ca
+                                                (case (constr 0 (case (constr 0 [(builtin equalsInteger)
+                                                          [b
+                                                            [(builtin unConstrData)
+                                                              [j by (lam cb
+                                                                  [ca cb bz])]]]
+                                                          (con integer 0)]
+                                                        (con bool False)
+                                                        (con bool True)) d)
+                                                    (con bool False)
+                                                    (con bool True)) d)))))))
+                                    [(builtin bData) bs]
+                                    (builtin equalsByteString)]))]) [i (lam j
+                              (lam cc
+                                (lam cd
+                                  (force (case (constr 0 cc
+                                      (delay (con data (Constr 1 [])))
+                                      (delay (force (case (constr 0 [cd [c cc]]
+                                          (delay [(builtin constrData)
+                                            (con integer 0) [e [c cc]
+                                              (con (list data) [])]])
+                                          (delay [(lam ce (lam cf [j ce cf])) [g
+                                              cc] cd])) d)))) a)))))]]) (lam cg
+                        [(lam ch [cg (lam ci [ch ch ci])]) (lam ch
+                            [cg (lam ci [ch ch ci])])])]))))))))))

--- a/submissions/htlc/Scalus_0.16.0_Unisay/htlc.uplc
+++ b/submissions/htlc/Scalus_0.16.0_Unisay/htlc.uplc
@@ -1,0 +1,594 @@
+(program 1.1.0 [(lam __Z
+      [(lam scalus_cardano_onchain_plutus_prelude_List__find28
+          [(lam scalus_cardano_onchain_plutus_prelude_Option__isEmpty44
+              [(lam scalus_cardano_onchain_plutus_prelude_List__contains55
+                  [(lam scalus_uplc_builtin_ByteString__given_Eq_ByteString59
+                      [(lam scalus_cardano_onchain_plutus_v1_PubKeyHash__given_Eq_PubKeyHash63
+                          [(lam scalus_cardano_onchain_plutus_v3_TxInfo__isSignedBy79
+                              [(lam htlc_HtlcValidator__extractPkh88
+                                  [(lam htlc_HtlcValidator__upperBoundExclusive100
+                                      [(lam scalus_cardano_onchain_plutus_prelude_List__foldLeft101
+                                          [(lam scalus_cardano_onchain_plutus_prelude_List__count141
+                                              [(lam htlc_HtlcValidator__countScriptInputs162
+                                                  [(lam scalus_cardano_onchain_plutus_v3_TxId__given_Eq_TxId166
+                                                      [(lam scalus_cardano_onchain_plutus_prelude_Eq__given_Eq_BigInt170
+                                                          [(lam scalus_cardano_onchain_plutus_v3_TxOutRef__given_Eq_TxOutRef175
+                                                              [(lam scalus_cardano_onchain_plutus_v3_Utils__findInput186
+                                                                  [(lam scalus_cardano_onchain_plutus_v3_TxInfo__findOwnInput190
+                                                                      [(lam htlc_HtlcValidator__extractScriptHash199
+                                                                          [(lam htlc_HtlcValidator__ownScriptHash211
+                                                                              [(lam htlc_HtlcValidator__validateClaim225
+                                                                                  [(lam htlc_HtlcValidator__lowerBoundInclusive237
+                                                                                      [(lam htlc_HtlcValidator__validateRefund248
+                                                                                          [(lam htlc_HtlcValidator__validate283
+                                                                                              (lam scData-30465284
+                                                                                                [htlc_HtlcValidator__validate283
+                                                                                                  scData-30465284]))
+                                                                                            (lam scData-15677249
+                                                                                              [(lam ctx-15678250
+                                                                                                  [(lam _match_scrutinee253
+                                                                                                      (force [(force (builtin ifThenElse))
+                                                                                                        [(builtin equalsInteger)
+                                                                                                          [(force (force (builtin fstPair)))
+                                                                                                            _match_scrutinee253]
+                                                                                                          (con integer 1)]
+                                                                                                        (delay [(lam _match_datalist256
+                                                                                                            [(lam datum-27523265
+                                                                                                                [(lam _match_scrutinee267
+                                                                                                                    (force [(force (builtin ifThenElse))
+                                                                                                                      [(builtin equalsInteger)
+                                                                                                                        [(force (force (builtin fstPair)))
+                                                                                                                          _match_scrutinee267]
+                                                                                                                        (con integer 0)]
+                                                                                                                      (delay [htlc_HtlcValidator__validateClaim225
+                                                                                                                        [(force (force (builtin sndPair)))
+                                                                                                                          [(builtin unConstrData)
+                                                                                                                            [(force (builtin headList))
+                                                                                                                              [(force (force (builtin sndPair)))
+                                                                                                                                [(builtin unConstrData)
+                                                                                                                                  ctx-15678250]]]]]
+                                                                                                                        [(force (force (builtin sndPair)))
+                                                                                                                          [(builtin unConstrData)
+                                                                                                                            [(force (builtin headList))
+                                                                                                                              _match_datalist256]]]
+                                                                                                                        datum-27523265
+                                                                                                                        [(builtin unBData)
+                                                                                                                          [(force (builtin headList))
+                                                                                                                            [(force (force (builtin sndPair)))
+                                                                                                                              _match_scrutinee267]]]])
+                                                                                                                      (delay [htlc_HtlcValidator__validateRefund248
+                                                                                                                        [(force (force (builtin sndPair)))
+                                                                                                                          [(builtin unConstrData)
+                                                                                                                            [(force (builtin headList))
+                                                                                                                              [(force (force (builtin sndPair)))
+                                                                                                                                [(builtin unConstrData)
+                                                                                                                                  ctx-15678250]]]]]
+                                                                                                                        [(force (force (builtin sndPair)))
+                                                                                                                          [(builtin unConstrData)
+                                                                                                                            [(force (builtin headList))
+                                                                                                                              _match_datalist256]]]
+                                                                                                                        datum-27523265])]))
+                                                                                                                  [(builtin unConstrData)
+                                                                                                                    [(force (builtin headList))
+                                                                                                                      [(force (builtin tailList))
+                                                                                                                        [(force (force (builtin sndPair)))
+                                                                                                                          [(builtin unConstrData)
+                                                                                                                            ctx-15678250]]]]]])
+                                                                                                              [(lam _match_scrutinee260
+                                                                                                                  [(lam _match_datalist256_t
+                                                                                                                      (force [(force (builtin ifThenElse))
+                                                                                                                        [(builtin equalsInteger)
+                                                                                                                          [(force (force (builtin fstPair)))
+                                                                                                                            _match_scrutinee260]
+                                                                                                                          (con integer 0)]
+                                                                                                                        (delay [(force (force (builtin sndPair)))
+                                                                                                                          [(builtin unConstrData)
+                                                                                                                            [(force (builtin headList))
+                                                                                                                              [(force (force (builtin sndPair)))
+                                                                                                                                _match_scrutinee260]]]])
+                                                                                                                        (delay (force [(force (builtin trace))
+                                                                                                                          (con string "Missing HTLC datum")
+                                                                                                                          (delay (error))]))]))
+                                                                                                                    [(force (builtin tailList))
+                                                                                                                      _match_datalist256]])
+                                                                                                                [(builtin unConstrData)
+                                                                                                                  [(force (builtin headList))
+                                                                                                                    [(force (builtin tailList))
+                                                                                                                      _match_datalist256]]]]])
+                                                                                                          [(force (force (builtin sndPair)))
+                                                                                                            _match_scrutinee253]])
+                                                                                                        (delay (force [(force (builtin trace))
+                                                                                                          (con string "Expected SpendingScript")
+                                                                                                          (delay (error))]))]))
+                                                                                                    [(builtin unConstrData)
+                                                                                                      [(force (builtin headList))
+                                                                                                        [(force (builtin tailList))
+                                                                                                          [(force (builtin tailList))
+                                                                                                            [(force (force (builtin sndPair)))
+                                                                                                              [(builtin unConstrData)
+                                                                                                                ctx-15678250]]]]]]])
+                                                                                                scData-15677249])])
+                                                                                        (lam tx-27590238
+                                                                                          (lam ownRef-27591239
+                                                                                            (lam d-27592240
+                                                                                              [(lam __HTLC_line_88-0242
+                                                                                                  [(lam __HTLC_line_89-0244
+                                                                                                      (force [(force (builtin ifThenElse))
+                                                                                                        [(builtin equalsInteger)
+                                                                                                          [htlc_HtlcValidator__countScriptInputs162
+                                                                                                            tx-27590238
+                                                                                                            [htlc_HtlcValidator__ownScriptHash211
+                                                                                                              tx-27590238
+                                                                                                              ownRef-27591239]]
+                                                                                                          (con integer 1)]
+                                                                                                        (delay (con unit ()))
+                                                                                                        (delay (force [(force (builtin trace))
+                                                                                                          (con string "Double satisfaction")
+                                                                                                          (delay (error))]))]))
+                                                                                                    (force [(force (builtin ifThenElse))
+                                                                                                      [(builtin lessThanInteger)
+                                                                                                        [(builtin unIData)
+                                                                                                          [(force (builtin headList))
+                                                                                                            [(force (builtin tailList))
+                                                                                                              [(force (builtin tailList))
+                                                                                                                [(force (builtin tailList))
+                                                                                                                  d-27592240]]]]]
+                                                                                                        [htlc_HtlcValidator__lowerBoundInclusive237
+                                                                                                          [(force (force (builtin sndPair)))
+                                                                                                            [(builtin unConstrData)
+                                                                                                              [(force (builtin headList))
+                                                                                                                [(force (builtin tailList))
+                                                                                                                  [(force (builtin tailList))
+                                                                                                                    [(force (builtin tailList))
+                                                                                                                      [(force (builtin tailList))
+                                                                                                                        [(force (builtin tailList))
+                                                                                                                          [(force (builtin tailList))
+                                                                                                                            [(force (builtin tailList))
+                                                                                                                              tx-27590238]]]]]]]]]]]]
+                                                                                                      (delay (con unit ()))
+                                                                                                      (delay (force [(force (builtin trace))
+                                                                                                        (con string "Refund not permitted at or before timeout")
+                                                                                                        (delay (error))]))])])
+                                                                                                (force [(force (builtin ifThenElse))
+                                                                                                  [scalus_cardano_onchain_plutus_v3_TxInfo__isSignedBy79
+                                                                                                    tx-27590238
+                                                                                                    [htlc_HtlcValidator__extractPkh88
+                                                                                                      [(force (force (builtin sndPair)))
+                                                                                                        [(builtin unConstrData)
+                                                                                                          [(force (builtin headList))
+                                                                                                            d-27592240]]]]]
+                                                                                                  (delay (con unit ()))
+                                                                                                  (delay (force [(force (builtin trace))
+                                                                                                    (con string "Missing payer signature")
+                                                                                                    (delay (error))]))])])))])
+                                                                                    (lam r-27747226
+                                                                                      [(lam _match_scrutinee229
+                                                                                          (force [(force (builtin ifThenElse))
+                                                                                            [(builtin equalsInteger)
+                                                                                              [(force (force (builtin fstPair)))
+                                                                                                _match_scrutinee229]
+                                                                                              (con integer 1)]
+                                                                                            (delay [(lam _match_datalist232
+                                                                                                (force [(force (builtin ifThenElse))
+                                                                                                  (force [(force (builtin ifThenElse))
+                                                                                                    [(builtin equalsInteger)
+                                                                                                      [(force (force (builtin fstPair)))
+                                                                                                        [(builtin unConstrData)
+                                                                                                          [(force (builtin headList))
+                                                                                                            [(force (builtin tailList))
+                                                                                                              [(force (force (builtin sndPair)))
+                                                                                                                [(builtin unConstrData)
+                                                                                                                  [(force (builtin headList))
+                                                                                                                    r-27747226]]]]]]]
+                                                                                                      (con integer 0)]
+                                                                                                    (delay (con bool False))
+                                                                                                    (delay (con bool True))])
+                                                                                                  (delay [(builtin unIData)
+                                                                                                    [(force (builtin headList))
+                                                                                                      _match_datalist232]])
+                                                                                                  (delay [(builtin addInteger)
+                                                                                                    [(builtin unIData)
+                                                                                                      [(force (builtin headList))
+                                                                                                        _match_datalist232]]
+                                                                                                    (con integer 1)])]))
+                                                                                              [(force (force (builtin sndPair)))
+                                                                                                _match_scrutinee229]])
+                                                                                            (delay (force [(force (builtin trace))
+                                                                                              (con string "Refund requires a finite lower bound")
+                                                                                              (delay (error))]))]))
+                                                                                        [(builtin unConstrData)
+                                                                                          [(force (builtin headList))
+                                                                                            [(force (force (builtin sndPair)))
+                                                                                              [(builtin unConstrData)
+                                                                                                [(force (builtin headList))
+                                                                                                  r-27747226]]]]]])])
+                                                                                (lam tx-27586212
+                                                                                  (lam ownRef-27587213
+                                                                                    (lam d-27588214
+                                                                                      (lam preimage-27589215
+                                                                                        [(lam __HTLC_line_79-0217
+                                                                                            [(lam __HTLC_line_80-0219
+                                                                                                [(lam __HTLC_line_81-0221
+                                                                                                    (force [(force (builtin ifThenElse))
+                                                                                                      [(builtin equalsInteger)
+                                                                                                        [htlc_HtlcValidator__countScriptInputs162
+                                                                                                          tx-27586212
+                                                                                                          [htlc_HtlcValidator__ownScriptHash211
+                                                                                                            tx-27586212
+                                                                                                            ownRef-27587213]]
+                                                                                                        (con integer 1)]
+                                                                                                      (delay (con unit ()))
+                                                                                                      (delay (force [(force (builtin trace))
+                                                                                                        (con string "Double satisfaction")
+                                                                                                        (delay (error))]))]))
+                                                                                                  (force [(force (builtin ifThenElse))
+                                                                                                    [(builtin lessThanInteger)
+                                                                                                      [htlc_HtlcValidator__upperBoundExclusive100
+                                                                                                        [(force (force (builtin sndPair)))
+                                                                                                          [(builtin unConstrData)
+                                                                                                            [(force (builtin headList))
+                                                                                                              [(force (builtin tailList))
+                                                                                                                [(force (builtin tailList))
+                                                                                                                  [(force (builtin tailList))
+                                                                                                                    [(force (builtin tailList))
+                                                                                                                      [(force (builtin tailList))
+                                                                                                                        [(force (builtin tailList))
+                                                                                                                          [(force (builtin tailList))
+                                                                                                                            tx-27586212]]]]]]]]]]]
+                                                                                                      [(builtin unIData)
+                                                                                                        [(force (builtin headList))
+                                                                                                          [(force (builtin tailList))
+                                                                                                            [(force (builtin tailList))
+                                                                                                              [(force (builtin tailList))
+                                                                                                                d-27588214]]]]]]
+                                                                                                    (delay (con unit ()))
+                                                                                                    (delay (force [(force (builtin trace))
+                                                                                                      (con string "Claim not permitted at or after timeout")
+                                                                                                      (delay (error))]))])])
+                                                                                              (force [(force (builtin ifThenElse))
+                                                                                                [scalus_cardano_onchain_plutus_v3_TxInfo__isSignedBy79
+                                                                                                  tx-27586212
+                                                                                                  [htlc_HtlcValidator__extractPkh88
+                                                                                                    [(force (force (builtin sndPair)))
+                                                                                                      [(builtin unConstrData)
+                                                                                                        [(force (builtin headList))
+                                                                                                          [(force (builtin tailList))
+                                                                                                            d-27588214]]]]]]
+                                                                                                (delay (con unit ()))
+                                                                                                (delay (force [(force (builtin trace))
+                                                                                                  (con string "Missing recipient signature")
+                                                                                                  (delay (error))]))])])
+                                                                                          (force [(force (builtin ifThenElse))
+                                                                                            [(builtin equalsByteString)
+                                                                                              [(builtin sha2_256)
+                                                                                                preimage-27589215]
+                                                                                              [(builtin unBData)
+                                                                                                [(force (builtin headList))
+                                                                                                  [(force (builtin tailList))
+                                                                                                    [(force (builtin tailList))
+                                                                                                      d-27588214]]]]]
+                                                                                            (delay (con unit ()))
+                                                                                            (delay (force [(force (builtin trace))
+                                                                                              (con string "Preimage does not match stored hash")
+                                                                                              (delay (error))]))])]))))])
+                                                                            (lam tx-27695200
+                                                                              (lam ownRef-27696201
+                                                                                [(lam _match_scrutinee204
+                                                                                    (force [(force (builtin ifThenElse))
+                                                                                      [(builtin equalsInteger)
+                                                                                        [(force (force (builtin fstPair)))
+                                                                                          _match_scrutinee204]
+                                                                                        (con integer 0)]
+                                                                                      (delay [htlc_HtlcValidator__extractScriptHash199
+                                                                                        [(force (force (builtin sndPair)))
+                                                                                          [(builtin unConstrData)
+                                                                                            [(force (builtin headList))
+                                                                                              [(force (force (builtin sndPair)))
+                                                                                                [(builtin unConstrData)
+                                                                                                  [(force (builtin headList))
+                                                                                                    [(force (builtin tailList))
+                                                                                                      [(force (force (builtin sndPair)))
+                                                                                                        [(builtin unConstrData)
+                                                                                                          [(force (builtin headList))
+                                                                                                            [(force (force (builtin sndPair)))
+                                                                                                              _match_scrutinee204]]]]]]]]]]]])
+                                                                                      (delay (force [(force (builtin trace))
+                                                                                        (con string "Own input not found")
+                                                                                        (delay (error))]))]))
+                                                                                  [(builtin unConstrData)
+                                                                                    [scalus_cardano_onchain_plutus_v3_TxInfo__findOwnInput190
+                                                                                      tx-27695200
+                                                                                      ownRef-27696201]]]))])
+                                                                        (lam addr-27836191
+                                                                          [(lam _match_scrutinee193
+                                                                              (force [(force (builtin ifThenElse))
+                                                                                [(builtin equalsInteger)
+                                                                                  [(force (force (builtin fstPair)))
+                                                                                    _match_scrutinee193]
+                                                                                  (con integer 1)]
+                                                                                (delay [(builtin unBData)
+                                                                                  [(force (builtin headList))
+                                                                                    [(force (force (builtin sndPair)))
+                                                                                      _match_scrutinee193]]])
+                                                                                (delay (force [(force (builtin trace))
+                                                                                  (con string "Expected ScriptCredential")
+                                                                                  (delay (error))]))]))
+                                                                            [(builtin unConstrData)
+                                                                              [(force (builtin headList))
+                                                                                addr-27836191]]])])
+                                                                    (lam self-305431187
+                                                                      (lam outRef-305432188
+                                                                        [scalus_cardano_onchain_plutus_v3_Utils__findInput186
+                                                                          [(builtin unListData)
+                                                                            [(force (builtin headList))
+                                                                              self-305431187]]
+                                                                          outRef-305432188]))])
+                                                                (lam inputs-305446176
+                                                                  (lam outRef-305447177
+                                                                    [(lam xIn178
+                                                                        [scalus_cardano_onchain_plutus_prelude_List__find28
+                                                                          inputs-305446176
+                                                                          (lam xIn179
+                                                                            [xIn178
+                                                                              [(force (force (builtin sndPair)))
+                                                                                [(builtin unConstrData)
+                                                                                  xIn179]]])])
+                                                                      (lam __12-305531183
+                                                                        [scalus_cardano_onchain_plutus_v3_TxOutRef__given_Eq_TxOutRef175
+                                                                          [(force (force (builtin sndPair)))
+                                                                            [(builtin unConstrData)
+                                                                              [(force (builtin headList))
+                                                                                __12-305531183]]]
+                                                                          outRef-305447177])]))])
+                                                            (lam a-303790171
+                                                              (lam b-303791172
+                                                                (force [(force (builtin ifThenElse))
+                                                                  [scalus_cardano_onchain_plutus_v3_TxId__given_Eq_TxId166
+                                                                    [(builtin unBData)
+                                                                      [(force (builtin headList))
+                                                                        a-303790171]]
+                                                                    [(builtin unBData)
+                                                                      [(force (builtin headList))
+                                                                        b-303791172]]]
+                                                                  (delay [scalus_cardano_onchain_plutus_prelude_Eq__given_Eq_BigInt170
+                                                                    [(builtin unIData)
+                                                                      [(force (builtin headList))
+                                                                        [(force (builtin tailList))
+                                                                          a-303790171]]]
+                                                                    [(builtin unIData)
+                                                                      [(force (builtin headList))
+                                                                        [(force (builtin tailList))
+                                                                          b-303791172]]]])
+                                                                  (delay (con bool False))])))])
+                                                        (lam x-88106167
+                                                          (lam y-88107168
+                                                            [(builtin equalsInteger)
+                                                              x-88106167
+                                                              y-88107168]))])
+                                                    (lam a-303746163
+                                                      (lam b-303747164
+                                                        [scalus_uplc_builtin_ByteString__given_Eq_ByteString59
+                                                          a-303746163
+                                                          b-303747164]))])
+                                                (lam tx-27693142
+                                                  (lam scriptHash-27694143
+                                                    [(lam xIn144
+                                                        [scalus_cardano_onchain_plutus_prelude_List__count141
+                                                          [(builtin unListData)
+                                                            [(force (builtin headList))
+                                                              tx-27693142]]
+                                                          (lam xIn145
+                                                            [xIn144
+                                                              [(force (force (builtin sndPair)))
+                                                                [(builtin unConstrData)
+                                                                  xIn145]]])])
+                                                      (lam i-28278149
+                                                        [(lam _match_scrutinee153
+                                                            (force [(force (builtin ifThenElse))
+                                                              [(builtin equalsInteger)
+                                                                [(force (force (builtin fstPair)))
+                                                                  _match_scrutinee153]
+                                                                (con integer 1)]
+                                                              (delay [(builtin equalsByteString)
+                                                                [(builtin unBData)
+                                                                  [(force (builtin headList))
+                                                                    [(force (force (builtin sndPair)))
+                                                                      _match_scrutinee153]]]
+                                                                scriptHash-27694143])
+                                                              (delay (con bool False))]))
+                                                          [(builtin unConstrData)
+                                                            [(force (builtin headList))
+                                                              [(force (force (builtin sndPair)))
+                                                                [(builtin unConstrData)
+                                                                  [(force (builtin headList))
+                                                                    [(force (force (builtin sndPair)))
+                                                                      [(builtin unConstrData)
+                                                                        [(force (builtin headList))
+                                                                          [(force (builtin tailList))
+                                                                            i-28278149]]]]]]]]]])]))])
+                                            (lam self-90574120
+                                              (lam p-90575121
+                                                [(lam xIn127
+                                                    [(builtin unIData)
+                                                      [(lam xIn122
+                                                          (lam xIn123
+                                                            [scalus_cardano_onchain_plutus_prelude_List__foldLeft101
+                                                              self-90574120
+                                                              xIn122 xIn123]))
+                                                        (con data (I 0))
+                                                        (lam x131132
+                                                          (lam x134135
+                                                            [(lam xIn128
+                                                                [(lam xIn128r129
+                                                                    (lam xIn130
+                                                                      [(builtin iData)
+                                                                        [xIn127
+                                                                          xIn128r129
+                                                                          xIn130]]))
+                                                                  [(builtin unIData)
+                                                                    xIn128]])
+                                                              x131132
+                                                              x134135]))]])
+                                                  (lam counter-90577136
+                                                    (lam elem-90578137
+                                                      (force [(force (builtin ifThenElse))
+                                                        [p-90575121
+                                                          elem-90578137]
+                                                        (delay [(builtin addInteger)
+                                                          counter-90577136
+                                                          (con integer 1)])
+                                                        (delay counter-90577136)])))]))])
+                                        [__Z
+                                          (lam scalus_cardano_onchain_plutus_prelude_List__foldLeft101
+                                            (lam self-86666102
+                                              (lam init-86668103
+                                                (lam combiner-86669104
+                                                  [(lam listInput105
+                                                      (force [(force (force (builtin chooseList)))
+                                                        listInput105
+                                                        (delay init-86668103)
+                                                        (delay [(lam consTail107
+                                                            [(lam consHead106
+                                                                (lam xIn114
+                                                                  [(lam xIn108
+                                                                      (lam xIn109
+                                                                        [scalus_cardano_onchain_plutus_prelude_List__foldLeft101
+                                                                          consTail107
+                                                                          xIn108
+                                                                          xIn109]))
+                                                                    [combiner-86669104
+                                                                      init-86668103
+                                                                      consHead106]
+                                                                    xIn114]))
+                                                              [(force (builtin headList))
+                                                                listInput105]])
+                                                          [(force (builtin tailList))
+                                                            listInput105]
+                                                          combiner-86669104])]))
+                                                    self-86666102]))))]])
+                                    (lam r-2769289
+                                      [(lam _match_scrutinee92
+                                          (force [(force (builtin ifThenElse))
+                                            [(builtin equalsInteger)
+                                              [(force (force (builtin fstPair)))
+                                                _match_scrutinee92]
+                                              (con integer 1)]
+                                            (delay [(lam _match_datalist95
+                                                (force [(force (builtin ifThenElse))
+                                                  (force [(force (builtin ifThenElse))
+                                                    [(builtin equalsInteger)
+                                                      [(force (force (builtin fstPair)))
+                                                        [(builtin unConstrData)
+                                                          [(force (builtin headList))
+                                                            [(force (builtin tailList))
+                                                              [(force (force (builtin sndPair)))
+                                                                [(builtin unConstrData)
+                                                                  [(force (builtin headList))
+                                                                    [(force (builtin tailList))
+                                                                      r-2769289]]]]]]]]
+                                                      (con integer 0)]
+                                                    (delay (con bool False))
+                                                    (delay (con bool True))])
+                                                  (delay [(builtin unIData)
+                                                    [(force (builtin headList))
+                                                      _match_datalist95]])
+                                                  (delay [(builtin subtractInteger)
+                                                    [(builtin unIData)
+                                                      [(force (builtin headList))
+                                                        _match_datalist95]]
+                                                    (con integer 1)])]))
+                                              [(force (force (builtin sndPair)))
+                                                _match_scrutinee92]])
+                                            (delay (force [(force (builtin trace))
+                                              (con string "Claim requires a finite upper bound")
+                                              (delay (error))]))]))
+                                        [(builtin unConstrData)
+                                          [(force (builtin headList))
+                                            [(force (force (builtin sndPair)))
+                                              [(builtin unConstrData)
+                                                [(force (builtin headList))
+                                                  [(force (builtin tailList))
+                                                    r-2769289]]]]]]])])
+                                (lam addr-2769180
+                                  [(lam _match_scrutinee82
+                                      (force [(force (builtin ifThenElse))
+                                        [(builtin equalsInteger)
+                                          [(force (force (builtin fstPair)))
+                                            _match_scrutinee82] (con integer 0)]
+                                        (delay [(builtin unBData)
+                                          [(force (builtin headList))
+                                            [(force (force (builtin sndPair)))
+                                              _match_scrutinee82]]])
+                                        (delay (force [(force (builtin trace))
+                                          (con string "Expected PubKeyCredential")
+                                          (delay (error))]))]))
+                                    [(builtin unConstrData)
+                                      [(force (builtin headList))
+                                        addr-2769180]]])]) (lam self-30547764
+                              (lam pubKeyHash-30547865
+                                [(lam pubKeyHash_305478r71
+                                    (lam xIn72
+                                      [(lam xIn66
+                                          (lam xIn67
+                                            [scalus_cardano_onchain_plutus_prelude_List__contains55
+                                              [(builtin unListData)
+                                                [(force (builtin headList))
+                                                  [(force (builtin tailList))
+                                                    [(force (builtin tailList))
+                                                      [(force (builtin tailList))
+                                                        [(force (builtin tailList))
+                                                          [(force (builtin tailList))
+                                                            [(force (builtin tailList))
+                                                              [(force (builtin tailList))
+                                                                [(force (builtin tailList))
+                                                                  self-30547764]]]]]]]]]]
+                                              xIn66 xIn67]))
+                                        pubKeyHash_305478r71 (lam xIn73
+                                          [(lam xIn73r74
+                                              (lam xIn75
+                                                [xIn72 xIn73r74
+                                                  [(builtin unBData) xIn75]]))
+                                            [(builtin unBData) xIn73]])]))
+                                  [(builtin bData) pubKeyHash-30547865]
+                                  scalus_cardano_onchain_plutus_v1_PubKeyHash__given_Eq_PubKeyHash63]))])
+                        (lam a-30281160
+                          (lam b-30281261
+                            [scalus_uplc_builtin_ByteString__given_Eq_ByteString59
+                              a-30281160 b-30281261]))]) (lam x-13839556
+                      (lam y-13839657
+                        [(builtin equalsByteString) x-13839556 y-13839657]))])
+                (lam self-9039345
+                  (lam elem-9039546
+                    (lam eq-9039647
+                      [(lam self_proxy6-21259854
+                          (force [(force (builtin ifThenElse))
+                            [scalus_cardano_onchain_plutus_prelude_Option__isEmpty44
+                              self_proxy6-21259854] (delay (con bool False))
+                            (delay (con bool True))])) [(lam xIn48
+                            [scalus_cardano_onchain_plutus_prelude_List__find28
+                              self-9039345 xIn48]) (lam __1-21260051
+                            [eq-9039647 __1-21260051 elem-9039546])]])))])
+            (lam self-9098438
+              (force [(force (builtin ifThenElse)) [(builtin equalsInteger)
+                  [(force (force (builtin fstPair))) [(builtin unConstrData)
+                      self-9098438]] (con integer 0)] (delay (con bool False))
+                (delay (con bool True))]))]) [__Z
+          (lam scalus_cardano_onchain_plutus_prelude_List__find28
+            (lam self-9039929
+              (lam predicate-9040030
+                [(lam listInput31
+                    (force [(force (force (builtin chooseList))) listInput31
+                      (delay [(builtin constrData) (con integer 1)
+                        (con (list data) [])])
+                      (delay (force [(force (builtin ifThenElse))
+                        [predicate-9040030 [(force (builtin headList))
+                            listInput31]] (delay [(builtin constrData)
+                          (con integer 0) [(force (builtin mkCons))
+                            [(force (builtin headList)) listInput31]
+                            (con (list data) [])]]) (delay [(lam consTail33
+                            (lam xIn34
+                              [scalus_cardano_onchain_plutus_prelude_List__find28
+                                consTail33 xIn34])) [(force (builtin tailList))
+                            listInput31] predicate-9040030])]))]))
+                  self-9039929])))]]) (lam ff
+      [(lam xx [ff (lam vv [xx xx vv])]) (lam xx [ff (lam vv [xx xx vv])])])])

--- a/submissions/htlc/Scalus_0.16.0_Unisay/metadata.json
+++ b/submissions/htlc/Scalus_0.16.0_Unisay/metadata.json
@@ -1,0 +1,25 @@
+{
+  "compiler": {
+    "name": "Scalus",
+    "version": "0.16.0",
+    "commit_hash": "bc4614a71ab491622da8c173920705348d516cf1"
+  },
+  "compilation_config": {
+    "optimization_level": "Scalus",
+    "target": "uplc",
+    "flags": ["Scalus"]
+  },
+  "contributors": [
+    {
+      "name": "Unisay",
+      "organization": "Intersect MBO"
+    }
+  ],
+  "submission": {
+    "date": "2026-04-24T12:48:44Z",
+    "source_available": true,
+    "source_repository": "https://github.com/Unisay/scalus-cape-submissions",
+    "source_commit_hash": "9cdace4a7369954f470d73a58f3c902e4427c439",
+    "implementation_notes": "Scalus 0.16.0 HTLC spending validator (`@Compile object HTLCValidator`, `Data -> Unit`). Derives FromData/ToData for HTLCDatum and HTLCRedeemer. Claim reads the upper bound of `txInfoValidRange` (finite, strictly `< timeout`); refund reads the lower bound (finite, strictly `> timeout`). Matches the production-safe convention introduced in IntersectMBO/UPLC-CAPE#170. Uses `toUplc()` instead of `toUplcOptimized()` to avoid CaseConstrApply syntax rejected by plutus-core 1.45.0.0 (upstream: IntersectMBO/plutus#7742). Post-processing renames NAME-NNNNrMMMM identifiers (Scalus refresh-counter suffix) to NAME_NNNNrMMMM so the plutus-core unique-suffix parser (Lex.decimal after hyphen) does not split the name incorrectly."
+  }
+}

--- a/submissions/htlc/Scalus_0.16.0_Unisay/metadata.json
+++ b/submissions/htlc/Scalus_0.16.0_Unisay/metadata.json
@@ -19,7 +19,7 @@
     "date": "2026-04-24T12:48:44Z",
     "source_available": true,
     "source_repository": "https://github.com/Unisay/scalus-cape-submissions",
-    "source_commit_hash": "9cdace4a7369954f470d73a58f3c902e4427c439",
-    "implementation_notes": "Scalus 0.16.0 HTLC spending validator (`@Compile object HTLCValidator`, `Data -> Unit`). Derives FromData/ToData for HTLCDatum and HTLCRedeemer. Claim reads the upper bound of `txInfoValidRange` (finite, strictly `< timeout`); refund reads the lower bound (finite, strictly `> timeout`). Matches the production-safe convention introduced in IntersectMBO/UPLC-CAPE#170. Uses `toUplc()` instead of `toUplcOptimized()` to avoid CaseConstrApply syntax rejected by plutus-core 1.45.0.0 (upstream: IntersectMBO/plutus#7742). Post-processing renames NAME-NNNNrMMMM identifiers (Scalus refresh-counter suffix) to NAME_NNNNrMMMM so the plutus-core unique-suffix parser (Lex.decimal after hyphen) does not split the name incorrectly."
+    "source_commit_hash": "07350edfbaaa3f4c42cf116a3c360ba3098ccf3f",
+    "implementation_notes": "Scalus 0.16.0 HTLC spending validator (`@Compile object HTLCValidator`, `Data -> Unit`). Derives FromData/ToData for HTLCDatum and HTLCRedeemer. Claim reads the upper bound of `txInfoValidRange` (finite, strictly `< timeout`); refund reads the lower bound (finite, strictly `> timeout`). Matches the production-safe convention introduced in IntersectMBO/UPLC-CAPE#170. Uses `toUplcOptimized()` with CaseConstrApply and builtin-packing; an AST-level alpha-rename pass rewrites all generated names to short purely-alphabetic identifiers (a, b, ..., z, aa, ...) before serialisation, ensuring compatibility with the plutus-core 1.45.0.0 textual parser."
   }
 }

--- a/submissions/htlc/Scalus_0.16.0_Unisay/metrics.json
+++ b/submissions/htlc/Scalus_0.16.0_Unisay/metrics.json
@@ -1,0 +1,215 @@
+{
+  "evaluations": [
+    {
+      "cpu_units": 24688,
+      "description": "Validator fails when redeemer is raw integer 0 instead of constructor 0(preimage)",
+      "execution_result": "success",
+      "memory_units": 132,
+      "name": "redeemer_integer_0"
+    },
+    {
+      "cpu_units": 24688,
+      "description": "Validator fails when redeemer is raw integer 1 instead of constructor 1()",
+      "execution_result": "success",
+      "memory_units": 132,
+      "name": "redeemer_integer_1"
+    },
+    {
+      "cpu_units": 24688,
+      "description": "Validator fails when redeemer is bytestring instead of constructor",
+      "execution_result": "success",
+      "memory_units": 132,
+      "name": "redeemer_bytestring"
+    },
+    {
+      "cpu_units": 24688,
+      "description": "Validator fails when redeemer is list [1 2 3] instead of constructor",
+      "execution_result": "success",
+      "memory_units": 132,
+      "name": "redeemer_list"
+    },
+    {
+      "cpu_units": 6500516,
+      "description": "Validator fails when Claim is constructor 0() with no preimage field",
+      "execution_result": "success",
+      "memory_units": 21162,
+      "name": "redeemer_claim_without_preimage"
+    },
+    {
+      "cpu_units": 34380491,
+      "description": "Claim at time=50 with correct preimage and recipient signature should succeed",
+      "execution_result": "success",
+      "memory_units": 121955,
+      "name": "claim_well_before_timeout"
+    },
+    {
+      "cpu_units": 34380491,
+      "description": "Claim at time=99 (just before timeout=100) with correct preimage should succeed",
+      "execution_result": "success",
+      "memory_units": 121955,
+      "name": "claim_just_before_timeout"
+    },
+    {
+      "cpu_units": 32424661,
+      "description": "Refund at time=101 (just after timeout=100) with payer signature should succeed",
+      "execution_result": "success",
+      "memory_units": 116629,
+      "name": "refund_just_after_timeout"
+    },
+    {
+      "cpu_units": 32424661,
+      "description": "Refund at time=200 with payer signature should succeed",
+      "execution_result": "success",
+      "memory_units": 116629,
+      "name": "refund_well_after_timeout"
+    },
+    {
+      "cpu_units": 12776083,
+      "description": "Claim without recipient signature should fail",
+      "execution_result": "success",
+      "memory_units": 42166,
+      "name": "claim_missing_signature"
+    },
+    {
+      "cpu_units": 13219873,
+      "description": "Claim with only payer signature (not recipient) should fail",
+      "execution_result": "success",
+      "memory_units": 42328,
+      "name": "claim_wrong_signature_payer"
+    },
+    {
+      "cpu_units": 13219873,
+      "description": "Claim with only impostor signature (not recipient) should fail",
+      "execution_result": "success",
+      "memory_units": 42328,
+      "name": "claim_wrong_signature_impostor"
+    },
+    {
+      "cpu_units": 7245713,
+      "description": "Claim with preimage #cafebabe (hash does not match) should fail",
+      "execution_result": "success",
+      "memory_units": 21360,
+      "name": "claim_wrong_preimage"
+    },
+    {
+      "cpu_units": 7245713,
+      "description": "Claim with empty preimage (hash does not match) should fail",
+      "execution_result": "success",
+      "memory_units": 21360,
+      "name": "claim_empty_preimage"
+    },
+    {
+      "cpu_units": 19474735,
+      "description": "Claim at time=100 (boundary, must be strictly before timeout) should fail",
+      "execution_result": "success",
+      "memory_units": 63391,
+      "name": "claim_at_timeout"
+    },
+    {
+      "cpu_units": 19474735,
+      "description": "Claim at time=150 (after timeout) should fail even with correct preimage",
+      "execution_result": "success",
+      "memory_units": 63391,
+      "name": "claim_after_timeout"
+    },
+    {
+      "cpu_units": 17891507,
+      "description": "Claim with from_time=50 and no upper bound (+inf) should fail; the upper bound must be finite",
+      "execution_result": "success",
+      "memory_units": 62874,
+      "name": "claim_infinite_upper_bound"
+    },
+    {
+      "cpu_units": 36911900,
+      "description": "Claim with two script inputs should fail (double satisfaction attack)",
+      "execution_result": "success",
+      "memory_units": 126133,
+      "name": "claim_double_satisfaction"
+    },
+    {
+      "cpu_units": 11783579,
+      "description": "Refund without payer signature should fail",
+      "execution_result": "success",
+      "memory_units": 41904,
+      "name": "refund_missing_signature"
+    },
+    {
+      "cpu_units": 12227369,
+      "description": "Refund with only recipient signature (not payer) should fail",
+      "execution_result": "success",
+      "memory_units": 42066,
+      "name": "refund_wrong_signature_recipient"
+    },
+    {
+      "cpu_units": 12227369,
+      "description": "Refund with only impostor signature (not payer) should fail",
+      "execution_result": "success",
+      "memory_units": 42066,
+      "name": "refund_wrong_signature_impostor"
+    },
+    {
+      "cpu_units": 18318905,
+      "description": "Refund at time=50 (before timeout) should fail",
+      "execution_result": "success",
+      "memory_units": 63065,
+      "name": "refund_before_timeout"
+    },
+    {
+      "cpu_units": 18318905,
+      "description": "Refund at time=100 (boundary, must be strictly after timeout) should fail",
+      "execution_result": "success",
+      "memory_units": 63065,
+      "name": "refund_at_timeout"
+    },
+    {
+      "cpu_units": 13966223,
+      "description": "Refund with no lower bound (-inf) should fail; the lower bound must be finite",
+      "execution_result": "success",
+      "memory_units": 42740,
+      "name": "refund_infinite_lower_bound"
+    },
+    {
+      "cpu_units": 35756070,
+      "description": "Refund with two script inputs should fail (double satisfaction attack)",
+      "execution_result": "success",
+      "memory_units": 125807,
+      "name": "refund_double_satisfaction"
+    }
+  ],
+  "execution_environment": {
+    "evaluator": "<evaluator-version>"
+  },
+  "measurements": {
+    "block_cpu_budget_pct": 0.09227975,
+    "block_memory_budget_pct": 0.20344032258064518,
+    "cpu_units": {
+      "maximum": 36911900,
+      "median": 13219873,
+      "minimum": 24688,
+      "sum": 410268124,
+      "sum_negative": 0,
+      "sum_positive": 410268124
+    },
+    "execution_fee_lovelace": 110644,
+    "memory_units": {
+      "maximum": 126133,
+      "median": 42328,
+      "minimum": 132,
+      "sum": 1404902,
+      "sum_negative": 0,
+      "sum_positive": 1404902
+    },
+    "reference_script_fee_lovelace": 24720,
+    "script_size_bytes": 1648,
+    "scripts_per_block": 491,
+    "scripts_per_tx": 110,
+    "term_size": 1491,
+    "total_fee_lovelace": 135364,
+    "tx_cpu_budget_pct": 0.369119,
+    "tx_memory_budget_pct": 0.90095
+  },
+  "scenario": "htlc",
+  "timestamp": "2026-04-24T15:03:42Z",
+  "version": "1.0.0",
+  "notes": "<optional notes>"
+}

--- a/submissions/htlc/Scalus_0.16.0_Unisay/metrics.json
+++ b/submissions/htlc/Scalus_0.16.0_Unisay/metrics.json
@@ -29,59 +29,59 @@
       "name": "redeemer_list"
     },
     {
-      "cpu_units": 6500516,
+      "cpu_units": 3300516,
       "description": "Validator fails when Claim is constructor 0() with no preimage field",
       "execution_result": "success",
-      "memory_units": 21162,
+      "memory_units": 1162,
       "name": "redeemer_claim_without_preimage"
     },
     {
-      "cpu_units": 34380491,
+      "cpu_units": 29068491,
       "description": "Claim at time=50 with correct preimage and recipient signature should succeed",
       "execution_result": "success",
-      "memory_units": 121955,
+      "memory_units": 88755,
       "name": "claim_well_before_timeout"
     },
     {
-      "cpu_units": 34380491,
+      "cpu_units": 29068491,
       "description": "Claim at time=99 (just before timeout=100) with correct preimage should succeed",
       "execution_result": "success",
-      "memory_units": 121955,
+      "memory_units": 88755,
       "name": "claim_just_before_timeout"
     },
     {
-      "cpu_units": 32424661,
+      "cpu_units": 27304661,
       "description": "Refund at time=101 (just after timeout=100) with payer signature should succeed",
       "execution_result": "success",
-      "memory_units": 116629,
+      "memory_units": 84629,
       "name": "refund_just_after_timeout"
     },
     {
-      "cpu_units": 32424661,
+      "cpu_units": 27304661,
       "description": "Refund at time=200 with payer signature should succeed",
       "execution_result": "success",
-      "memory_units": 116629,
+      "memory_units": 84629,
       "name": "refund_well_after_timeout"
     },
     {
-      "cpu_units": 12776083,
+      "cpu_units": 9553932,
       "description": "Claim without recipient signature should fail",
       "execution_result": "success",
-      "memory_units": 42166,
+      "memory_units": 22134,
       "name": "claim_missing_signature"
     },
     {
-      "cpu_units": 13219873,
+      "cpu_units": 13197722,
       "description": "Claim with only payer signature (not recipient) should fail",
       "execution_result": "success",
-      "memory_units": 42328,
+      "memory_units": 42296,
       "name": "claim_wrong_signature_payer"
     },
     {
-      "cpu_units": 13219873,
+      "cpu_units": 13197722,
       "description": "Claim with only impostor signature (not recipient) should fail",
       "execution_result": "success",
-      "memory_units": 42328,
+      "memory_units": 42296,
       "name": "claim_wrong_signature_impostor"
     },
     {
@@ -99,66 +99,66 @@
       "name": "claim_empty_preimage"
     },
     {
-      "cpu_units": 19474735,
+      "cpu_units": 16274735,
       "description": "Claim at time=100 (boundary, must be strictly before timeout) should fail",
       "execution_result": "success",
-      "memory_units": 63391,
+      "memory_units": 43391,
       "name": "claim_at_timeout"
     },
     {
-      "cpu_units": 19474735,
+      "cpu_units": 16274735,
       "description": "Claim at time=150 (after timeout) should fail even with correct preimage",
       "execution_result": "success",
-      "memory_units": 63391,
+      "memory_units": 43391,
       "name": "claim_after_timeout"
     },
     {
-      "cpu_units": 17891507,
+      "cpu_units": 14691507,
       "description": "Claim with from_time=50 and no upper bound (+inf) should fail; the upper bound must be finite",
       "execution_result": "success",
-      "memory_units": 62874,
+      "memory_units": 42874,
       "name": "claim_infinite_upper_bound"
     },
     {
-      "cpu_units": 36911900,
+      "cpu_units": 30511900,
       "description": "Claim with two script inputs should fail (double satisfaction attack)",
       "execution_result": "success",
-      "memory_units": 126133,
+      "memory_units": 86133,
       "name": "claim_double_satisfaction"
     },
     {
-      "cpu_units": 11783579,
+      "cpu_units": 8561428,
       "description": "Refund without payer signature should fail",
       "execution_result": "success",
-      "memory_units": 41904,
+      "memory_units": 21872,
       "name": "refund_missing_signature"
     },
     {
-      "cpu_units": 12227369,
+      "cpu_units": 9005218,
       "description": "Refund with only recipient signature (not payer) should fail",
       "execution_result": "success",
-      "memory_units": 42066,
+      "memory_units": 22034,
       "name": "refund_wrong_signature_recipient"
     },
     {
-      "cpu_units": 12227369,
+      "cpu_units": 9005218,
       "description": "Refund with only impostor signature (not payer) should fail",
       "execution_result": "success",
-      "memory_units": 42066,
+      "memory_units": 22034,
       "name": "refund_wrong_signature_impostor"
     },
     {
-      "cpu_units": 18318905,
+      "cpu_units": 15118905,
       "description": "Refund at time=50 (before timeout) should fail",
       "execution_result": "success",
-      "memory_units": 63065,
+      "memory_units": 43065,
       "name": "refund_before_timeout"
     },
     {
-      "cpu_units": 18318905,
+      "cpu_units": 15118905,
       "description": "Refund at time=100 (boundary, must be strictly after timeout) should fail",
       "execution_result": "success",
-      "memory_units": 63065,
+      "memory_units": 43065,
       "name": "refund_at_timeout"
     },
     {
@@ -169,10 +169,10 @@
       "name": "refund_infinite_lower_bound"
     },
     {
-      "cpu_units": 35756070,
+      "cpu_units": 29356070,
       "description": "Refund with two script inputs should fail (double satisfaction attack)",
       "execution_result": "success",
-      "memory_units": 125807,
+      "memory_units": 85807,
       "name": "refund_double_satisfaction"
     }
   ],
@@ -180,36 +180,36 @@
     "evaluator": "<evaluator-version>"
   },
   "measurements": {
-    "block_cpu_budget_pct": 0.09227975,
-    "block_memory_budget_pct": 0.20344032258064518,
+    "block_cpu_budget_pct": 0.07627975000000001,
+    "block_memory_budget_pct": 0.1431532258064516,
     "cpu_units": {
-      "maximum": 36911900,
-      "median": 13219873,
+      "maximum": 30511900,
+      "median": 13197722,
       "minimum": 24688,
-      "sum": 410268124,
+      "sum": 344471218,
       "sum_negative": 0,
-      "sum_positive": 410268124
+      "sum_positive": 344471218
     },
-    "execution_fee_lovelace": 110644,
+    "execution_fee_lovelace": 82209,
     "memory_units": {
-      "maximum": 126133,
-      "median": 42328,
+      "maximum": 88755,
+      "median": 42296,
       "minimum": 132,
-      "sum": 1404902,
+      "sum": 994310,
       "sum_negative": 0,
-      "sum_positive": 1404902
+      "sum_positive": 994310
     },
-    "reference_script_fee_lovelace": 24720,
-    "script_size_bytes": 1648,
-    "scripts_per_block": 491,
-    "scripts_per_tx": 110,
-    "term_size": 1491,
-    "total_fee_lovelace": 135364,
-    "tx_cpu_budget_pct": 0.369119,
-    "tx_memory_budget_pct": 0.90095
+    "reference_script_fee_lovelace": 22455,
+    "script_size_bytes": 1497,
+    "scripts_per_block": 698,
+    "scripts_per_tx": 157,
+    "term_size": 1101,
+    "total_fee_lovelace": 104664,
+    "tx_cpu_budget_pct": 0.30511900000000003,
+    "tx_memory_budget_pct": 0.6339642857142858
   },
   "scenario": "htlc",
-  "timestamp": "2026-04-24T15:03:42Z",
+  "timestamp": "2026-04-24T16:31:02Z",
   "version": "1.0.0",
   "notes": "<optional notes>"
 }

--- a/submissions/htlc/Scalus_0.16.0_Unisay/source/README.md
+++ b/submissions/htlc/Scalus_0.16.0_Unisay/source/README.md
@@ -1,0 +1,33 @@
+# Scalus HTLC Implementation
+
+**Source Code**: [HTLC.scala](https://github.com/Unisay/scalus-cape-submissions/blob/9cdace4a7369954f470d73a58f3c902e4427c439/src/htlc/HTLC.scala)
+
+**Repository**: <https://github.com/Unisay/scalus-cape-submissions>
+
+**Commit**: `9cdace4a7369954f470d73a58f3c902e4427c439`
+
+**Path**: `src/htlc/HTLC.scala`
+
+This submission uses Scalus compiler version 0.16.0 with a spending validator that enforces the production-safe validity-range convention (claim reads the upper bound, refund reads the lower bound — both finite and strict). Two workarounds are applied to make the UPLC compatible with the plutus-core 1.45.0.0 textual parser:
+
+1. `toUplc()` instead of `toUplcOptimized()` — avoids `case`/`constr` syntax from CaseConstrApply (upstream: [IntersectMBO/plutus#7742](https://github.com/IntersectMBO/plutus/issues/7742)).
+2. Post-processing renames `NAME-NNNNrMMMM` identifiers to `NAME_NNNNrMMMM` — the plutus-core unique-suffix parser uses `Lex.decimal` after a hyphen, which stops at `r`, causing the refresh-counter suffix to be misread as the lambda body.
+
+## Reproducing the Compilation
+
+1. Clone the repository:
+
+   ```bash
+   git clone https://github.com/Unisay/scalus-cape-submissions
+   cd scalus-cape-submissions
+   ```
+
+2. Check out the specific commit:
+
+   ```bash
+   git checkout 0846510184d98b054c4405c4d036154444467d9f
+   ```
+
+3. Follow build instructions in the repository README
+
+4. The compiled UPLC output should match `htlc.uplc` in this submission

--- a/submissions/htlc/Scalus_0.16.0_Unisay/source/README.md
+++ b/submissions/htlc/Scalus_0.16.0_Unisay/source/README.md
@@ -1,17 +1,16 @@
 # Scalus HTLC Implementation
 
-**Source Code**: [HTLC.scala](https://github.com/Unisay/scalus-cape-submissions/blob/9cdace4a7369954f470d73a58f3c902e4427c439/src/htlc/HTLC.scala)
+**Source Code**: [HTLC.scala](https://github.com/Unisay/scalus-cape-submissions/blob/07350edfbaaa3f4c42cf116a3c360ba3098ccf3f/src/htlc/HTLC.scala)
 
 **Repository**: <https://github.com/Unisay/scalus-cape-submissions>
 
-**Commit**: `9cdace4a7369954f470d73a58f3c902e4427c439`
+**Commit**: `07350edfbaaa3f4c42cf116a3c360ba3098ccf3f`
 
 **Path**: `src/htlc/HTLC.scala`
 
-This submission uses Scalus compiler version 0.16.0 with a spending validator that enforces the production-safe validity-range convention (claim reads the upper bound, refund reads the lower bound — both finite and strict). Two workarounds are applied to make the UPLC compatible with the plutus-core 1.45.0.0 textual parser:
+This submission uses Scalus compiler version 0.16.0 with a spending validator that enforces the production-safe validity-range convention (claim reads the upper bound, refund reads the lower bound — both finite and strict).
 
-1. `toUplc()` instead of `toUplcOptimized()` — avoids `case`/`constr` syntax from CaseConstrApply (upstream: [IntersectMBO/plutus#7742](https://github.com/IntersectMBO/plutus/issues/7742)).
-2. Post-processing renames `NAME-NNNNrMMMM` identifiers to `NAME_NNNNrMMMM` — the plutus-core unique-suffix parser uses `Lex.decimal` after a hyphen, which stops at `r`, causing the refresh-counter suffix to be misread as the lambda body.
+The artifact is compiled with `toUplcOptimized()` (CaseConstrApply + builtin-packing). An AST-level alpha-rename pass rewrites all generated identifiers to short purely-alphabetic names (a, b, …, z, aa, …) before serialisation. This makes the output compatible with the plutus-core 1.45.0.0 textual parser without sacrificing optimised code size.
 
 ## Reproducing the Compilation
 
@@ -25,7 +24,7 @@ This submission uses Scalus compiler version 0.16.0 with a spending validator th
 2. Check out the specific commit:
 
    ```bash
-   git checkout 0846510184d98b054c4405c4d036154444467d9f
+   git checkout 07350edfbaaa3f4c42cf116a3c360ba3098ccf3f
    ```
 
 3. Follow build instructions in the repository README


### PR DESCRIPTION
## Summary

- Adds `submissions/htlc/Scalus_0.16.0_Unisay/` with a Scalus 0.16.0 spending validator for the HTLC scenario
- 25/25 cape tests pass; script size 1497 bytes
- Enforces the production-safe validity-range convention from #170 (claim reads upper bound, refund reads lower bound)

## Parser compatibility

The artifact uses `toUplcOptimized()` (CaseConstrApply + builtin-packing) with an AST-level alpha-rename pass that rewrites all generated identifiers to short purely-alphabetic names (a, b, …, z, aa, …) before serialisation. This ensures compatibility with the plutus-core 1.45.0.0 textual parser without sacrificing optimised code size.

## Metrics

| test | cpu | mem |
|------|-----|-----|
| `claim_well_before_timeout` | 29 068 491 | 88 755 |
| `refund_well_after_timeout` | 27 304 661 | 84 629 |
| script size | — | 1 497 bytes |

Closes #161