### PR TITLE
chore(submissions): apply alpha-rename to Scalus 0.16.0 factorial/fibonacci

### DIFF
--- a/submissions/factorial_naive_recursion/Scalus_0.16.0_Unisay/factorial.uplc
+++ b/submissions/factorial_naive_recursion/Scalus_0.16.0_Unisay/factorial.uplc
@@ -1,12 +1,8 @@
-(program 1.1.0 [(lam __builtin_IfThenElse
-      [(lam ff
-          [(lam xx [ff (lam vv [xx xx vv])]) (lam xx [ff (lam vv [xx xx vv])])])
-        (lam factorial_naive_recursion_FactorialNaiveRecursion__factorial28
-          (lam n-2831429
-            (force (case (constr 0 [(builtin lessThanEqualsInteger) n-2831429
+(program 1.1.0 [(lam a
+      [(lam b [(lam c [b (lam d [c c d])]) (lam c [b (lam d [c c d])])]) (lam e
+          (lam f
+            (force (case (constr 0 [(builtin lessThanEqualsInteger) f
                   (con integer 0)] (delay (con integer 1))
-                (delay [(builtin multiplyInteger) n-2831429
-                  [factorial_naive_recursion_FactorialNaiveRecursion__factorial28
-                    [(builtin subtractInteger) n-2831429
-                      (con integer 1)]]])) __builtin_IfThenElse))))])
+                (delay [(builtin multiplyInteger) f [e
+                    [(builtin subtractInteger) f (con integer 1)]]])) a))))])
     (force (builtin ifThenElse))])

--- a/submissions/factorial_naive_recursion/Scalus_0.16.0_Unisay/metadata.json
+++ b/submissions/factorial_naive_recursion/Scalus_0.16.0_Unisay/metadata.json
@@ -19,7 +19,7 @@
     "date": "2026-04-21T12:00:00Z",
     "source_available": true,
     "source_repository": "https://github.com/Unisay/scalus-cape-submissions",
-    "source_commit_hash": "e02e7f74322a81622ff51bb41c6d671e09032379",
-    "implementation_notes": "Scalus with default options (naive recursive implementation, no optimization)"
+    "source_commit_hash": "2126a807bbe2a744e2b924bda3099881e09d969f",
+    "implementation_notes": "Scalus with default options (naive recursive implementation, no optimization). AST-level alpha-rename pass applied: all generated identifiers rewritten to short purely-alphabetic names before serialisation."
   }
 }

--- a/submissions/factorial_naive_recursion/Scalus_0.16.0_Unisay/source/README.md
+++ b/submissions/factorial_naive_recursion/Scalus_0.16.0_Unisay/source/README.md
@@ -1,10 +1,10 @@
 # Scalus Factorial Naive Recursion Implementation
 
-**Source Code**: [FactorialNaiveRecursion.scala](https://github.com/Unisay/scalus-cape-submissions/blob/e02e7f74322a81622ff51bb41c6d671e09032379/src/factorial_naive_recursion/FactorialNaiveRecursion.scala)
+**Source Code**: [FactorialNaiveRecursion.scala](https://github.com/Unisay/scalus-cape-submissions/blob/2126a807bbe2a744e2b924bda3099881e09d969f/src/factorial_naive_recursion/FactorialNaiveRecursion.scala)
 
 **Repository**: <https://github.com/Unisay/scalus-cape-submissions>
 
-**Commit**: `e02e7f74322a81622ff51bb41c6d671e09032379`
+**Commit**: `2126a807bbe2a744e2b924bda3099881e09d969f`
 
 **Path**: `src/factorial_naive_recursion/FactorialNaiveRecursion.scala`
 
@@ -22,7 +22,7 @@ This submission uses Scalus compiler version 0.16.0 with a naive recursive imple
 2. Check out the specific commit:
 
    ```bash
-   git checkout e02e7f74322a81622ff51bb41c6d671e09032379
+   git checkout 2126a807bbe2a744e2b924bda3099881e09d969f
    ```
 
 3. Follow build instructions in the repository README

--- a/submissions/fibonacci/Scalus_0.16.0_Unisay_prepacked/fibonacci.uplc
+++ b/submissions/fibonacci/Scalus_0.16.0_Unisay_prepacked/fibonacci.uplc
@@ -1,7 +1,6 @@
-(program 1.1.0 (lam x-2972429
-    (force (case (constr 0 [(builtin lessThanEqualsInteger) x-2972429
-          (con integer 0)] (delay x-2972429)
-        (delay [(builtin byteStringToInteger) (con bool True)
-          (case (constr 0 [(builtin multiplyInteger) x-2972429 (con integer 3)]
+(program 1.1.0 (lam a
+    (force (case (constr 0 [(builtin lessThanEqualsInteger) a (con integer 0)]
+        (delay a) (delay [(builtin byteStringToInteger) (con bool True)
+          (case (constr 0 [(builtin multiplyInteger) a (con integer 3)]
               (con integer 3)
               (con bytestring #00000000000100000100000200000300000500000800000d0000150000220000370000590000900000e90001790002620003db00063d000a18001055001a6d002ac200452f006ff100b520012511)) (builtin sliceByteString))])) (force (builtin ifThenElse))))))

--- a/submissions/fibonacci/Scalus_0.16.0_Unisay_prepacked/metadata.json
+++ b/submissions/fibonacci/Scalus_0.16.0_Unisay_prepacked/metadata.json
@@ -19,7 +19,7 @@
     "date": "2026-04-21T12:00:00Z",
     "source_available": true,
     "source_repository": "https://github.com/Unisay/scalus-cape-submissions",
-    "source_commit_hash": "e02e7f74322a81622ff51bb41c6d671e09032379",
-    "implementation_notes": "Optimized prepacked implementation using pre-computed Fibonacci numbers stored in a ByteString for O(1) constant-time lookup. Pre-computed values for fib(0) through fib(25), each encoded as 3 bytes in big-endian format."
+    "source_commit_hash": "2126a807bbe2a744e2b924bda3099881e09d969f",
+    "implementation_notes": "Optimized prepacked implementation using pre-computed Fibonacci numbers stored in a ByteString for O(1) constant-time lookup. Pre-computed values for fib(0) through fib(25), each encoded as 3 bytes in big-endian format. AST-level alpha-rename pass applied: all generated identifiers rewritten to short purely-alphabetic names before serialisation."
   }
 }

--- a/submissions/fibonacci/Scalus_0.16.0_Unisay_prepacked/source/README.md
+++ b/submissions/fibonacci/Scalus_0.16.0_Unisay_prepacked/source/README.md
@@ -1,10 +1,10 @@
 # Scalus Fibonacci Prepacked Implementation
 
-**Source Code**: [FibonacciPrepacked.scala](https://github.com/Unisay/scalus-cape-submissions/blob/e02e7f74322a81622ff51bb41c6d671e09032379/src/fibonacci_prepacked/FibonacciPrepacked.scala)
+**Source Code**: [FibonacciPrepacked.scala](https://github.com/Unisay/scalus-cape-submissions/blob/2126a807bbe2a744e2b924bda3099881e09d969f/src/fibonacci_prepacked/FibonacciPrepacked.scala)
 
 **Repository**: <https://github.com/Unisay/scalus-cape-submissions>
 
-**Commit**: `e02e7f74322a81622ff51bb41c6d671e09032379`
+**Commit**: `2126a807bbe2a744e2b924bda3099881e09d969f`
 
 **Path**: `src/fibonacci_prepacked/FibonacciPrepacked.scala`
 
@@ -29,7 +29,7 @@ This submission uses Scalus compiler version 0.16.0 with a prepacked optimizatio
 2. Check out the specific commit:
 
    ```bash
-   git checkout e02e7f74322a81622ff51bb41c6d671e09032379
+   git checkout 2126a807bbe2a744e2b924bda3099881e09d969f
    ```
 
 3. Run the compilation:

--- a/submissions/fibonacci_naive_recursion/Scalus_0.16.0_Unisay/fibonacci.uplc
+++ b/submissions/fibonacci_naive_recursion/Scalus_0.16.0_Unisay/fibonacci.uplc
@@ -1,16 +1,11 @@
-(program 1.1.0 [(lam __builtin_IfThenElse
-      [(lam ff
-          [(lam xx [ff (lam vv [xx xx vv])]) (lam xx [ff (lam vv [xx xx vv])])])
-        (lam fibonacci_naive_recursion_FibonacciNaiveRecursion__fibonacci28
-          (lam n-2924829
-            (force (case (constr 0 [(builtin lessThanEqualsInteger) n-2924829
-                  (con integer 1)] (delay n-2924829)
-                (delay (force (case (constr 0 [(builtin equalsInteger) n-2924829
+(program 1.1.0 [(lam a
+      [(lam b [(lam c [b (lam d [c c d])]) (lam c [b (lam d [c c d])])]) (lam e
+          (lam f
+            (force (case (constr 0 [(builtin lessThanEqualsInteger) f
+                  (con integer 1)] (delay f)
+                (delay (force (case (constr 0 [(builtin equalsInteger) f
                       (con integer 2)] (delay (con integer 1))
-                    (delay [(builtin addInteger)
-                      [fibonacci_naive_recursion_FibonacciNaiveRecursion__fibonacci28
-                        [(builtin subtractInteger) n-2924829 (con integer 1)]]
-                      [fibonacci_naive_recursion_FibonacciNaiveRecursion__fibonacci28
-                        [(builtin subtractInteger) n-2924829
-                          (con integer 2)]]])) __builtin_IfThenElse)))) __builtin_IfThenElse))))])
+                    (delay [(builtin addInteger) [e [(builtin subtractInteger) f
+                          (con integer 1)]] [e [(builtin subtractInteger) f
+                          (con integer 2)]]])) a)))) a))))])
     (force (builtin ifThenElse))])

--- a/submissions/fibonacci_naive_recursion/Scalus_0.16.0_Unisay/metadata.json
+++ b/submissions/fibonacci_naive_recursion/Scalus_0.16.0_Unisay/metadata.json
@@ -19,7 +19,7 @@
     "date": "2026-04-21T12:00:00Z",
     "source_available": true,
     "source_repository": "https://github.com/Unisay/scalus-cape-submissions",
-    "source_commit_hash": "e02e7f74322a81622ff51bb41c6d671e09032379",
-    "implementation_notes": "Scalus with default options (naive recursive implementation, no optimization)"
+    "source_commit_hash": "2126a807bbe2a744e2b924bda3099881e09d969f",
+    "implementation_notes": "Scalus with default options (naive recursive implementation, no optimization). AST-level alpha-rename pass applied: all generated identifiers rewritten to short purely-alphabetic names before serialisation."
   }
 }

--- a/submissions/fibonacci_naive_recursion/Scalus_0.16.0_Unisay/source/README.md
+++ b/submissions/fibonacci_naive_recursion/Scalus_0.16.0_Unisay/source/README.md
@@ -1,10 +1,10 @@
 # Scalus Fibonacci Naive Recursion Implementation
 
-**Source Code**: [FibonacciNaiveRecursion.scala](https://github.com/Unisay/scalus-cape-submissions/blob/e02e7f74322a81622ff51bb41c6d671e09032379/src/fibonacci_naive_recursion/FibonacciNaiveRecursion.scala)
+**Source Code**: [FibonacciNaiveRecursion.scala](https://github.com/Unisay/scalus-cape-submissions/blob/2126a807bbe2a744e2b924bda3099881e09d969f/src/fibonacci_naive_recursion/FibonacciNaiveRecursion.scala)
 
 **Repository**: <https://github.com/Unisay/scalus-cape-submissions>
 
-**Commit**: `e02e7f74322a81622ff51bb41c6d671e09032379`
+**Commit**: `2126a807bbe2a744e2b924bda3099881e09d969f`
 
 **Path**: `src/fibonacci_naive_recursion/FibonacciNaiveRecursion.scala`
 
@@ -22,7 +22,7 @@ This submission uses Scalus compiler version 0.16.0 with a naive recursive imple
 2. Check out the specific commit:
 
    ```bash
-   git checkout e02e7f74322a81622ff51bb41c6d671e09032379
+   git checkout 2126a807bbe2a744e2b924bda3099881e09d969f
    ```
 
 3. Follow build instructions in the repository README


### PR DESCRIPTION
## Summary

Refreshes three Scalus 0.16.0 submissions with the AST-level alpha-rename pass from [Unisay/scalus-cape-submissions@2126a80](https://github.com/Unisay/scalus-cape-submissions/commit/2126a807bbe2a744e2b924bda3099881e09d969f).

All generated identifiers are rewritten to short purely-alphabetic names (a, b, …) before serialisation — the same approach introduced for HTLC in #173.

## Submissions updated

| submission | textual UPLC before | after | Δ |
|---|---|---|---|
| `factorial_naive_recursion/Scalus_0.16.0_Unisay` | 679 B | 416 B | −38.7% |
| `fibonacci_naive_recursion/Scalus_0.16.0_Unisay` | 1008 B | 623 B | −38.2% |
| `fibonacci/Scalus_0.16.0_Unisay_prepacked` | 569 B | 527 B | −7.4% |

## Effect on metrics

The alpha-rename only affects the textual UPLC representation. Flat encoding uses de Bruijn indices so execution costs and `script_size_bytes` in `metrics.json` are unchanged.