### PR TITLE
feat(submissions): add Scalus 0.17.0 Unisay submissions

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# pre-commit: enforce canonical pretty-uplc formatting on staged .uplc files.
+#
+# Runs the in-repo `pretty-uplc` formatter (treefmt's *.uplc formatter) on a
+# temporary copy of each staged .uplc file and compares against the staged
+# content. If any file would change, the commit is aborted with a hint to run
+# `treefmt <file>` (or `treefmt`) and re-stage. Bypass with `--no-verify`.
+
+set -Eeuo pipefail
+
+mapfile -t staged < <(git diff --cached --name-only --diff-filter=ACMR -- '*.uplc')
+
+if [ ${#staged[@]} -eq 0 ]; then
+  exit 0
+fi
+
+if ! command -v pretty-uplc > /dev/null 2>&1; then
+  echo "pre-commit: pretty-uplc not found on PATH; entering devshell expected (run 'direnv allow' or 'nix develop')." >&2
+  echo "pre-commit: skipping .uplc format check on $(printf '%s ' "${staged[@]}")" >&2
+  exit 0
+fi
+
+bad=()
+for f in "${staged[@]}"; do
+  [ -f "$f" ] || continue
+  tmp="$(mktemp --suffix=.uplc)"
+  trap 'rm -f "$tmp"' EXIT
+  git show ":$f" > "$tmp"
+  if ! pretty-uplc "$tmp" 2> /dev/null; then
+    echo "pre-commit: pretty-uplc failed to parse $f" >&2
+    bad+=("$f")
+    rm -f "$tmp"
+    trap - EXIT
+    continue
+  fi
+  if ! git diff --no-index --quiet -- <(git show ":$f") "$tmp" > /dev/null 2>&1; then
+    bad+=("$f")
+  fi
+  rm -f "$tmp"
+  trap - EXIT
+done
+
+if [ ${#bad[@]} -gt 0 ]; then
+  echo >&2
+  echo "pre-commit: the following .uplc files are not formatted with pretty-uplc:" >&2
+  printf '  - %s\n' "${bad[@]}" >&2
+  echo >&2
+  echo "Fix with:  treefmt ${bad[*]}" >&2
+  echo "Then re-stage and commit again. Bypass (not recommended): git commit --no-verify" >&2
+  exit 1
+fi

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -14,6 +14,47 @@ permissions:
   pull-requests: write
 
 jobs:
+  format-check:
+    name: Check pretty-uplc formatting
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            accept-flake-config = true
+
+      - name: Use Cachix (pull/push if token provided)
+        uses: cachix/cachix-action@v17
+        with:
+          name: uplc-cape
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
+      - name: List .uplc files changed vs main
+        id: changed
+        run: |
+          git fetch origin main --depth=1
+          mapfile -t files < <(git diff --name-only --diff-filter=ACMR origin/main...HEAD -- '*.uplc')
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "No .uplc changes vs origin/main; skipping format check."
+            echo "files=" >> "$GITHUB_OUTPUT"
+          else
+            printf 'Will check %d file(s):\n' "${#files[@]}"
+            printf '  - %s\n' "${files[@]}"
+            printf 'files=%s\n' "${files[*]}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run treefmt --ci on changed .uplc files
+        if: steps.changed.outputs.files != ''
+        run: |
+          # shellcheck disable=SC2086
+          nix develop --accept-flake-config --command treefmt --ci ${{ steps.changed.outputs.files }}
+
   build-measure:
     name: Build Measure Executable
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ build-and-deploy.sh
 result
 result-*
 *.code-workspace
+.direnv
+.local

--- a/.wtp.yml
+++ b/.wtp.yml
@@ -6,9 +6,6 @@ hooks:
   post_create:
     # Symlink all shared resources
     - type: symlink
-      from: dist-newstyle
-      to: dist-newstyle
-    - type: symlink
       from: .direnv
       to: .direnv
     - type: symlink

--- a/flake.nix
+++ b/flake.nix
@@ -253,6 +253,14 @@
             # Prevents build failures when index-state is updated (see issue #104)
             echo "📦 Synchronizing Cabal package index..."
             cabal update > /dev/null 2>&1 || true
+
+            # Wire repo-tracked git hooks (.githooks/) once per worktree.
+            if [ -n "$REPO_ROOT" ] && [ -d "$REPO_ROOT/.githooks" ]; then
+              current_path="$(git -C "$REPO_ROOT" config --local --get core.hooksPath 2>/dev/null || true)"
+              if [ "$current_path" != ".githooks" ]; then
+                git -C "$REPO_ROOT" config --local core.hooksPath .githooks
+              fi
+            fi
           '';
         };
       in

--- a/pretty-uplc-app/Main.hs
+++ b/pretty-uplc-app/Main.hs
@@ -9,7 +9,9 @@ module Main (main) where
 
 import Prelude
 
+import Control.Monad qualified
 import Data.List qualified as L
+import Data.Text qualified as T
 import Data.Text.IO qualified as Text.IO
 import Options.Applicative qualified as Opts
 import PlutusCore qualified as PLC
@@ -67,6 +69,8 @@ formatFile path = do
       -- of file" and the formatter is idempotent across editors that
       -- auto-add one.
       let rendered = show (PP.prettyPlcClassic prog)
-          normalised = L.dropWhileEnd (== '\n') rendered <> "\n"
-      writeFile path normalised
+          normalised = T.pack (L.dropWhileEnd (== '\n') rendered) <> "\n"
+      -- Only rewrite when content actually changed; otherwise treefmt --ci
+      -- treats a no-op rewrite (mtime change) as a formatting failure.
+      Control.Monad.when (src /= normalised) (Text.IO.writeFile path normalised)
       pure True

--- a/submissions/factorial/Scalus_0.17.0_Unisay/README.md
+++ b/submissions/factorial/Scalus_0.17.0_Unisay/README.md
@@ -1,0 +1,23 @@
+# Benchmark Implementation Notes
+
+**Scenario**: `factorial`
+
+**Submission ID**: `Scalus_0.17.0_Unisay`
+
+## Implementation Details
+
+- **Compiler**: `Scalus 0.17.0`
+- **Implementation Approach**: `simple recursive via explicit pfix (Y-combinator)`
+- **Compilation Flags**: `default`
+
+## Performance Results
+
+- See [metrics.json](metrics.json) for detailed performance measurements
+
+## Source Code
+
+- See [source/README.md](source/README.md) for source code and reproducibility instructions
+
+## Notes
+
+Surface Scalus defines factorial as `pfix: r => λ x. if x ≤ 0 then 1 else x * r(x-1)` — plain recursion with an explicit Y-combinator (`pfix`), no accumulator, no tail-recursive rewrite. The source code is maintained in a separate repository to avoid duplication.

--- a/submissions/factorial/Scalus_0.17.0_Unisay/factorial.uplc
+++ b/submissions/factorial/Scalus_0.17.0_Unisay/factorial.uplc
@@ -1,6 +1,31 @@
-(program 1.1.0 [(lam a [a a]) (lam a
-      (lam b
-        (force (case (constr 0 [(builtin lessThanEqualsInteger) b
-              (con integer 0)] (delay (con integer 1))
-            (delay [(builtin multiplyInteger) b [a a [(builtin subtractInteger)
-                  b (con integer 1)]]])) (force (builtin ifThenElse))))))])
+(program
+  1.1.0
+  [
+    (lam a-0 [ a-0 a-0 ])
+    (lam
+      a-0
+      (lam
+        b-1
+        (force
+          (case
+            (constr
+              0
+              [ [ (builtin lessThanEqualsInteger) b-1 ] (con integer 0) ]
+              (delay (con integer 1))
+              (delay
+                [
+                  [ (builtin multiplyInteger) b-1 ]
+                  [
+                    [ a-0 a-0 ]
+                    [ [ (builtin subtractInteger) b-1 ] (con integer 1) ]
+                  ]
+                ]
+              )
+            )
+            (force (builtin ifThenElse))
+          )
+        )
+      )
+    )
+  ]
+)

--- a/submissions/factorial/Scalus_0.17.0_Unisay/factorial.uplc
+++ b/submissions/factorial/Scalus_0.17.0_Unisay/factorial.uplc
@@ -1,0 +1,6 @@
+(program 1.1.0 [(lam a [a a]) (lam a
+      (lam b
+        (force (case (constr 0 [(builtin lessThanEqualsInteger) b
+              (con integer 0)] (delay (con integer 1))
+            (delay [(builtin multiplyInteger) b [a a [(builtin subtractInteger)
+                  b (con integer 1)]]])) (force (builtin ifThenElse))))))])

--- a/submissions/factorial/Scalus_0.17.0_Unisay/metadata.json
+++ b/submissions/factorial/Scalus_0.17.0_Unisay/metadata.json
@@ -1,0 +1,25 @@
+{
+  "compiler": {
+    "name": "Scalus",
+    "version": "0.17.0",
+    "commit_hash": "553d4d420166d87efad7220ce288e0961cfe17c0"
+  },
+  "compilation_config": {
+    "optimization_level": "Scalus",
+    "target": "uplc",
+    "flags": ["Scalus"]
+  },
+  "contributors": [
+    {
+      "name": "Unisay",
+      "organization": "Intersect MBO"
+    }
+  ],
+  "submission": {
+    "date": "2026-05-05T17:30:00Z",
+    "source_available": true,
+    "source_repository": "https://github.com/Unisay/scalus-cape-submissions",
+    "source_commit_hash": "0c8cfdb82fff4e10cd0fdf41e69738886edd7491",
+    "implementation_notes": "Scalus with default options"
+  }
+}

--- a/submissions/factorial/Scalus_0.17.0_Unisay/metrics.json
+++ b/submissions/factorial/Scalus_0.17.0_Unisay/metrics.json
@@ -1,0 +1,110 @@
+{
+  "evaluations": [
+    {
+      "cpu_units": 471986,
+      "description": "Factorial of 0 should return 1 (mathematical definition)",
+      "execution_result": "success",
+      "memory_units": 2302,
+      "name": "factorial_0"
+    },
+    {
+      "cpu_units": 1200033,
+      "description": "Factorial of 1 should return 1",
+      "execution_result": "success",
+      "memory_units": 4908,
+      "name": "factorial_1"
+    },
+    {
+      "cpu_units": 1928080,
+      "description": "Factorial of 2 should return 2",
+      "execution_result": "success",
+      "memory_units": 7514,
+      "name": "factorial_2"
+    },
+    {
+      "cpu_units": 2656127,
+      "description": "Factorial of 3 should return 6",
+      "execution_result": "success",
+      "memory_units": 10120,
+      "name": "factorial_3"
+    },
+    {
+      "cpu_units": 3384174,
+      "description": "Factorial of 4 should return 24",
+      "execution_result": "success",
+      "memory_units": 12726,
+      "name": "factorial_4"
+    },
+    {
+      "cpu_units": 4112221,
+      "description": "Factorial of 5 should return 120",
+      "execution_result": "success",
+      "memory_units": 15332,
+      "name": "factorial_5"
+    },
+    {
+      "cpu_units": 6296362,
+      "description": "Factorial of 8 should return 40320",
+      "execution_result": "success",
+      "memory_units": 23150,
+      "name": "factorial_8"
+    },
+    {
+      "cpu_units": 7752456,
+      "description": "Factorial of 10 should return 3628800 (original benchmark target)",
+      "execution_result": "success",
+      "memory_units": 28362,
+      "name": "factorial_10"
+    },
+    {
+      "cpu_units": 9208550,
+      "description": "Factorial of 12 should return 479001600",
+      "execution_result": "success",
+      "memory_units": 33574,
+      "name": "factorial_12"
+    },
+    {
+      "cpu_units": 471986,
+      "description": "Factorial of negative number should return 1 based on current implementation (n <= 0 case)",
+      "execution_result": "success",
+      "memory_units": 2302,
+      "name": "factorial_negative"
+    }
+  ],
+  "execution_environment": {
+    "evaluator": "<evaluator-version>"
+  },
+  "measurements": {
+    "block_cpu_budget_pct": 0.023021375,
+    "block_memory_budget_pct": 0.05415161290322581,
+    "cpu_units": {
+      "maximum": 9208550,
+      "median": 3020150,
+      "minimum": 471986,
+      "sum": 37481975,
+      "sum_negative": 0,
+      "sum_positive": 37481975
+    },
+    "execution_fee_lovelace": 10798,
+    "memory_units": {
+      "maximum": 33574,
+      "median": 11423,
+      "minimum": 2302,
+      "sum": 140290,
+      "sum_negative": 0,
+      "sum_positive": 140290
+    },
+    "reference_script_fee_lovelace": 600,
+    "script_size_bytes": 40,
+    "scripts_per_block": 1846,
+    "scripts_per_tx": 416,
+    "term_size": 33,
+    "total_fee_lovelace": 11398,
+    "tx_cpu_budget_pct": 0.0920855,
+    "tx_memory_budget_pct": 0.2398142857142857
+  },
+  "scenario": "factorial",
+  "timestamp": "2026-05-05T17:29:18Z",
+  "version": "1.0.0",
+  "notes": "<optional notes>"
+}

--- a/submissions/factorial/Scalus_0.17.0_Unisay/source/README.md
+++ b/submissions/factorial/Scalus_0.17.0_Unisay/source/README.md
@@ -1,0 +1,32 @@
+# Scalus Factorial Implementation
+
+**Source Code**: [Factorial.scala](https://github.com/Unisay/scalus-cape-submissions/blob/0c8cfdb82fff4e10cd0fdf41e69738886edd7491/src/factorial/Factorial.scala)
+
+**Repository**: <https://github.com/Unisay/scalus-cape-submissions>
+
+**Commit**: `0c8cfdb82fff4e10cd0fdf41e69738886edd7491`
+
+**Path**: `src/factorial/Factorial.scala`
+
+This submission uses Scalus compiler version 0.17.0 with a simple recursive factorial implementation via an explicit `pfix` (Y-combinator).
+
+## Reproducing the Compilation
+
+1. Clone the repository:
+
+   ```bash
+   git clone https://github.com/Unisay/scalus-cape-submissions
+   cd scalus-cape-submissions
+   ```
+
+2. Check out the specific commit:
+
+   ```bash
+   git checkout 0c8cfdb82fff4e10cd0fdf41e69738886edd7491
+   ```
+
+3. Follow build instructions in the repository README
+
+4. The compiled UPLC output should match `factorial.uplc` in this submission
+
+For detailed build instructions and environment setup, see the repository README.

--- a/submissions/factorial_naive_recursion/Scalus_0.17.0_Unisay/README.md
+++ b/submissions/factorial_naive_recursion/Scalus_0.17.0_Unisay/README.md
@@ -1,0 +1,23 @@
+# Benchmark Implementation Notes
+
+**Scenario**: `factorial_naive_recursion`
+
+**Submission ID**: `Scalus_0.17.0_Unisay`
+
+## Implementation Details
+
+- **Compiler**: `Scalus 0.17.0`
+- **Implementation Approach**: `naive recursive`
+- **Compilation Flags**: `default`
+
+## Performance Results
+
+- See [metrics.json](metrics.json) for detailed performance measurements
+
+## Source Code
+
+- See [source/README.md](source/README.md) for source code and reproducibility instructions
+
+## Notes
+
+This submission implements the factorial_naive_recursion scenario using the prescribed naive recursive approach. The source code is maintained in a separate repository to avoid duplication.

--- a/submissions/factorial_naive_recursion/Scalus_0.17.0_Unisay/factorial.uplc
+++ b/submissions/factorial_naive_recursion/Scalus_0.17.0_Unisay/factorial.uplc
@@ -1,7 +1,34 @@
-(program 1.1.0 [(lam a
-      [(lam b [a (lam c [b b c])]) (lam b [a (lam c [b b c])])]) (lam d
-      (lam e
-        (force (case (constr 0 [(builtin lessThanEqualsInteger) e
-              (con integer 0)] (delay (con integer 1))
-            (delay [(builtin multiplyInteger) e [d [(builtin subtractInteger) e
-                  (con integer 1)]]])) (force (builtin ifThenElse))))))])
+(program
+  1.1.0
+  [
+    (lam
+      a-0
+      [
+        (lam b-1 [ a-0 (lam c-2 [ [ b-1 b-1 ] c-2 ]) ])
+        (lam b-1 [ a-0 (lam c-2 [ [ b-1 b-1 ] c-2 ]) ])
+      ]
+    )
+    (lam
+      d-3
+      (lam
+        e-4
+        (force
+          (case
+            (constr
+              0
+              [ [ (builtin lessThanEqualsInteger) e-4 ] (con integer 0) ]
+              (delay (con integer 1))
+              (delay
+                [
+                  [ (builtin multiplyInteger) e-4 ]
+                  [ d-3 [ [ (builtin subtractInteger) e-4 ] (con integer 1) ] ]
+                ]
+              )
+            )
+            (force (builtin ifThenElse))
+          )
+        )
+      )
+    )
+  ]
+)

--- a/submissions/factorial_naive_recursion/Scalus_0.17.0_Unisay/factorial.uplc
+++ b/submissions/factorial_naive_recursion/Scalus_0.17.0_Unisay/factorial.uplc
@@ -1,0 +1,7 @@
+(program 1.1.0 [(lam a
+      [(lam b [a (lam c [b b c])]) (lam b [a (lam c [b b c])])]) (lam d
+      (lam e
+        (force (case (constr 0 [(builtin lessThanEqualsInteger) e
+              (con integer 0)] (delay (con integer 1))
+            (delay [(builtin multiplyInteger) e [d [(builtin subtractInteger) e
+                  (con integer 1)]]])) (force (builtin ifThenElse))))))])

--- a/submissions/factorial_naive_recursion/Scalus_0.17.0_Unisay/metadata.json
+++ b/submissions/factorial_naive_recursion/Scalus_0.17.0_Unisay/metadata.json
@@ -1,0 +1,25 @@
+{
+  "compiler": {
+    "name": "Scalus",
+    "version": "0.17.0",
+    "commit_hash": "553d4d420166d87efad7220ce288e0961cfe17c0"
+  },
+  "compilation_config": {
+    "optimization_level": "Scalus",
+    "target": "uplc",
+    "flags": ["Scalus"]
+  },
+  "contributors": [
+    {
+      "name": "Unisay",
+      "organization": "Intersect MBO"
+    }
+  ],
+  "submission": {
+    "date": "2026-05-05T17:30:00Z",
+    "source_available": true,
+    "source_repository": "https://github.com/Unisay/scalus-cape-submissions",
+    "source_commit_hash": "0c8cfdb82fff4e10cd0fdf41e69738886edd7491",
+    "implementation_notes": "Scalus with default options (naive recursive implementation, no optimization). AST-level alpha-rename pass applied: all generated identifiers rewritten to short purely-alphabetic names before serialisation."
+  }
+}

--- a/submissions/factorial_naive_recursion/Scalus_0.17.0_Unisay/metrics.json
+++ b/submissions/factorial_naive_recursion/Scalus_0.17.0_Unisay/metrics.json
@@ -1,0 +1,110 @@
+{
+  "evaluations": [
+    {
+      "cpu_units": 519986,
+      "description": "Factorial of 0 should return 1 (mathematical definition)",
+      "execution_result": "success",
+      "memory_units": 2602,
+      "name": "factorial_0"
+    },
+    {
+      "cpu_units": 1344033,
+      "description": "Factorial of 1 should return 1",
+      "execution_result": "success",
+      "memory_units": 5808,
+      "name": "factorial_1"
+    },
+    {
+      "cpu_units": 2168080,
+      "description": "Factorial of 2 should return 2",
+      "execution_result": "success",
+      "memory_units": 9014,
+      "name": "factorial_2"
+    },
+    {
+      "cpu_units": 2992127,
+      "description": "Factorial of 3 should return 6",
+      "execution_result": "success",
+      "memory_units": 12220,
+      "name": "factorial_3"
+    },
+    {
+      "cpu_units": 3816174,
+      "description": "Factorial of 4 should return 24",
+      "execution_result": "success",
+      "memory_units": 15426,
+      "name": "factorial_4"
+    },
+    {
+      "cpu_units": 4640221,
+      "description": "Factorial of 5 should return 120",
+      "execution_result": "success",
+      "memory_units": 18632,
+      "name": "factorial_5"
+    },
+    {
+      "cpu_units": 7112362,
+      "description": "Factorial of 8 should return 40320",
+      "execution_result": "success",
+      "memory_units": 28250,
+      "name": "factorial_8"
+    },
+    {
+      "cpu_units": 8760456,
+      "description": "Factorial of 10 should return 3628800 (original benchmark target)",
+      "execution_result": "success",
+      "memory_units": 34662,
+      "name": "factorial_10"
+    },
+    {
+      "cpu_units": 10408550,
+      "description": "Factorial of 12 should return 479001600",
+      "execution_result": "success",
+      "memory_units": 41074,
+      "name": "factorial_12"
+    },
+    {
+      "cpu_units": 519986,
+      "description": "Factorial of negative number should return 1 based on current implementation (n <= 0 case)",
+      "execution_result": "success",
+      "memory_units": 2602,
+      "name": "factorial_negative"
+    }
+  ],
+  "execution_environment": {
+    "evaluator": "<evaluator-version>"
+  },
+  "measurements": {
+    "block_cpu_budget_pct": 0.026021375,
+    "block_memory_budget_pct": 0.06624838709677419,
+    "cpu_units": {
+      "maximum": 10408550,
+      "median": 3404150,
+      "minimum": 519986,
+      "sum": 42281975,
+      "sum_negative": 0,
+      "sum_positive": 42281975
+    },
+    "execution_fee_lovelace": 12875,
+    "memory_units": {
+      "maximum": 41074,
+      "median": 13823,
+      "minimum": 2602,
+      "sum": 170290,
+      "sum_negative": 0,
+      "sum_positive": 170290
+    },
+    "reference_script_fee_lovelace": 780,
+    "script_size_bytes": 52,
+    "scripts_per_block": 1509,
+    "scripts_per_tx": 340,
+    "term_size": 47,
+    "total_fee_lovelace": 13655,
+    "tx_cpu_budget_pct": 0.1040855,
+    "tx_memory_budget_pct": 0.2933857142857143
+  },
+  "scenario": "factorial_naive_recursion",
+  "timestamp": "2026-05-05T17:30:20Z",
+  "version": "1.0.0",
+  "notes": "<optional notes>"
+}

--- a/submissions/factorial_naive_recursion/Scalus_0.17.0_Unisay/source/README.md
+++ b/submissions/factorial_naive_recursion/Scalus_0.17.0_Unisay/source/README.md
@@ -1,0 +1,32 @@
+# Scalus Factorial Naive Recursion Implementation
+
+**Source Code**: [FactorialNaiveRecursion.scala](https://github.com/Unisay/scalus-cape-submissions/blob/0c8cfdb82fff4e10cd0fdf41e69738886edd7491/src/factorial_naive_recursion/FactorialNaiveRecursion.scala)
+
+**Repository**: <https://github.com/Unisay/scalus-cape-submissions>
+
+**Commit**: `0c8cfdb82fff4e10cd0fdf41e69738886edd7491`
+
+**Path**: `src/factorial_naive_recursion/FactorialNaiveRecursion.scala`
+
+This submission uses Scalus compiler version 0.17.0 with a naive recursive implementation (no optimization, per scenario specification).
+
+## Reproducing the Compilation
+
+1. Clone the repository:
+
+   ```bash
+   git clone https://github.com/Unisay/scalus-cape-submissions
+   cd scalus-cape-submissions
+   ```
+
+2. Check out the specific commit:
+
+   ```bash
+   git checkout 0c8cfdb82fff4e10cd0fdf41e69738886edd7491
+   ```
+
+3. Follow build instructions in the repository README
+
+4. The compiled UPLC output should match `factorial.uplc` in this submission
+
+For detailed build instructions and environment setup, see the repository README.

--- a/submissions/fibonacci/Scalus_0.17.0_Unisay/README.md
+++ b/submissions/fibonacci/Scalus_0.17.0_Unisay/README.md
@@ -1,0 +1,23 @@
+# Benchmark Implementation Notes
+
+**Scenario**: `fibonacci`
+
+**Submission ID**: `Scalus_0.17.0_Unisay`
+
+## Implementation Details
+
+- **Compiler**: `Scalus 0.17.0`
+- **Implementation Approach**: `naive recursive via explicit pfix (Y-combinator)`
+- **Compilation Flags**: `default`
+
+## Performance Results
+
+- See [metrics.json](metrics.json) for detailed performance measurements
+
+## Source Code
+
+- See [source/README.md](source/README.md) for source code and reproducibility instructions
+
+## Notes
+
+Surface Scalus defines fibonacci as `pfix: r => λ x. if x ≤ 1 then x else r(x-1) + r(x-2)` — the classic naive O(2^n) recurrence with an explicit Y-combinator (`pfix`), not an iterative or tail-recursive form. The source code is maintained in a separate repository to avoid duplication.

--- a/submissions/fibonacci/Scalus_0.17.0_Unisay/fibonacci.uplc
+++ b/submissions/fibonacci/Scalus_0.17.0_Unisay/fibonacci.uplc
@@ -1,7 +1,37 @@
-(program 1.1.0 [(lam a [a a]) (lam a
-      (lam b
-        (force (case (constr 0 [(builtin lessThanEqualsInteger) b
-              (con integer 1)] (delay b) (delay [(builtin addInteger) [a a
-                [(builtin subtractInteger) b (con integer 1)]] [a a
-                [(builtin subtractInteger) b
-                  (con integer 2)]]])) (force (builtin ifThenElse))))))])
+(program
+  1.1.0
+  [
+    (lam a-0 [ a-0 a-0 ])
+    (lam
+      a-0
+      (lam
+        b-1
+        (force
+          (case
+            (constr
+              0
+              [ [ (builtin lessThanEqualsInteger) b-1 ] (con integer 1) ]
+              (delay b-1)
+              (delay
+                [
+                  [
+                    (builtin addInteger)
+                    [
+                      [ a-0 a-0 ]
+                      [ [ (builtin subtractInteger) b-1 ] (con integer 1) ]
+                    ]
+                  ]
+                  [
+                    [ a-0 a-0 ]
+                    [ [ (builtin subtractInteger) b-1 ] (con integer 2) ]
+                  ]
+                ]
+              )
+            )
+            (force (builtin ifThenElse))
+          )
+        )
+      )
+    )
+  ]
+)

--- a/submissions/fibonacci/Scalus_0.17.0_Unisay/fibonacci.uplc
+++ b/submissions/fibonacci/Scalus_0.17.0_Unisay/fibonacci.uplc
@@ -1,0 +1,7 @@
+(program 1.1.0 [(lam a [a a]) (lam a
+      (lam b
+        (force (case (constr 0 [(builtin lessThanEqualsInteger) b
+              (con integer 1)] (delay b) (delay [(builtin addInteger) [a a
+                [(builtin subtractInteger) b (con integer 1)]] [a a
+                [(builtin subtractInteger) b
+                  (con integer 2)]]])) (force (builtin ifThenElse))))))])

--- a/submissions/fibonacci/Scalus_0.17.0_Unisay/metadata.json
+++ b/submissions/fibonacci/Scalus_0.17.0_Unisay/metadata.json
@@ -1,0 +1,25 @@
+{
+  "compiler": {
+    "name": "Scalus",
+    "version": "0.17.0",
+    "commit_hash": "553d4d420166d87efad7220ce288e0961cfe17c0"
+  },
+  "compilation_config": {
+    "optimization_level": "Scalus",
+    "target": "uplc",
+    "flags": ["Scalus"]
+  },
+  "contributors": [
+    {
+      "name": "Unisay",
+      "organization": "Intersect MBO"
+    }
+  ],
+  "submission": {
+    "date": "2026-05-05T17:30:00Z",
+    "source_available": true,
+    "source_repository": "https://github.com/Unisay/scalus-cape-submissions",
+    "source_commit_hash": "0c8cfdb82fff4e10cd0fdf41e69738886edd7491",
+    "implementation_notes": "Naive recursive Fibonacci via explicit pfix (Y-combinator); surface: `pfix: r => λ x. if x ≤ 1 then x else r(x-1) + r(x-2)`"
+  }
+}

--- a/submissions/fibonacci/Scalus_0.17.0_Unisay/metrics.json
+++ b/submissions/fibonacci/Scalus_0.17.0_Unisay/metrics.json
@@ -1,0 +1,117 @@
+{
+  "evaluations": [
+    {
+      "cpu_units": 471986,
+      "description": "Fibonacci of 0 should return 0",
+      "execution_result": "success",
+      "memory_units": 2302,
+      "name": "fibonacci_0"
+    },
+    {
+      "cpu_units": 471986,
+      "description": "Fibonacci of 1 should return 1",
+      "execution_result": "success",
+      "memory_units": 2302,
+      "name": "fibonacci_1"
+    },
+    {
+      "cpu_units": 1783382,
+      "description": "Fibonacci of 2 should return 1",
+      "execution_result": "success",
+      "memory_units": 7112,
+      "name": "fibonacci_2"
+    },
+    {
+      "cpu_units": 3094778,
+      "description": "Fibonacci of 3 should return 2",
+      "execution_result": "success",
+      "memory_units": 11922,
+      "name": "fibonacci_3"
+    },
+    {
+      "cpu_units": 9651758,
+      "description": "Fibonacci of 5 should return 5",
+      "execution_result": "success",
+      "memory_units": 35972,
+      "name": "fibonacci_5"
+    },
+    {
+      "cpu_units": 43748054,
+      "description": "Fibonacci of 8 should return 21",
+      "execution_result": "success",
+      "memory_units": 161032,
+      "name": "fibonacci_8"
+    },
+    {
+      "cpu_units": 115874834,
+      "description": "Fibonacci of 10 should return 55",
+      "execution_result": "success",
+      "memory_units": 425582,
+      "name": "fibonacci_10"
+    },
+    {
+      "cpu_units": 1293508442,
+      "description": "Fibonacci of 15 should return 610",
+      "execution_result": "success",
+      "memory_units": 4744962,
+      "name": "fibonacci_15"
+    },
+    {
+      "cpu_units": 14353701206,
+      "description": "Fibonacci of 20 should return 6765",
+      "execution_result": "success",
+      "memory_units": 52647752,
+      "name": "fibonacci_20"
+    },
+    {
+      "cpu_units": 159193455218,
+      "description": "Fibonacci of 25 should return 75025 (original benchmark target)",
+      "execution_result": "success",
+      "memory_units": 583897822,
+      "name": "fibonacci_25"
+    },
+    {
+      "cpu_units": 471986,
+      "description": "Fibonacci of negative number should return the negative number itself based on current implementation",
+      "execution_result": "success",
+      "memory_units": 2302,
+      "name": "fibonacci_negative"
+    }
+  ],
+  "execution_environment": {
+    "evaluator": "<evaluator-version>"
+  },
+  "measurements": {
+    "block_cpu_budget_pct": 397.983638045,
+    "block_memory_budget_pct": 941.7706806451612,
+    "cpu_units": {
+      "maximum": 159193455218,
+      "median": 9651758,
+      "minimum": 471986,
+      "sum": 175016233630,
+      "sum_negative": 0,
+      "sum_positive": 175016233630
+    },
+    "execution_fee_lovelace": 49658555,
+    "memory_units": {
+      "maximum": 583897822,
+      "median": 35972,
+      "minimum": 2302,
+      "sum": 641939062,
+      "sum_negative": 0,
+      "sum_positive": 641939062
+    },
+    "reference_script_fee_lovelace": 705,
+    "script_size_bytes": 47,
+    "scripts_per_block": 0,
+    "scripts_per_tx": 0,
+    "term_size": 41,
+    "total_fee_lovelace": 49659260,
+    "tx_cpu_budget_pct": 1591.93455218,
+    "tx_memory_budget_pct": 4170.698728571429
+  },
+  "scenario": "fibonacci",
+  "timestamp": "2026-05-05T17:31:11Z",
+  "version": "1.0.0",
+  "notes": "<optional notes>"
+}

--- a/submissions/fibonacci/Scalus_0.17.0_Unisay/source/README.md
+++ b/submissions/fibonacci/Scalus_0.17.0_Unisay/source/README.md
@@ -1,0 +1,32 @@
+# Scalus Fibonacci Implementation
+
+**Source Code**: [Fibonacci.scala](https://github.com/Unisay/scalus-cape-submissions/blob/0c8cfdb82fff4e10cd0fdf41e69738886edd7491/src/fibonacci/Fibonacci.scala)
+
+**Repository**: <https://github.com/Unisay/scalus-cape-submissions>
+
+**Commit**: `0c8cfdb82fff4e10cd0fdf41e69738886edd7491`
+
+**Path**: `src/fibonacci/Fibonacci.scala`
+
+This submission uses Scalus compiler version 0.17.0 with a naive recursive Fibonacci implementation via an explicit `pfix` (Y-combinator).
+
+## Reproducing the Compilation
+
+1. Clone the repository:
+
+   ```bash
+   git clone https://github.com/Unisay/scalus-cape-submissions
+   cd scalus-cape-submissions
+   ```
+
+2. Check out the specific commit:
+
+   ```bash
+   git checkout 0c8cfdb82fff4e10cd0fdf41e69738886edd7491
+   ```
+
+3. Follow build instructions in the repository README
+
+4. The compiled UPLC output should match `fibonacci.uplc` in this submission
+
+For detailed build instructions and environment setup, see the repository README.

--- a/submissions/fibonacci_naive_recursion/Scalus_0.17.0_Unisay/README.md
+++ b/submissions/fibonacci_naive_recursion/Scalus_0.17.0_Unisay/README.md
@@ -1,0 +1,23 @@
+# Benchmark Implementation Notes
+
+**Scenario**: `fibonacci_naive_recursion`
+
+**Submission ID**: `Scalus_0.17.0_Unisay`
+
+## Implementation Details
+
+- **Compiler**: `Scalus 0.17.0`
+- **Implementation Approach**: `naive recursive`
+- **Compilation Flags**: `default`
+
+## Performance Results
+
+- See [metrics.json](metrics.json) for detailed performance measurements
+
+## Source Code
+
+- See [source/README.md](source/README.md) for source code and reproducibility instructions
+
+## Notes
+
+This submission implements the fibonacci_naive_recursion scenario using the prescribed naive recursive approach. The source code is maintained in a separate repository to avoid duplication.

--- a/submissions/fibonacci_naive_recursion/Scalus_0.17.0_Unisay/fibonacci.uplc
+++ b/submissions/fibonacci_naive_recursion/Scalus_0.17.0_Unisay/fibonacci.uplc
@@ -1,11 +1,67 @@
-(program 1.1.0 [(lam a
-      [(lam b [(lam c [b (lam d [c c d])]) (lam c [b (lam d [c c d])])]) (lam e
-          (lam f
-            (force (case (constr 0 [(builtin lessThanEqualsInteger) f
-                  (con integer 1)] (delay f)
-                (delay (force (case (constr 0 [(builtin equalsInteger) f
-                      (con integer 2)] (delay (con integer 1))
-                    (delay [(builtin addInteger) [e [(builtin subtractInteger) f
-                          (con integer 1)]] [e [(builtin subtractInteger) f
-                          (con integer 2)]]])) a)))) a))))])
-    (force (builtin ifThenElse))])
+(program
+  1.1.0
+  [
+    (lam
+      a-0
+      [
+        (lam
+          b-1
+          [
+            (lam c-2 [ b-1 (lam d-3 [ [ c-2 c-2 ] d-3 ]) ])
+            (lam c-2 [ b-1 (lam d-3 [ [ c-2 c-2 ] d-3 ]) ])
+          ]
+        )
+        (lam
+          e-4
+          (lam
+            f-5
+            (force
+              (case
+                (constr
+                  0
+                  [ [ (builtin lessThanEqualsInteger) f-5 ] (con integer 1) ]
+                  (delay f-5)
+                  (delay
+                    (force
+                      (case
+                        (constr
+                          0
+                          [ [ (builtin equalsInteger) f-5 ] (con integer 2) ]
+                          (delay (con integer 1))
+                          (delay
+                            [
+                              [
+                                (builtin addInteger)
+                                [
+                                  e-4
+                                  [
+                                    [ (builtin subtractInteger) f-5 ]
+                                    (con integer 1)
+                                  ]
+                                ]
+                              ]
+                              [
+                                e-4
+                                [
+                                  [ (builtin subtractInteger) f-5 ]
+                                  (con integer 2)
+                                ]
+                              ]
+                            ]
+                          )
+                        )
+                        a-0
+                      )
+                    )
+                  )
+                )
+                a-0
+              )
+            )
+          )
+        )
+      ]
+    )
+    (force (builtin ifThenElse))
+  ]
+)

--- a/submissions/fibonacci_naive_recursion/Scalus_0.17.0_Unisay/fibonacci.uplc
+++ b/submissions/fibonacci_naive_recursion/Scalus_0.17.0_Unisay/fibonacci.uplc
@@ -1,0 +1,11 @@
+(program 1.1.0 [(lam a
+      [(lam b [(lam c [b (lam d [c c d])]) (lam c [b (lam d [c c d])])]) (lam e
+          (lam f
+            (force (case (constr 0 [(builtin lessThanEqualsInteger) f
+                  (con integer 1)] (delay f)
+                (delay (force (case (constr 0 [(builtin equalsInteger) f
+                      (con integer 2)] (delay (con integer 1))
+                    (delay [(builtin addInteger) [e [(builtin subtractInteger) f
+                          (con integer 1)]] [e [(builtin subtractInteger) f
+                          (con integer 2)]]])) a)))) a))))])
+    (force (builtin ifThenElse))])

--- a/submissions/fibonacci_naive_recursion/Scalus_0.17.0_Unisay/metadata.json
+++ b/submissions/fibonacci_naive_recursion/Scalus_0.17.0_Unisay/metadata.json
@@ -1,0 +1,25 @@
+{
+  "compiler": {
+    "name": "Scalus",
+    "version": "0.17.0",
+    "commit_hash": "553d4d420166d87efad7220ce288e0961cfe17c0"
+  },
+  "compilation_config": {
+    "optimization_level": "Scalus",
+    "target": "uplc",
+    "flags": ["Scalus"]
+  },
+  "contributors": [
+    {
+      "name": "Unisay",
+      "organization": "Intersect MBO"
+    }
+  ],
+  "submission": {
+    "date": "2026-05-05T17:30:00Z",
+    "source_available": true,
+    "source_repository": "https://github.com/Unisay/scalus-cape-submissions",
+    "source_commit_hash": "0c8cfdb82fff4e10cd0fdf41e69738886edd7491",
+    "implementation_notes": "Scalus with default options (naive recursive implementation, no optimization). AST-level alpha-rename pass applied: all generated identifiers rewritten to short purely-alphabetic names before serialisation."
+  }
+}

--- a/submissions/fibonacci_naive_recursion/Scalus_0.17.0_Unisay/metrics.json
+++ b/submissions/fibonacci_naive_recursion/Scalus_0.17.0_Unisay/metrics.json
@@ -1,0 +1,117 @@
+{
+  "evaluations": [
+    {
+      "cpu_units": 567986,
+      "description": "Fibonacci of 0 should return 0",
+      "execution_result": "success",
+      "memory_units": 2902,
+      "name": "fibonacci_0"
+    },
+    {
+      "cpu_units": 567986,
+      "description": "Fibonacci of 1 should return 1",
+      "execution_result": "success",
+      "memory_units": 2902,
+      "name": "fibonacci_1"
+    },
+    {
+      "cpu_units": 872368,
+      "description": "Fibonacci of 2 should return 1",
+      "execution_result": "success",
+      "memory_units": 4004,
+      "name": "fibonacci_2"
+    },
+    {
+      "cpu_units": 2648146,
+      "description": "Fibonacci of 3 should return 2",
+      "execution_result": "success",
+      "memory_units": 10916,
+      "name": "fibonacci_3"
+    },
+    {
+      "cpu_units": 8584244,
+      "description": "Fibonacci of 5 should return 5",
+      "execution_result": "success",
+      "memory_units": 33856,
+      "name": "fibonacci_5"
+    },
+    {
+      "cpu_units": 40040512,
+      "description": "Fibonacci of 8 should return 21",
+      "execution_result": "success",
+      "memory_units": 155468,
+      "name": "fibonacci_8"
+    },
+    {
+      "cpu_units": 106808986,
+      "description": "Fibonacci of 10 should return 55",
+      "execution_result": "success",
+      "memory_units": 413618,
+      "name": "fibonacci_10"
+    },
+    {
+      "cpu_units": 1196768802,
+      "description": "Fibonacci of 15 should return 610",
+      "execution_result": "success",
+      "memory_units": 4627764,
+      "name": "fibonacci_15"
+    },
+    {
+      "cpu_units": 13284551520,
+      "description": "Fibonacci of 20 should return 6765",
+      "execution_result": "success",
+      "memory_units": 51363132,
+      "name": "fibonacci_20"
+    },
+    {
+      "cpu_units": 147340121234,
+      "description": "Fibonacci of 25 should return 75025 (original benchmark target)",
+      "execution_result": "success",
+      "memory_units": 569666326,
+      "name": "fibonacci_25"
+    },
+    {
+      "cpu_units": 567986,
+      "description": "Fibonacci of negative number should return the negative number itself based on current implementation",
+      "execution_result": "success",
+      "memory_units": 2902,
+      "name": "fibonacci_negative"
+    }
+  ],
+  "execution_environment": {
+    "evaluator": "<evaluator-version>"
+  },
+  "measurements": {
+    "block_cpu_budget_pct": 368.350303085,
+    "block_memory_budget_pct": 918.8166548387096,
+    "cpu_units": {
+      "maximum": 147340121234,
+      "median": 8584244,
+      "minimum": 567986,
+      "sum": 161982099770,
+      "sum_negative": 0,
+      "sum_positive": 161982099770
+    },
+    "execution_fee_lovelace": 47815485,
+    "memory_units": {
+      "maximum": 569666326,
+      "median": 33856,
+      "minimum": 2902,
+      "sum": 626283790,
+      "sum_negative": 0,
+      "sum_positive": 626283790
+    },
+    "reference_script_fee_lovelace": 1110,
+    "script_size_bytes": 74,
+    "scripts_per_block": 0,
+    "scripts_per_tx": 0,
+    "term_size": 68,
+    "total_fee_lovelace": 47816595,
+    "tx_cpu_budget_pct": 1473.40121234,
+    "tx_memory_budget_pct": 4069.0451857142853
+  },
+  "scenario": "fibonacci_naive_recursion",
+  "timestamp": "2026-05-05T17:32:05Z",
+  "version": "1.0.0",
+  "notes": "<optional notes>"
+}

--- a/submissions/fibonacci_naive_recursion/Scalus_0.17.0_Unisay/source/README.md
+++ b/submissions/fibonacci_naive_recursion/Scalus_0.17.0_Unisay/source/README.md
@@ -1,0 +1,32 @@
+# Scalus Fibonacci Naive Recursion Implementation
+
+**Source Code**: [FibonacciNaiveRecursion.scala](https://github.com/Unisay/scalus-cape-submissions/blob/0c8cfdb82fff4e10cd0fdf41e69738886edd7491/src/fibonacci_naive_recursion/FibonacciNaiveRecursion.scala)
+
+**Repository**: <https://github.com/Unisay/scalus-cape-submissions>
+
+**Commit**: `0c8cfdb82fff4e10cd0fdf41e69738886edd7491`
+
+**Path**: `src/fibonacci_naive_recursion/FibonacciNaiveRecursion.scala`
+
+This submission uses Scalus compiler version 0.17.0 with a naive recursive implementation (no optimization, per scenario specification).
+
+## Reproducing the Compilation
+
+1. Clone the repository:
+
+   ```bash
+   git clone https://github.com/Unisay/scalus-cape-submissions
+   cd scalus-cape-submissions
+   ```
+
+2. Check out the specific commit:
+
+   ```bash
+   git checkout 0c8cfdb82fff4e10cd0fdf41e69738886edd7491
+   ```
+
+3. Follow build instructions in the repository README
+
+4. The compiled UPLC output should match `fibonacci.uplc` in this submission
+
+For detailed build instructions and environment setup, see the repository README.

--- a/submissions/htlc/Scalus_0.17.0_Unisay/README.md
+++ b/submissions/htlc/Scalus_0.17.0_Unisay/README.md
@@ -1,0 +1,23 @@
+# Benchmark Implementation Notes
+
+**Scenario**: `htlc`
+
+**Submission ID**: `Scalus_0.17.0_Unisay`
+
+## Implementation Details
+
+- **Compiler**: `Scalus 0.17.0`
+- **Implementation Approach**: `idiomatic @Compile spending validator, Data -> Unit, derived FromData/ToData`
+- **Compilation Flags**: `default`
+
+## Performance Results
+
+- See [metrics.json](metrics.json) for detailed performance measurements
+
+## Source Code
+
+- See [source/README.md](source/README.md) for source code and reproducibility instructions
+
+## Notes
+
+Scalus spending validator matching the production-safe validity-range convention introduced in #170: claim reads the upper bound of `txInfoValidRange` (finite, strictly `< timeout`); refund reads the lower bound (finite, strictly `> timeout`). Datum and redeemer shapes are identical to the Plinth reference (`HTLCDatum = 0(payer, recipient, secretHash, timeout)`; `Claim(preimage) = 0(preimage)`, `Refund = 1()`). The source is maintained in a separate repository to avoid duplication.

--- a/submissions/htlc/Scalus_0.17.0_Unisay/htlc.uplc
+++ b/submissions/htlc/Scalus_0.17.0_Unisay/htlc.uplc
@@ -1,363 +1,1630 @@
-(program 1.1.0 (case (constr 0 (force (force (builtin chooseList)))
-      (force (force (builtin fstPair))) (force (builtin headList))
-      (force (builtin ifThenElse)) (force (builtin mkCons))
-      (force (force (builtin sndPair))) (force (builtin tailList))) (lam a
-      (lam b
-        (lam c
-          (lam d
-            (lam e
-              (lam f
-                (lam g
-                  [(lam h
-                      [(lam i
-                          [(lam j
-                              [(lam k
-                                  [(lam l
-                                      [(lam m
-                                          [(lam n
-                                              (lam o
-                                                [(lam p
-                                                    [(lam q
-                                                        [(lam r
-                                                            (force (case (constr 0 [(builtin equalsInteger)
-                                                                  [b r]
-                                                                  (con integer 1)]
-                                                                (delay [(lam s
-                                                                    [(lam t
-                                                                        [(lam u
-                                                                            (force (case (constr 0 [(builtin equalsInteger)
-                                                                                  [b
-                                                                                    u]
-                                                                                  (con integer 0)]
-                                                                                (delay (case (constr 0 [f
-                                                                                      [(builtin unConstrData)
-                                                                                        [c
-                                                                                          p]]]
-                                                                                    [f
-                                                                                      [(builtin unConstrData)
-                                                                                        [c
-                                                                                          s]]]
-                                                                                    t
-                                                                                    [(builtin unBData)
-                                                                                      [c
-                                                                                        [f
-                                                                                          u]]]) (lam v
-                                                                                    (lam w
-                                                                                      (lam x
-                                                                                        (lam y
-                                                                                          [(lam z
-                                                                                              [(lam aa
-                                                                                                  [(lam ab
-                                                                                                      [(lam ac
-                                                                                                          [(lam ad
-                                                                                                              (force (case (constr 0 [(builtin equalsInteger)
-                                                                                                                    [(builtin unIData)
-                                                                                                                      [m
-                                                                                                                        v
-                                                                                                                        [n
-                                                                                                                          v
-                                                                                                                          w]]]
-                                                                                                                    (con integer 1)]
-                                                                                                                  (delay (con unit ()))
-                                                                                                                  (delay (error))) d)))
-                                                                                                            (force (case (constr 0 [(builtin lessThanInteger)
-                                                                                                                  [(lam ae
-                                                                                                                      [(lam af
-                                                                                                                          (force (case (constr 0 [(builtin equalsInteger)
-                                                                                                                                [b
-                                                                                                                                  af]
-                                                                                                                                (con integer 1)]
-                                                                                                                              (delay [(lam ag
-                                                                                                                                  (force (case (constr 0 (case (constr 0 [(builtin equalsInteger)
-                                                                                                                                            [b
-                                                                                                                                              [(builtin unConstrData)
-                                                                                                                                                [c
-                                                                                                                                                  [g
-                                                                                                                                                    ae]]]]
-                                                                                                                                            (con integer 0)]
-                                                                                                                                          (con bool False)
-                                                                                                                                          (con bool True)) d)
-                                                                                                                                      (delay [(builtin unIData)
-                                                                                                                                        [c
-                                                                                                                                          ag]])
-                                                                                                                                      (delay [(builtin subtractInteger)
-                                                                                                                                        [(builtin unIData)
-                                                                                                                                          [c
-                                                                                                                                            ag]]
-                                                                                                                                        (con integer 1)])) d)))
-                                                                                                                                [f
-                                                                                                                                  af]])
-                                                                                                                              (delay (error))) d)))
-                                                                                                                        [(builtin unConstrData)
-                                                                                                                          [c
-                                                                                                                            ae]]])
-                                                                                                                    [f
-                                                                                                                      [(builtin unConstrData)
-                                                                                                                        [c
-                                                                                                                          [g
-                                                                                                                            [f
-                                                                                                                              [(builtin unConstrData)
-                                                                                                                                [c
-                                                                                                                                  [g
-                                                                                                                                    [g
-                                                                                                                                      [g
-                                                                                                                                        [g
-                                                                                                                                          [g
-                                                                                                                                            [g
-                                                                                                                                              [g
-                                                                                                                                                v]]]]]]]]]]]]]]]
-                                                                                                                  [(builtin unIData)
-                                                                                                                    [c
-                                                                                                                      [g
-                                                                                                                        aa]]]]
-                                                                                                                (delay (con unit ()))
-                                                                                                                (delay (error))) d))])
-                                                                                                        (force (case (constr 0 [j
-                                                                                                              v
-                                                                                                              [k
-                                                                                                                [f
-                                                                                                                  [(builtin unConstrData)
-                                                                                                                    [c
-                                                                                                                      z]]]]]
-                                                                                                            (delay (con unit ()))
-                                                                                                            (delay (error))) d))])
-                                                                                                    (force (case (constr 0 [(builtin equalsByteString)
-                                                                                                          [(builtin sha2_256)
-                                                                                                            y]
-                                                                                                          [(builtin unBData)
-                                                                                                            [c
-                                                                                                              aa]]]
-                                                                                                        (delay (con unit ()))
-                                                                                                        (delay (error))) d))])
-                                                                                                [g
-                                                                                                  z]])
-                                                                                            [g
-                                                                                              x]]))))))
-                                                                                (delay (case (constr 0 [f
-                                                                                      [(builtin unConstrData)
-                                                                                        [c
-                                                                                          p]]]
-                                                                                    [f
-                                                                                      [(builtin unConstrData)
-                                                                                        [c
-                                                                                          s]]]
-                                                                                    t) (lam ah
-                                                                                    (lam ai
-                                                                                      (lam aj
-                                                                                        [(lam ak
-                                                                                            [(lam al
-                                                                                                (force (case (constr 0 [(builtin equalsInteger)
-                                                                                                      [(builtin unIData)
-                                                                                                        [m
-                                                                                                          ah
-                                                                                                          [n
-                                                                                                            ah
-                                                                                                            ai]]]
-                                                                                                      (con integer 1)]
-                                                                                                    (delay (con unit ()))
-                                                                                                    (delay (error))) d)))
-                                                                                              (force (case (constr 0 [(builtin lessThanInteger)
-                                                                                                    [(builtin unIData)
-                                                                                                      [c
-                                                                                                        [g
-                                                                                                          [g
-                                                                                                            [g
-                                                                                                              aj]]]]]
-                                                                                                    [(lam am
-                                                                                                        [(lam an
-                                                                                                            (force (case (constr 0 [(builtin equalsInteger)
-                                                                                                                  [b
-                                                                                                                    an]
-                                                                                                                  (con integer 1)]
-                                                                                                                (delay [(lam ao
-                                                                                                                    (force (case (constr 0 (case (constr 0 [(builtin equalsInteger)
-                                                                                                                              [b
-                                                                                                                                [(builtin unConstrData)
-                                                                                                                                  [c
-                                                                                                                                    [g
-                                                                                                                                      am]]]]
-                                                                                                                              (con integer 0)]
-                                                                                                                            (con bool False)
-                                                                                                                            (con bool True)) d)
-                                                                                                                        (delay [(builtin unIData)
-                                                                                                                          [c
-                                                                                                                            ao]])
-                                                                                                                        (delay [(builtin addInteger)
-                                                                                                                          [(builtin unIData)
-                                                                                                                            [c
-                                                                                                                              ao]]
-                                                                                                                          (con integer 1)])) d)))
-                                                                                                                  [f
-                                                                                                                    an]])
-                                                                                                                (delay (error))) d)))
-                                                                                                          [(builtin unConstrData)
-                                                                                                            [c
-                                                                                                              am]]])
-                                                                                                      [f
-                                                                                                        [(builtin unConstrData)
-                                                                                                          [c
-                                                                                                            [f
-                                                                                                              [(builtin unConstrData)
-                                                                                                                [c
-                                                                                                                  [g
-                                                                                                                    [g
-                                                                                                                      [g
-                                                                                                                        [g
-                                                                                                                          [g
-                                                                                                                            [g
-                                                                                                                              [g
-                                                                                                                                ah]]]]]]]]]]]]]]]
-                                                                                                  (delay (con unit ()))
-                                                                                                  (delay (error))) d))])
-                                                                                          (force (case (constr 0 [j
-                                                                                                ah
-                                                                                                [k
-                                                                                                  [f
-                                                                                                    [(builtin unConstrData)
-                                                                                                      [c
-                                                                                                        aj]]]]]
-                                                                                              (delay (con unit ()))
-                                                                                              (delay (error))) d))])))))) d)))
-                                                                          [(builtin unConstrData)
-                                                                            [c
-                                                                              q]]])
-                                                                      [(lam ap
-                                                                          (force (case (constr 0 [(builtin equalsInteger)
-                                                                                [b
-                                                                                  ap]
-                                                                                (con integer 0)]
-                                                                              (delay [f
-                                                                                [(builtin unConstrData)
-                                                                                  [c
-                                                                                    [f
-                                                                                      ap]]]])
-                                                                              (delay (error))) d)))
-                                                                        [(builtin unConstrData)
-                                                                          [c [g
-                                                                              s]]]]])
-                                                                  [f r]])
-                                                                (delay (error))) d)))
-                                                          [(builtin unConstrData)
-                                                            [c [g q]]]]) [g p]])
-                                                  [f [(builtin unConstrData)
-                                                      o]]])) (lam aq
-                                              (lam ar
-                                                [(lam as
-                                                    (force (case (constr 0 [(builtin equalsInteger)
-                                                          [b as]
-                                                          (con integer 0)]
-                                                        (delay [(lam at
-                                                            (force (case (constr 0 [(builtin equalsInteger)
-                                                                  [b at]
-                                                                  (con integer 1)]
-                                                                (delay [(builtin unBData)
-                                                                  [c [f at]]])
-                                                                (delay (error))) d)))
-                                                          [(builtin unConstrData)
-                                                            [c [f
-                                                                [(builtin unConstrData)
-                                                                  [c [f
-                                                                      [(builtin unConstrData)
-                                                                        [c [g [f
-                                                                              [(builtin unConstrData)
-                                                                                [c
-                                                                                  [f
-                                                                                    as]]]]]]]]]]]]]])
-                                                        (delay (error))) d)))
-                                                  [(builtin unConstrData)
-                                                    [(lam au
-                                                        (lam av
-                                                          [i au [(lam aw
-                                                                (lam ax
-                                                                  [(builtin equalsData)
-                                                                    [c [f
-                                                                        [(builtin unConstrData)
-                                                                          ax]]]
-                                                                    aw]))
-                                                              [(builtin constrData)
-                                                                (con integer 0)
-                                                                av]]]))
-                                                      [(builtin unListData) [c
-                                                          aq]] ar]]]))]) (lam ay
-                                          (lam az
-                                            [(lam ba
-                                                (lam bb
-                                                  (case (constr 0 ba
-                                                      (con data (I 0)) (lam bc
-                                                        [(lam bd
-                                                            (lam be
-                                                              [(builtin iData)
-                                                                (force (case (constr 0 [bb
-                                                                      be]
-                                                                    (delay [(builtin addInteger)
-                                                                      bd
-                                                                      (con integer 1)])
-                                                                    (delay bd)) d))]))
-                                                          [(builtin unIData)
-                                                            bc]])) l)))
-                                              [(builtin unListData) [c ay]]
-                                              (lam bf
-                                                [(lam bg
-                                                    (force (case (constr 0 [(builtin equalsInteger)
-                                                          [b bg]
-                                                          (con integer 1)]
-                                                        (delay [(builtin equalsByteString)
-                                                          [(builtin unBData) [c
-                                                              [f bg]]] az])
-                                                        (delay (con bool False))) d)))
-                                                  [(builtin unConstrData) [c [f
-                                                        [(builtin unConstrData)
-                                                          [c [f
-                                                              [(builtin unConstrData)
-                                                                [c [g [f
-                                                                      [(builtin unConstrData)
-                                                                        bf]]]]]]]]]]]])]))])
-                                    [h (lam l
-                                        (lam bh
-                                          (lam bi
-                                            (lam bj
-                                              (force (case (constr 0 bh
-                                                  (delay bi)
-                                                  (delay (case (constr 0 [g bh]
-                                                      [bj bi [c bh]]
-                                                      bj) l))) a))))))]])
-                                (lam bk
-                                  [(lam bl
-                                      (force (case (constr 0 [(builtin equalsInteger)
-                                            [b bl] (con integer 0)]
-                                          (delay [(builtin unBData) [c [f bl]]])
-                                          (delay (error))) d)))
-                                    [(builtin unConstrData) [c bk]]])]) (lam bm
-                              (lam bn
-                                (case (constr 0 [(builtin unListData) [c [g [g
-                                            [g [g [g [g [g [g bm]]]]]]]]]]
-                                    [(builtin bData) bn] (lam bo
-                                      [(lam bp
-                                          (lam bq
-                                            [(builtin equalsByteString) bp
-                                              [(builtin unBData) bq]]))
-                                        [(builtin unBData) bo]])) (lam br
-                                    (lam bs
-                                      (lam bt
-                                        (case (constr 0 (case (constr 0 [(builtin equalsInteger)
-                                                  [b [(builtin unConstrData) [i
-                                                        br (lam bu
-                                                          [(builtin equalsData)
-                                                            bu bs])]]]
-                                                  (con integer 0)]
+(program
+  1.1.0
+  (case
+    (constr
+      0
+      (force (force (builtin chooseList)))
+      (force (force (builtin fstPair)))
+      (force (builtin headList))
+      (force (builtin ifThenElse))
+      (force (builtin mkCons))
+      (force (force (builtin sndPair)))
+      (force (builtin tailList))
+    )
+    (lam
+      a-0
+      (lam
+        b-1
+        (lam
+          c-2
+          (lam
+            d-3
+            (lam
+              e-4
+              (lam
+                f-5
+                (lam
+                  g-6
+                  [
+                    (lam
+                      h-7
+                      [
+                        (lam
+                          i-8
+                          [
+                            (lam
+                              j-9
+                              [
+                                (lam
+                                  k-10
+                                  [
+                                    (lam
+                                      l-11
+                                      [
+                                        (lam
+                                          m-12
+                                          [
+                                            (lam
+                                              n-13
+                                              (lam
+                                                o-14
+                                                [
+                                                  (lam
+                                                    p-15
+                                                    [
+                                                      (lam
+                                                        q-16
+                                                        [
+                                                          (lam
+                                                            r-17
+                                                            (force
+                                                              (case
+                                                                (constr
+                                                                  0
+                                                                  [
+                                                                    [
+                                                                      (builtin
+                                                                        equalsInteger
+                                                                      )
+                                                                      [
+                                                                        b-1 r-17
+                                                                      ]
+                                                                    ]
+                                                                    (con
+                                                                      integer 1
+                                                                    )
+                                                                  ]
+                                                                  (delay
+                                                                    [
+                                                                      (lam
+                                                                        s-18
+                                                                        [
+                                                                          (lam
+                                                                            t-19
+                                                                            [
+                                                                              (lam
+                                                                                u-20
+                                                                                (force
+                                                                                  (case
+                                                                                    (constr
+                                                                                      0
+                                                                                      [
+                                                                                        [
+                                                                                          (builtin
+                                                                                            equalsInteger
+                                                                                          )
+                                                                                          [
+                                                                                            b-1
+                                                                                            u-20
+                                                                                          ]
+                                                                                        ]
+                                                                                        (con
+                                                                                          integer
+                                                                                          0
+                                                                                        )
+                                                                                      ]
+                                                                                      (delay
+                                                                                        (case
+                                                                                          (constr
+                                                                                            0
+                                                                                            [
+                                                                                              f-5
+                                                                                              [
+                                                                                                (builtin
+                                                                                                  unConstrData
+                                                                                                )
+                                                                                                [
+                                                                                                  c-2
+                                                                                                  p-15
+                                                                                                ]
+                                                                                              ]
+                                                                                            ]
+                                                                                            [
+                                                                                              f-5
+                                                                                              [
+                                                                                                (builtin
+                                                                                                  unConstrData
+                                                                                                )
+                                                                                                [
+                                                                                                  c-2
+                                                                                                  s-18
+                                                                                                ]
+                                                                                              ]
+                                                                                            ]
+                                                                                            t-19
+                                                                                            [
+                                                                                              (builtin
+                                                                                                unBData
+                                                                                              )
+                                                                                              [
+                                                                                                c-2
+                                                                                                [
+                                                                                                  f-5
+                                                                                                  u-20
+                                                                                                ]
+                                                                                              ]
+                                                                                            ]
+                                                                                          )
+                                                                                          (lam
+                                                                                            v-21
+                                                                                            (lam
+                                                                                              w-22
+                                                                                              (lam
+                                                                                                x-23
+                                                                                                (lam
+                                                                                                  y-24
+                                                                                                  [
+                                                                                                    (lam
+                                                                                                      z-25
+                                                                                                      [
+                                                                                                        (lam
+                                                                                                          aa-26
+                                                                                                          [
+                                                                                                            (lam
+                                                                                                              ab-27
+                                                                                                              [
+                                                                                                                (lam
+                                                                                                                  ac-28
+                                                                                                                  [
+                                                                                                                    (lam
+                                                                                                                      ad-29
+                                                                                                                      (force
+                                                                                                                        (case
+                                                                                                                          (constr
+                                                                                                                            0
+                                                                                                                            [
+                                                                                                                              [
+                                                                                                                                (builtin
+                                                                                                                                  equalsInteger
+                                                                                                                                )
+                                                                                                                                [
+                                                                                                                                  (builtin
+                                                                                                                                    unIData
+                                                                                                                                  )
+                                                                                                                                  [
+                                                                                                                                    [
+                                                                                                                                      m-12
+                                                                                                                                      v-21
+                                                                                                                                    ]
+                                                                                                                                    [
+                                                                                                                                      [
+                                                                                                                                        n-13
+                                                                                                                                        v-21
+                                                                                                                                      ]
+                                                                                                                                      w-22
+                                                                                                                                    ]
+                                                                                                                                  ]
+                                                                                                                                ]
+                                                                                                                              ]
+                                                                                                                              (con
+                                                                                                                                integer
+                                                                                                                                1
+                                                                                                                              )
+                                                                                                                            ]
+                                                                                                                            (delay
+                                                                                                                              (con
+                                                                                                                                unit
+                                                                                                                                ()
+                                                                                                                              )
+                                                                                                                            )
+                                                                                                                            (delay
+                                                                                                                              (error
+
+                                                                                                                              )
+                                                                                                                            )
+                                                                                                                          )
+                                                                                                                          d-3
+                                                                                                                        )
+                                                                                                                      )
+                                                                                                                    )
+                                                                                                                    (force
+                                                                                                                      (case
+                                                                                                                        (constr
+                                                                                                                          0
+                                                                                                                          [
+                                                                                                                            [
+                                                                                                                              (builtin
+                                                                                                                                lessThanInteger
+                                                                                                                              )
+                                                                                                                              [
+                                                                                                                                (lam
+                                                                                                                                  ae-30
+                                                                                                                                  [
+                                                                                                                                    (lam
+                                                                                                                                      af-31
+                                                                                                                                      (force
+                                                                                                                                        (case
+                                                                                                                                          (constr
+                                                                                                                                            0
+                                                                                                                                            [
+                                                                                                                                              [
+                                                                                                                                                (builtin
+                                                                                                                                                  equalsInteger
+                                                                                                                                                )
+                                                                                                                                                [
+                                                                                                                                                  b-1
+                                                                                                                                                  af-31
+                                                                                                                                                ]
+                                                                                                                                              ]
+                                                                                                                                              (con
+                                                                                                                                                integer
+                                                                                                                                                1
+                                                                                                                                              )
+                                                                                                                                            ]
+                                                                                                                                            (delay
+                                                                                                                                              [
+                                                                                                                                                (lam
+                                                                                                                                                  ag-32
+                                                                                                                                                  (force
+                                                                                                                                                    (case
+                                                                                                                                                      (constr
+                                                                                                                                                        0
+                                                                                                                                                        (case
+                                                                                                                                                          (constr
+                                                                                                                                                            0
+                                                                                                                                                            [
+                                                                                                                                                              [
+                                                                                                                                                                (builtin
+                                                                                                                                                                  equalsInteger
+                                                                                                                                                                )
+                                                                                                                                                                [
+                                                                                                                                                                  b-1
+                                                                                                                                                                  [
+                                                                                                                                                                    (builtin
+                                                                                                                                                                      unConstrData
+                                                                                                                                                                    )
+                                                                                                                                                                    [
+                                                                                                                                                                      c-2
+                                                                                                                                                                      [
+                                                                                                                                                                        g-6
+                                                                                                                                                                        ae-30
+                                                                                                                                                                      ]
+                                                                                                                                                                    ]
+                                                                                                                                                                  ]
+                                                                                                                                                                ]
+                                                                                                                                                              ]
+                                                                                                                                                              (con
+                                                                                                                                                                integer
+                                                                                                                                                                0
+                                                                                                                                                              )
+                                                                                                                                                            ]
+                                                                                                                                                            (con
+                                                                                                                                                              bool
+                                                                                                                                                              False
+                                                                                                                                                            )
+                                                                                                                                                            (con
+                                                                                                                                                              bool
+                                                                                                                                                              True
+                                                                                                                                                            )
+                                                                                                                                                          )
+                                                                                                                                                          d-3
+                                                                                                                                                        )
+                                                                                                                                                        (delay
+                                                                                                                                                          [
+                                                                                                                                                            (builtin
+                                                                                                                                                              unIData
+                                                                                                                                                            )
+                                                                                                                                                            [
+                                                                                                                                                              c-2
+                                                                                                                                                              ag-32
+                                                                                                                                                            ]
+                                                                                                                                                          ]
+                                                                                                                                                        )
+                                                                                                                                                        (delay
+                                                                                                                                                          [
+                                                                                                                                                            [
+                                                                                                                                                              (builtin
+                                                                                                                                                                subtractInteger
+                                                                                                                                                              )
+                                                                                                                                                              [
+                                                                                                                                                                (builtin
+                                                                                                                                                                  unIData
+                                                                                                                                                                )
+                                                                                                                                                                [
+                                                                                                                                                                  c-2
+                                                                                                                                                                  ag-32
+                                                                                                                                                                ]
+                                                                                                                                                              ]
+                                                                                                                                                            ]
+                                                                                                                                                            (con
+                                                                                                                                                              integer
+                                                                                                                                                              1
+                                                                                                                                                            )
+                                                                                                                                                          ]
+                                                                                                                                                        )
+                                                                                                                                                      )
+                                                                                                                                                      d-3
+                                                                                                                                                    )
+                                                                                                                                                  )
+                                                                                                                                                )
+                                                                                                                                                [
+                                                                                                                                                  f-5
+                                                                                                                                                  af-31
+                                                                                                                                                ]
+                                                                                                                                              ]
+                                                                                                                                            )
+                                                                                                                                            (delay
+                                                                                                                                              (error
+
+                                                                                                                                              )
+                                                                                                                                            )
+                                                                                                                                          )
+                                                                                                                                          d-3
+                                                                                                                                        )
+                                                                                                                                      )
+                                                                                                                                    )
+                                                                                                                                    [
+                                                                                                                                      (builtin
+                                                                                                                                        unConstrData
+                                                                                                                                      )
+                                                                                                                                      [
+                                                                                                                                        c-2
+                                                                                                                                        ae-30
+                                                                                                                                      ]
+                                                                                                                                    ]
+                                                                                                                                  ]
+                                                                                                                                )
+                                                                                                                                [
+                                                                                                                                  f-5
+                                                                                                                                  [
+                                                                                                                                    (builtin
+                                                                                                                                      unConstrData
+                                                                                                                                    )
+                                                                                                                                    [
+                                                                                                                                      c-2
+                                                                                                                                      [
+                                                                                                                                        g-6
+                                                                                                                                        [
+                                                                                                                                          f-5
+                                                                                                                                          [
+                                                                                                                                            (builtin
+                                                                                                                                              unConstrData
+                                                                                                                                            )
+                                                                                                                                            [
+                                                                                                                                              c-2
+                                                                                                                                              [
+                                                                                                                                                g-6
+                                                                                                                                                [
+                                                                                                                                                  g-6
+                                                                                                                                                  [
+                                                                                                                                                    g-6
+                                                                                                                                                    [
+                                                                                                                                                      g-6
+                                                                                                                                                      [
+                                                                                                                                                        g-6
+                                                                                                                                                        [
+                                                                                                                                                          g-6
+                                                                                                                                                          [
+                                                                                                                                                            g-6
+                                                                                                                                                            v-21
+                                                                                                                                                          ]
+                                                                                                                                                        ]
+                                                                                                                                                      ]
+                                                                                                                                                    ]
+                                                                                                                                                  ]
+                                                                                                                                                ]
+                                                                                                                                              ]
+                                                                                                                                            ]
+                                                                                                                                          ]
+                                                                                                                                        ]
+                                                                                                                                      ]
+                                                                                                                                    ]
+                                                                                                                                  ]
+                                                                                                                                ]
+                                                                                                                              ]
+                                                                                                                            ]
+                                                                                                                            [
+                                                                                                                              (builtin
+                                                                                                                                unIData
+                                                                                                                              )
+                                                                                                                              [
+                                                                                                                                c-2
+                                                                                                                                [
+                                                                                                                                  g-6
+                                                                                                                                  aa-26
+                                                                                                                                ]
+                                                                                                                              ]
+                                                                                                                            ]
+                                                                                                                          ]
+                                                                                                                          (delay
+                                                                                                                            (con
+                                                                                                                              unit
+                                                                                                                              ()
+                                                                                                                            )
+                                                                                                                          )
+                                                                                                                          (delay
+                                                                                                                            (error
+
+                                                                                                                            )
+                                                                                                                          )
+                                                                                                                        )
+                                                                                                                        d-3
+                                                                                                                      )
+                                                                                                                    )
+                                                                                                                  ]
+                                                                                                                )
+                                                                                                                (force
+                                                                                                                  (case
+                                                                                                                    (constr
+                                                                                                                      0
+                                                                                                                      [
+                                                                                                                        [
+                                                                                                                          j-9
+                                                                                                                          v-21
+                                                                                                                        ]
+                                                                                                                        [
+                                                                                                                          k-10
+                                                                                                                          [
+                                                                                                                            f-5
+                                                                                                                            [
+                                                                                                                              (builtin
+                                                                                                                                unConstrData
+                                                                                                                              )
+                                                                                                                              [
+                                                                                                                                c-2
+                                                                                                                                z-25
+                                                                                                                              ]
+                                                                                                                            ]
+                                                                                                                          ]
+                                                                                                                        ]
+                                                                                                                      ]
+                                                                                                                      (delay
+                                                                                                                        (con
+                                                                                                                          unit
+                                                                                                                          ()
+                                                                                                                        )
+                                                                                                                      )
+                                                                                                                      (delay
+                                                                                                                        (error
+
+                                                                                                                        )
+                                                                                                                      )
+                                                                                                                    )
+                                                                                                                    d-3
+                                                                                                                  )
+                                                                                                                )
+                                                                                                              ]
+                                                                                                            )
+                                                                                                            (force
+                                                                                                              (case
+                                                                                                                (constr
+                                                                                                                  0
+                                                                                                                  [
+                                                                                                                    [
+                                                                                                                      (builtin
+                                                                                                                        equalsByteString
+                                                                                                                      )
+                                                                                                                      [
+                                                                                                                        (builtin
+                                                                                                                          sha2_256
+                                                                                                                        )
+                                                                                                                        y-24
+                                                                                                                      ]
+                                                                                                                    ]
+                                                                                                                    [
+                                                                                                                      (builtin
+                                                                                                                        unBData
+                                                                                                                      )
+                                                                                                                      [
+                                                                                                                        c-2
+                                                                                                                        aa-26
+                                                                                                                      ]
+                                                                                                                    ]
+                                                                                                                  ]
+                                                                                                                  (delay
+                                                                                                                    (con
+                                                                                                                      unit
+                                                                                                                      ()
+                                                                                                                    )
+                                                                                                                  )
+                                                                                                                  (delay
+                                                                                                                    (error
+
+                                                                                                                    )
+                                                                                                                  )
+                                                                                                                )
+                                                                                                                d-3
+                                                                                                              )
+                                                                                                            )
+                                                                                                          ]
+                                                                                                        )
+                                                                                                        [
+                                                                                                          g-6
+                                                                                                          z-25
+                                                                                                        ]
+                                                                                                      ]
+                                                                                                    )
+                                                                                                    [
+                                                                                                      g-6
+                                                                                                      x-23
+                                                                                                    ]
+                                                                                                  ]
+                                                                                                )
+                                                                                              )
+                                                                                            )
+                                                                                          )
+                                                                                        )
+                                                                                      )
+                                                                                      (delay
+                                                                                        (case
+                                                                                          (constr
+                                                                                            0
+                                                                                            [
+                                                                                              f-5
+                                                                                              [
+                                                                                                (builtin
+                                                                                                  unConstrData
+                                                                                                )
+                                                                                                [
+                                                                                                  c-2
+                                                                                                  p-15
+                                                                                                ]
+                                                                                              ]
+                                                                                            ]
+                                                                                            [
+                                                                                              f-5
+                                                                                              [
+                                                                                                (builtin
+                                                                                                  unConstrData
+                                                                                                )
+                                                                                                [
+                                                                                                  c-2
+                                                                                                  s-18
+                                                                                                ]
+                                                                                              ]
+                                                                                            ]
+                                                                                            t-19
+                                                                                          )
+                                                                                          (lam
+                                                                                            ah-33
+                                                                                            (lam
+                                                                                              ai-34
+                                                                                              (lam
+                                                                                                aj-35
+                                                                                                [
+                                                                                                  (lam
+                                                                                                    ak-36
+                                                                                                    [
+                                                                                                      (lam
+                                                                                                        al-37
+                                                                                                        (force
+                                                                                                          (case
+                                                                                                            (constr
+                                                                                                              0
+                                                                                                              [
+                                                                                                                [
+                                                                                                                  (builtin
+                                                                                                                    equalsInteger
+                                                                                                                  )
+                                                                                                                  [
+                                                                                                                    (builtin
+                                                                                                                      unIData
+                                                                                                                    )
+                                                                                                                    [
+                                                                                                                      [
+                                                                                                                        m-12
+                                                                                                                        ah-33
+                                                                                                                      ]
+                                                                                                                      [
+                                                                                                                        [
+                                                                                                                          n-13
+                                                                                                                          ah-33
+                                                                                                                        ]
+                                                                                                                        ai-34
+                                                                                                                      ]
+                                                                                                                    ]
+                                                                                                                  ]
+                                                                                                                ]
+                                                                                                                (con
+                                                                                                                  integer
+                                                                                                                  1
+                                                                                                                )
+                                                                                                              ]
+                                                                                                              (delay
+                                                                                                                (con
+                                                                                                                  unit
+                                                                                                                  ()
+                                                                                                                )
+                                                                                                              )
+                                                                                                              (delay
+                                                                                                                (error
+
+                                                                                                                )
+                                                                                                              )
+                                                                                                            )
+                                                                                                            d-3
+                                                                                                          )
+                                                                                                        )
+                                                                                                      )
+                                                                                                      (force
+                                                                                                        (case
+                                                                                                          (constr
+                                                                                                            0
+                                                                                                            [
+                                                                                                              [
+                                                                                                                (builtin
+                                                                                                                  lessThanInteger
+                                                                                                                )
+                                                                                                                [
+                                                                                                                  (builtin
+                                                                                                                    unIData
+                                                                                                                  )
+                                                                                                                  [
+                                                                                                                    c-2
+                                                                                                                    [
+                                                                                                                      g-6
+                                                                                                                      [
+                                                                                                                        g-6
+                                                                                                                        [
+                                                                                                                          g-6
+                                                                                                                          aj-35
+                                                                                                                        ]
+                                                                                                                      ]
+                                                                                                                    ]
+                                                                                                                  ]
+                                                                                                                ]
+                                                                                                              ]
+                                                                                                              [
+                                                                                                                (lam
+                                                                                                                  am-38
+                                                                                                                  [
+                                                                                                                    (lam
+                                                                                                                      an-39
+                                                                                                                      (force
+                                                                                                                        (case
+                                                                                                                          (constr
+                                                                                                                            0
+                                                                                                                            [
+                                                                                                                              [
+                                                                                                                                (builtin
+                                                                                                                                  equalsInteger
+                                                                                                                                )
+                                                                                                                                [
+                                                                                                                                  b-1
+                                                                                                                                  an-39
+                                                                                                                                ]
+                                                                                                                              ]
+                                                                                                                              (con
+                                                                                                                                integer
+                                                                                                                                1
+                                                                                                                              )
+                                                                                                                            ]
+                                                                                                                            (delay
+                                                                                                                              [
+                                                                                                                                (lam
+                                                                                                                                  ao-40
+                                                                                                                                  (force
+                                                                                                                                    (case
+                                                                                                                                      (constr
+                                                                                                                                        0
+                                                                                                                                        (case
+                                                                                                                                          (constr
+                                                                                                                                            0
+                                                                                                                                            [
+                                                                                                                                              [
+                                                                                                                                                (builtin
+                                                                                                                                                  equalsInteger
+                                                                                                                                                )
+                                                                                                                                                [
+                                                                                                                                                  b-1
+                                                                                                                                                  [
+                                                                                                                                                    (builtin
+                                                                                                                                                      unConstrData
+                                                                                                                                                    )
+                                                                                                                                                    [
+                                                                                                                                                      c-2
+                                                                                                                                                      [
+                                                                                                                                                        g-6
+                                                                                                                                                        am-38
+                                                                                                                                                      ]
+                                                                                                                                                    ]
+                                                                                                                                                  ]
+                                                                                                                                                ]
+                                                                                                                                              ]
+                                                                                                                                              (con
+                                                                                                                                                integer
+                                                                                                                                                0
+                                                                                                                                              )
+                                                                                                                                            ]
+                                                                                                                                            (con
+                                                                                                                                              bool
+                                                                                                                                              False
+                                                                                                                                            )
+                                                                                                                                            (con
+                                                                                                                                              bool
+                                                                                                                                              True
+                                                                                                                                            )
+                                                                                                                                          )
+                                                                                                                                          d-3
+                                                                                                                                        )
+                                                                                                                                        (delay
+                                                                                                                                          [
+                                                                                                                                            (builtin
+                                                                                                                                              unIData
+                                                                                                                                            )
+                                                                                                                                            [
+                                                                                                                                              c-2
+                                                                                                                                              ao-40
+                                                                                                                                            ]
+                                                                                                                                          ]
+                                                                                                                                        )
+                                                                                                                                        (delay
+                                                                                                                                          [
+                                                                                                                                            [
+                                                                                                                                              (builtin
+                                                                                                                                                addInteger
+                                                                                                                                              )
+                                                                                                                                              [
+                                                                                                                                                (builtin
+                                                                                                                                                  unIData
+                                                                                                                                                )
+                                                                                                                                                [
+                                                                                                                                                  c-2
+                                                                                                                                                  ao-40
+                                                                                                                                                ]
+                                                                                                                                              ]
+                                                                                                                                            ]
+                                                                                                                                            (con
+                                                                                                                                              integer
+                                                                                                                                              1
+                                                                                                                                            )
+                                                                                                                                          ]
+                                                                                                                                        )
+                                                                                                                                      )
+                                                                                                                                      d-3
+                                                                                                                                    )
+                                                                                                                                  )
+                                                                                                                                )
+                                                                                                                                [
+                                                                                                                                  f-5
+                                                                                                                                  an-39
+                                                                                                                                ]
+                                                                                                                              ]
+                                                                                                                            )
+                                                                                                                            (delay
+                                                                                                                              (error
+
+                                                                                                                              )
+                                                                                                                            )
+                                                                                                                          )
+                                                                                                                          d-3
+                                                                                                                        )
+                                                                                                                      )
+                                                                                                                    )
+                                                                                                                    [
+                                                                                                                      (builtin
+                                                                                                                        unConstrData
+                                                                                                                      )
+                                                                                                                      [
+                                                                                                                        c-2
+                                                                                                                        am-38
+                                                                                                                      ]
+                                                                                                                    ]
+                                                                                                                  ]
+                                                                                                                )
+                                                                                                                [
+                                                                                                                  f-5
+                                                                                                                  [
+                                                                                                                    (builtin
+                                                                                                                      unConstrData
+                                                                                                                    )
+                                                                                                                    [
+                                                                                                                      c-2
+                                                                                                                      [
+                                                                                                                        f-5
+                                                                                                                        [
+                                                                                                                          (builtin
+                                                                                                                            unConstrData
+                                                                                                                          )
+                                                                                                                          [
+                                                                                                                            c-2
+                                                                                                                            [
+                                                                                                                              g-6
+                                                                                                                              [
+                                                                                                                                g-6
+                                                                                                                                [
+                                                                                                                                  g-6
+                                                                                                                                  [
+                                                                                                                                    g-6
+                                                                                                                                    [
+                                                                                                                                      g-6
+                                                                                                                                      [
+                                                                                                                                        g-6
+                                                                                                                                        [
+                                                                                                                                          g-6
+                                                                                                                                          ah-33
+                                                                                                                                        ]
+                                                                                                                                      ]
+                                                                                                                                    ]
+                                                                                                                                  ]
+                                                                                                                                ]
+                                                                                                                              ]
+                                                                                                                            ]
+                                                                                                                          ]
+                                                                                                                        ]
+                                                                                                                      ]
+                                                                                                                    ]
+                                                                                                                  ]
+                                                                                                                ]
+                                                                                                              ]
+                                                                                                            ]
+                                                                                                            (delay
+                                                                                                              (con
+                                                                                                                unit
+                                                                                                                ()
+                                                                                                              )
+                                                                                                            )
+                                                                                                            (delay
+                                                                                                              (error
+
+                                                                                                              )
+                                                                                                            )
+                                                                                                          )
+                                                                                                          d-3
+                                                                                                        )
+                                                                                                      )
+                                                                                                    ]
+                                                                                                  )
+                                                                                                  (force
+                                                                                                    (case
+                                                                                                      (constr
+                                                                                                        0
+                                                                                                        [
+                                                                                                          [
+                                                                                                            j-9
+                                                                                                            ah-33
+                                                                                                          ]
+                                                                                                          [
+                                                                                                            k-10
+                                                                                                            [
+                                                                                                              f-5
+                                                                                                              [
+                                                                                                                (builtin
+                                                                                                                  unConstrData
+                                                                                                                )
+                                                                                                                [
+                                                                                                                  c-2
+                                                                                                                  aj-35
+                                                                                                                ]
+                                                                                                              ]
+                                                                                                            ]
+                                                                                                          ]
+                                                                                                        ]
+                                                                                                        (delay
+                                                                                                          (con
+                                                                                                            unit
+                                                                                                            ()
+                                                                                                          )
+                                                                                                        )
+                                                                                                        (delay
+                                                                                                          (error
+
+                                                                                                          )
+                                                                                                        )
+                                                                                                      )
+                                                                                                      d-3
+                                                                                                    )
+                                                                                                  )
+                                                                                                ]
+                                                                                              )
+                                                                                            )
+                                                                                          )
+                                                                                        )
+                                                                                      )
+                                                                                    )
+                                                                                    d-3
+                                                                                  )
+                                                                                )
+                                                                              )
+                                                                              [
+                                                                                (builtin
+                                                                                  unConstrData
+                                                                                )
+                                                                                [
+                                                                                  c-2
+                                                                                  q-16
+                                                                                ]
+                                                                              ]
+                                                                            ]
+                                                                          )
+                                                                          [
+                                                                            (lam
+                                                                              ap-41
+                                                                              (force
+                                                                                (case
+                                                                                  (constr
+                                                                                    0
+                                                                                    [
+                                                                                      [
+                                                                                        (builtin
+                                                                                          equalsInteger
+                                                                                        )
+                                                                                        [
+                                                                                          b-1
+                                                                                          ap-41
+                                                                                        ]
+                                                                                      ]
+                                                                                      (con
+                                                                                        integer
+                                                                                        0
+                                                                                      )
+                                                                                    ]
+                                                                                    (delay
+                                                                                      [
+                                                                                        f-5
+                                                                                        [
+                                                                                          (builtin
+                                                                                            unConstrData
+                                                                                          )
+                                                                                          [
+                                                                                            c-2
+                                                                                            [
+                                                                                              f-5
+                                                                                              ap-41
+                                                                                            ]
+                                                                                          ]
+                                                                                        ]
+                                                                                      ]
+                                                                                    )
+                                                                                    (delay
+                                                                                      (error
+
+                                                                                      )
+                                                                                    )
+                                                                                  )
+                                                                                  d-3
+                                                                                )
+                                                                              )
+                                                                            )
+                                                                            [
+                                                                              (builtin
+                                                                                unConstrData
+                                                                              )
+                                                                              [
+                                                                                c-2
+                                                                                [
+                                                                                  g-6
+                                                                                  s-18
+                                                                                ]
+                                                                              ]
+                                                                            ]
+                                                                          ]
+                                                                        ]
+                                                                      )
+                                                                      [
+                                                                        f-5 r-17
+                                                                      ]
+                                                                    ]
+                                                                  )
+                                                                  (delay
+                                                                    (error)
+                                                                  )
+                                                                )
+                                                                d-3
+                                                              )
+                                                            )
+                                                          )
+                                                          [
+                                                            (builtin
+                                                              unConstrData
+                                                            )
+                                                            [ c-2 [ g-6 q-16 ] ]
+                                                          ]
+                                                        ]
+                                                      )
+                                                      [ g-6 p-15 ]
+                                                    ]
+                                                  )
+                                                  [
+                                                    f-5
+                                                    [
+                                                      (builtin unConstrData)
+                                                      o-14
+                                                    ]
+                                                  ]
+                                                ]
+                                              )
+                                            )
+                                            (lam
+                                              aq-42
+                                              (lam
+                                                ar-43
+                                                [
+                                                  (lam
+                                                    as-44
+                                                    (force
+                                                      (case
+                                                        (constr
+                                                          0
+                                                          [
+                                                            [
+                                                              (builtin
+                                                                equalsInteger
+                                                              )
+                                                              [ b-1 as-44 ]
+                                                            ]
+                                                            (con integer 0)
+                                                          ]
+                                                          (delay
+                                                            [
+                                                              (lam
+                                                                at-45
+                                                                (force
+                                                                  (case
+                                                                    (constr
+                                                                      0
+                                                                      [
+                                                                        [
+                                                                          (builtin
+                                                                            equalsInteger
+                                                                          )
+                                                                          [
+                                                                            b-1
+                                                                            at-45
+                                                                          ]
+                                                                        ]
+                                                                        (con
+                                                                          integer
+                                                                          1
+                                                                        )
+                                                                      ]
+                                                                      (delay
+                                                                        [
+                                                                          (builtin
+                                                                            unBData
+                                                                          )
+                                                                          [
+                                                                            c-2
+                                                                            [
+                                                                              f-5
+                                                                              at-45
+                                                                            ]
+                                                                          ]
+                                                                        ]
+                                                                      )
+                                                                      (delay
+                                                                        (error)
+                                                                      )
+                                                                    )
+                                                                    d-3
+                                                                  )
+                                                                )
+                                                              )
+                                                              [
+                                                                (builtin
+                                                                  unConstrData
+                                                                )
+                                                                [
+                                                                  c-2
+                                                                  [
+                                                                    f-5
+                                                                    [
+                                                                      (builtin
+                                                                        unConstrData
+                                                                      )
+                                                                      [
+                                                                        c-2
+                                                                        [
+                                                                          f-5
+                                                                          [
+                                                                            (builtin
+                                                                              unConstrData
+                                                                            )
+                                                                            [
+                                                                              c-2
+                                                                              [
+                                                                                g-6
+                                                                                [
+                                                                                  f-5
+                                                                                  [
+                                                                                    (builtin
+                                                                                      unConstrData
+                                                                                    )
+                                                                                    [
+                                                                                      c-2
+                                                                                      [
+                                                                                        f-5
+                                                                                        as-44
+                                                                                      ]
+                                                                                    ]
+                                                                                  ]
+                                                                                ]
+                                                                              ]
+                                                                            ]
+                                                                          ]
+                                                                        ]
+                                                                      ]
+                                                                    ]
+                                                                  ]
+                                                                ]
+                                                              ]
+                                                            ]
+                                                          )
+                                                          (delay (error))
+                                                        )
+                                                        d-3
+                                                      )
+                                                    )
+                                                  )
+                                                  [
+                                                    (builtin unConstrData)
+                                                    [
+                                                      [
+                                                        (lam
+                                                          au-46
+                                                          (lam
+                                                            av-47
+                                                            [
+                                                              [ i-8 au-46 ]
+                                                              [
+                                                                (lam
+                                                                  aw-48
+                                                                  (lam
+                                                                    ax-49
+                                                                    [
+                                                                      [
+                                                                        (builtin
+                                                                          equalsData
+                                                                        )
+                                                                        [
+                                                                          c-2
+                                                                          [
+                                                                            f-5
+                                                                            [
+                                                                              (builtin
+                                                                                unConstrData
+                                                                              )
+                                                                              ax-49
+                                                                            ]
+                                                                          ]
+                                                                        ]
+                                                                      ]
+                                                                      aw-48
+                                                                    ]
+                                                                  )
+                                                                )
+                                                                [
+                                                                  [
+                                                                    (builtin
+                                                                      constrData
+                                                                    )
+                                                                    (con
+                                                                      integer 0
+                                                                    )
+                                                                  ]
+                                                                  av-47
+                                                                ]
+                                                              ]
+                                                            ]
+                                                          )
+                                                        )
+                                                        [
+                                                          (builtin unListData)
+                                                          [ c-2 aq-42 ]
+                                                        ]
+                                                      ]
+                                                      ar-43
+                                                    ]
+                                                  ]
+                                                ]
+                                              )
+                                            )
+                                          ]
+                                        )
+                                        (lam
+                                          ay-50
+                                          (lam
+                                            az-51
+                                            [
+                                              [
+                                                (lam
+                                                  ba-52
+                                                  (lam
+                                                    bb-53
+                                                    (case
+                                                      (constr
+                                                        0
+                                                        ba-52
+                                                        (con data (I 0))
+                                                        (lam
+                                                          bc-54
+                                                          [
+                                                            (lam
+                                                              bd-55
+                                                              (lam
+                                                                be-56
+                                                                [
+                                                                  (builtin
+                                                                    iData
+                                                                  )
+                                                                  (force
+                                                                    (case
+                                                                      (constr
+                                                                        0
+                                                                        [
+                                                                          bb-53
+                                                                          be-56
+                                                                        ]
+                                                                        (delay
+                                                                          [
+                                                                            [
+                                                                              (builtin
+                                                                                addInteger
+                                                                              )
+                                                                              bd-55
+                                                                            ]
+                                                                            (con
+                                                                              integer
+                                                                              1
+                                                                            )
+                                                                          ]
+                                                                        )
+                                                                        (delay
+                                                                          bd-55
+                                                                        )
+                                                                      )
+                                                                      d-3
+                                                                    )
+                                                                  )
+                                                                ]
+                                                              )
+                                                            )
+                                                            [
+                                                              (builtin unIData)
+                                                              bc-54
+                                                            ]
+                                                          ]
+                                                        )
+                                                      )
+                                                      l-11
+                                                    )
+                                                  )
+                                                )
+                                                [
+                                                  (builtin unListData)
+                                                  [ c-2 ay-50 ]
+                                                ]
+                                              ]
+                                              (lam
+                                                bf-57
+                                                [
+                                                  (lam
+                                                    bg-58
+                                                    (force
+                                                      (case
+                                                        (constr
+                                                          0
+                                                          [
+                                                            [
+                                                              (builtin
+                                                                equalsInteger
+                                                              )
+                                                              [ b-1 bg-58 ]
+                                                            ]
+                                                            (con integer 1)
+                                                          ]
+                                                          (delay
+                                                            [
+                                                              [
+                                                                (builtin
+                                                                  equalsByteString
+                                                                )
+                                                                [
+                                                                  (builtin
+                                                                    unBData
+                                                                  )
+                                                                  [
+                                                                    c-2
+                                                                    [
+                                                                      f-5 bg-58
+                                                                    ]
+                                                                  ]
+                                                                ]
+                                                              ]
+                                                              az-51
+                                                            ]
+                                                          )
+                                                          (delay
+                                                            (con bool False)
+                                                          )
+                                                        )
+                                                        d-3
+                                                      )
+                                                    )
+                                                  )
+                                                  [
+                                                    (builtin unConstrData)
+                                                    [
+                                                      c-2
+                                                      [
+                                                        f-5
+                                                        [
+                                                          (builtin unConstrData)
+                                                          [
+                                                            c-2
+                                                            [
+                                                              f-5
+                                                              [
+                                                                (builtin
+                                                                  unConstrData
+                                                                )
+                                                                [
+                                                                  c-2
+                                                                  [
+                                                                    g-6
+                                                                    [
+                                                                      f-5
+                                                                      [
+                                                                        (builtin
+                                                                          unConstrData
+                                                                        )
+                                                                        bf-57
+                                                                      ]
+                                                                    ]
+                                                                  ]
+                                                                ]
+                                                              ]
+                                                            ]
+                                                          ]
+                                                        ]
+                                                      ]
+                                                    ]
+                                                  ]
+                                                ]
+                                              )
+                                            ]
+                                          )
+                                        )
+                                      ]
+                                    )
+                                    [
+                                      h-7
+                                      (lam
+                                        l-11
+                                        (lam
+                                          bh-59
+                                          (lam
+                                            bi-60
+                                            (lam
+                                              bj-61
+                                              (force
+                                                (case
+                                                  (constr
+                                                    0
+                                                    bh-59
+                                                    (delay bi-60)
+                                                    (delay
+                                                      (case
+                                                        (constr
+                                                          0
+                                                          [ g-6 bh-59 ]
+                                                          [
+                                                            [ bj-61 bi-60 ]
+                                                            [ c-2 bh-59 ]
+                                                          ]
+                                                          bj-61
+                                                        )
+                                                        l-11
+                                                      )
+                                                    )
+                                                  )
+                                                  a-0
+                                                )
+                                              )
+                                            )
+                                          )
+                                        )
+                                      )
+                                    ]
+                                  ]
+                                )
+                                (lam
+                                  bk-62
+                                  [
+                                    (lam
+                                      bl-63
+                                      (force
+                                        (case
+                                          (constr
+                                            0
+                                            [
+                                              [
+                                                (builtin equalsInteger)
+                                                [ b-1 bl-63 ]
+                                              ]
+                                              (con integer 0)
+                                            ]
+                                            (delay
+                                              [
+                                                (builtin unBData)
+                                                [ c-2 [ f-5 bl-63 ] ]
+                                              ]
+                                            )
+                                            (delay (error))
+                                          )
+                                          d-3
+                                        )
+                                      )
+                                    )
+                                    [ (builtin unConstrData) [ c-2 bk-62 ] ]
+                                  ]
+                                )
+                              ]
+                            )
+                            (lam
+                              bm-64
+                              (lam
+                                bn-65
+                                (case
+                                  (constr
+                                    0
+                                    [
+                                      (builtin unListData)
+                                      [
+                                        c-2
+                                        [
+                                          g-6
+                                          [
+                                            g-6
+                                            [
+                                              g-6
+                                              [
+                                                g-6
+                                                [
+                                                  g-6
+                                                  [ g-6 [ g-6 [ g-6 bm-64 ] ] ]
+                                                ]
+                                              ]
+                                            ]
+                                          ]
+                                        ]
+                                      ]
+                                    ]
+                                    [ (builtin bData) bn-65 ]
+                                    (lam
+                                      bo-66
+                                      [
+                                        (lam
+                                          bp-67
+                                          (lam
+                                            bq-68
+                                            [
+                                              [
+                                                (builtin equalsByteString) bp-67
+                                              ]
+                                              [ (builtin unBData) bq-68 ]
+                                            ]
+                                          )
+                                        )
+                                        [ (builtin unBData) bo-66 ]
+                                      ]
+                                    )
+                                  )
+                                  (lam
+                                    br-69
+                                    (lam
+                                      bs-70
+                                      (lam
+                                        bt-71
+                                        (case
+                                          (constr
+                                            0
+                                            (case
+                                              (constr
+                                                0
+                                                [
+                                                  [
+                                                    (builtin equalsInteger)
+                                                    [
+                                                      b-1
+                                                      [
+                                                        (builtin unConstrData)
+                                                        [
+                                                          [ i-8 br-69 ]
+                                                          (lam
+                                                            bu-72
+                                                            [
+                                                              [
+                                                                (builtin
+                                                                  equalsData
+                                                                )
+                                                                bu-72
+                                                              ]
+                                                              bs-70
+                                                            ]
+                                                          )
+                                                        ]
+                                                      ]
+                                                    ]
+                                                  ]
+                                                  (con integer 0)
+                                                ]
                                                 (con bool False)
-                                                (con bool True)) d)
+                                                (con bool True)
+                                              )
+                                              d-3
+                                            )
                                             (con bool False)
-                                            (con bool True)) d)))))))]) [h
-                          (lam i
-                            (lam bv
-                              (lam bw
-                                (force (case (constr 0 bv
-                                    (delay (con data (Constr 1 [])))
-                                    (delay (force (case (constr 0 [bw [c bv]]
-                                        (delay [(builtin constrData)
-                                          (con integer 0) [e [c bv]
-                                            (con (list data) [])]]) (delay [i [g
-                                            bv] bw])) d)))) a)))))]]) (lam bx
-                      [(lam by [bx (lam bz [by by bz])]) (lam by
-                          [bx (lam bz [by by bz])])])])))))))))
+                                            (con bool True)
+                                          )
+                                          d-3
+                                        )
+                                      )
+                                    )
+                                  )
+                                )
+                              )
+                            )
+                          ]
+                        )
+                        [
+                          h-7
+                          (lam
+                            i-8
+                            (lam
+                              bv-73
+                              (lam
+                                bw-74
+                                (force
+                                  (case
+                                    (constr
+                                      0
+                                      bv-73
+                                      (delay (con data (Constr 1 [])))
+                                      (delay
+                                        (force
+                                          (case
+                                            (constr
+                                              0
+                                              [ bw-74 [ c-2 bv-73 ] ]
+                                              (delay
+                                                [
+                                                  [
+                                                    (builtin constrData)
+                                                    (con integer 0)
+                                                  ]
+                                                  [
+                                                    [ e-4 [ c-2 bv-73 ] ]
+                                                    (con (list data) [])
+                                                  ]
+                                                ]
+                                              )
+                                              (delay
+                                                [ [ i-8 [ g-6 bv-73 ] ] bw-74 ]
+                                              )
+                                            )
+                                            d-3
+                                          )
+                                        )
+                                      )
+                                    )
+                                    a-0
+                                  )
+                                )
+                              )
+                            )
+                          )
+                        ]
+                      ]
+                    )
+                    (lam
+                      bx-75
+                      [
+                        (lam
+                          by-76 [ bx-75 (lam bz-77 [ [ by-76 by-76 ] bz-77 ]) ]
+                        )
+                        (lam
+                          by-76 [ bx-75 (lam bz-77 [ [ by-76 by-76 ] bz-77 ]) ]
+                        )
+                      ]
+                    )
+                  ]
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)

--- a/submissions/htlc/Scalus_0.17.0_Unisay/htlc.uplc
+++ b/submissions/htlc/Scalus_0.17.0_Unisay/htlc.uplc
@@ -1,0 +1,363 @@
+(program 1.1.0 (case (constr 0 (force (force (builtin chooseList)))
+      (force (force (builtin fstPair))) (force (builtin headList))
+      (force (builtin ifThenElse)) (force (builtin mkCons))
+      (force (force (builtin sndPair))) (force (builtin tailList))) (lam a
+      (lam b
+        (lam c
+          (lam d
+            (lam e
+              (lam f
+                (lam g
+                  [(lam h
+                      [(lam i
+                          [(lam j
+                              [(lam k
+                                  [(lam l
+                                      [(lam m
+                                          [(lam n
+                                              (lam o
+                                                [(lam p
+                                                    [(lam q
+                                                        [(lam r
+                                                            (force (case (constr 0 [(builtin equalsInteger)
+                                                                  [b r]
+                                                                  (con integer 1)]
+                                                                (delay [(lam s
+                                                                    [(lam t
+                                                                        [(lam u
+                                                                            (force (case (constr 0 [(builtin equalsInteger)
+                                                                                  [b
+                                                                                    u]
+                                                                                  (con integer 0)]
+                                                                                (delay (case (constr 0 [f
+                                                                                      [(builtin unConstrData)
+                                                                                        [c
+                                                                                          p]]]
+                                                                                    [f
+                                                                                      [(builtin unConstrData)
+                                                                                        [c
+                                                                                          s]]]
+                                                                                    t
+                                                                                    [(builtin unBData)
+                                                                                      [c
+                                                                                        [f
+                                                                                          u]]]) (lam v
+                                                                                    (lam w
+                                                                                      (lam x
+                                                                                        (lam y
+                                                                                          [(lam z
+                                                                                              [(lam aa
+                                                                                                  [(lam ab
+                                                                                                      [(lam ac
+                                                                                                          [(lam ad
+                                                                                                              (force (case (constr 0 [(builtin equalsInteger)
+                                                                                                                    [(builtin unIData)
+                                                                                                                      [m
+                                                                                                                        v
+                                                                                                                        [n
+                                                                                                                          v
+                                                                                                                          w]]]
+                                                                                                                    (con integer 1)]
+                                                                                                                  (delay (con unit ()))
+                                                                                                                  (delay (error))) d)))
+                                                                                                            (force (case (constr 0 [(builtin lessThanInteger)
+                                                                                                                  [(lam ae
+                                                                                                                      [(lam af
+                                                                                                                          (force (case (constr 0 [(builtin equalsInteger)
+                                                                                                                                [b
+                                                                                                                                  af]
+                                                                                                                                (con integer 1)]
+                                                                                                                              (delay [(lam ag
+                                                                                                                                  (force (case (constr 0 (case (constr 0 [(builtin equalsInteger)
+                                                                                                                                            [b
+                                                                                                                                              [(builtin unConstrData)
+                                                                                                                                                [c
+                                                                                                                                                  [g
+                                                                                                                                                    ae]]]]
+                                                                                                                                            (con integer 0)]
+                                                                                                                                          (con bool False)
+                                                                                                                                          (con bool True)) d)
+                                                                                                                                      (delay [(builtin unIData)
+                                                                                                                                        [c
+                                                                                                                                          ag]])
+                                                                                                                                      (delay [(builtin subtractInteger)
+                                                                                                                                        [(builtin unIData)
+                                                                                                                                          [c
+                                                                                                                                            ag]]
+                                                                                                                                        (con integer 1)])) d)))
+                                                                                                                                [f
+                                                                                                                                  af]])
+                                                                                                                              (delay (error))) d)))
+                                                                                                                        [(builtin unConstrData)
+                                                                                                                          [c
+                                                                                                                            ae]]])
+                                                                                                                    [f
+                                                                                                                      [(builtin unConstrData)
+                                                                                                                        [c
+                                                                                                                          [g
+                                                                                                                            [f
+                                                                                                                              [(builtin unConstrData)
+                                                                                                                                [c
+                                                                                                                                  [g
+                                                                                                                                    [g
+                                                                                                                                      [g
+                                                                                                                                        [g
+                                                                                                                                          [g
+                                                                                                                                            [g
+                                                                                                                                              [g
+                                                                                                                                                v]]]]]]]]]]]]]]]
+                                                                                                                  [(builtin unIData)
+                                                                                                                    [c
+                                                                                                                      [g
+                                                                                                                        aa]]]]
+                                                                                                                (delay (con unit ()))
+                                                                                                                (delay (error))) d))])
+                                                                                                        (force (case (constr 0 [j
+                                                                                                              v
+                                                                                                              [k
+                                                                                                                [f
+                                                                                                                  [(builtin unConstrData)
+                                                                                                                    [c
+                                                                                                                      z]]]]]
+                                                                                                            (delay (con unit ()))
+                                                                                                            (delay (error))) d))])
+                                                                                                    (force (case (constr 0 [(builtin equalsByteString)
+                                                                                                          [(builtin sha2_256)
+                                                                                                            y]
+                                                                                                          [(builtin unBData)
+                                                                                                            [c
+                                                                                                              aa]]]
+                                                                                                        (delay (con unit ()))
+                                                                                                        (delay (error))) d))])
+                                                                                                [g
+                                                                                                  z]])
+                                                                                            [g
+                                                                                              x]]))))))
+                                                                                (delay (case (constr 0 [f
+                                                                                      [(builtin unConstrData)
+                                                                                        [c
+                                                                                          p]]]
+                                                                                    [f
+                                                                                      [(builtin unConstrData)
+                                                                                        [c
+                                                                                          s]]]
+                                                                                    t) (lam ah
+                                                                                    (lam ai
+                                                                                      (lam aj
+                                                                                        [(lam ak
+                                                                                            [(lam al
+                                                                                                (force (case (constr 0 [(builtin equalsInteger)
+                                                                                                      [(builtin unIData)
+                                                                                                        [m
+                                                                                                          ah
+                                                                                                          [n
+                                                                                                            ah
+                                                                                                            ai]]]
+                                                                                                      (con integer 1)]
+                                                                                                    (delay (con unit ()))
+                                                                                                    (delay (error))) d)))
+                                                                                              (force (case (constr 0 [(builtin lessThanInteger)
+                                                                                                    [(builtin unIData)
+                                                                                                      [c
+                                                                                                        [g
+                                                                                                          [g
+                                                                                                            [g
+                                                                                                              aj]]]]]
+                                                                                                    [(lam am
+                                                                                                        [(lam an
+                                                                                                            (force (case (constr 0 [(builtin equalsInteger)
+                                                                                                                  [b
+                                                                                                                    an]
+                                                                                                                  (con integer 1)]
+                                                                                                                (delay [(lam ao
+                                                                                                                    (force (case (constr 0 (case (constr 0 [(builtin equalsInteger)
+                                                                                                                              [b
+                                                                                                                                [(builtin unConstrData)
+                                                                                                                                  [c
+                                                                                                                                    [g
+                                                                                                                                      am]]]]
+                                                                                                                              (con integer 0)]
+                                                                                                                            (con bool False)
+                                                                                                                            (con bool True)) d)
+                                                                                                                        (delay [(builtin unIData)
+                                                                                                                          [c
+                                                                                                                            ao]])
+                                                                                                                        (delay [(builtin addInteger)
+                                                                                                                          [(builtin unIData)
+                                                                                                                            [c
+                                                                                                                              ao]]
+                                                                                                                          (con integer 1)])) d)))
+                                                                                                                  [f
+                                                                                                                    an]])
+                                                                                                                (delay (error))) d)))
+                                                                                                          [(builtin unConstrData)
+                                                                                                            [c
+                                                                                                              am]]])
+                                                                                                      [f
+                                                                                                        [(builtin unConstrData)
+                                                                                                          [c
+                                                                                                            [f
+                                                                                                              [(builtin unConstrData)
+                                                                                                                [c
+                                                                                                                  [g
+                                                                                                                    [g
+                                                                                                                      [g
+                                                                                                                        [g
+                                                                                                                          [g
+                                                                                                                            [g
+                                                                                                                              [g
+                                                                                                                                ah]]]]]]]]]]]]]]]
+                                                                                                  (delay (con unit ()))
+                                                                                                  (delay (error))) d))])
+                                                                                          (force (case (constr 0 [j
+                                                                                                ah
+                                                                                                [k
+                                                                                                  [f
+                                                                                                    [(builtin unConstrData)
+                                                                                                      [c
+                                                                                                        aj]]]]]
+                                                                                              (delay (con unit ()))
+                                                                                              (delay (error))) d))])))))) d)))
+                                                                          [(builtin unConstrData)
+                                                                            [c
+                                                                              q]]])
+                                                                      [(lam ap
+                                                                          (force (case (constr 0 [(builtin equalsInteger)
+                                                                                [b
+                                                                                  ap]
+                                                                                (con integer 0)]
+                                                                              (delay [f
+                                                                                [(builtin unConstrData)
+                                                                                  [c
+                                                                                    [f
+                                                                                      ap]]]])
+                                                                              (delay (error))) d)))
+                                                                        [(builtin unConstrData)
+                                                                          [c [g
+                                                                              s]]]]])
+                                                                  [f r]])
+                                                                (delay (error))) d)))
+                                                          [(builtin unConstrData)
+                                                            [c [g q]]]]) [g p]])
+                                                  [f [(builtin unConstrData)
+                                                      o]]])) (lam aq
+                                              (lam ar
+                                                [(lam as
+                                                    (force (case (constr 0 [(builtin equalsInteger)
+                                                          [b as]
+                                                          (con integer 0)]
+                                                        (delay [(lam at
+                                                            (force (case (constr 0 [(builtin equalsInteger)
+                                                                  [b at]
+                                                                  (con integer 1)]
+                                                                (delay [(builtin unBData)
+                                                                  [c [f at]]])
+                                                                (delay (error))) d)))
+                                                          [(builtin unConstrData)
+                                                            [c [f
+                                                                [(builtin unConstrData)
+                                                                  [c [f
+                                                                      [(builtin unConstrData)
+                                                                        [c [g [f
+                                                                              [(builtin unConstrData)
+                                                                                [c
+                                                                                  [f
+                                                                                    as]]]]]]]]]]]]]])
+                                                        (delay (error))) d)))
+                                                  [(builtin unConstrData)
+                                                    [(lam au
+                                                        (lam av
+                                                          [i au [(lam aw
+                                                                (lam ax
+                                                                  [(builtin equalsData)
+                                                                    [c [f
+                                                                        [(builtin unConstrData)
+                                                                          ax]]]
+                                                                    aw]))
+                                                              [(builtin constrData)
+                                                                (con integer 0)
+                                                                av]]]))
+                                                      [(builtin unListData) [c
+                                                          aq]] ar]]]))]) (lam ay
+                                          (lam az
+                                            [(lam ba
+                                                (lam bb
+                                                  (case (constr 0 ba
+                                                      (con data (I 0)) (lam bc
+                                                        [(lam bd
+                                                            (lam be
+                                                              [(builtin iData)
+                                                                (force (case (constr 0 [bb
+                                                                      be]
+                                                                    (delay [(builtin addInteger)
+                                                                      bd
+                                                                      (con integer 1)])
+                                                                    (delay bd)) d))]))
+                                                          [(builtin unIData)
+                                                            bc]])) l)))
+                                              [(builtin unListData) [c ay]]
+                                              (lam bf
+                                                [(lam bg
+                                                    (force (case (constr 0 [(builtin equalsInteger)
+                                                          [b bg]
+                                                          (con integer 1)]
+                                                        (delay [(builtin equalsByteString)
+                                                          [(builtin unBData) [c
+                                                              [f bg]]] az])
+                                                        (delay (con bool False))) d)))
+                                                  [(builtin unConstrData) [c [f
+                                                        [(builtin unConstrData)
+                                                          [c [f
+                                                              [(builtin unConstrData)
+                                                                [c [g [f
+                                                                      [(builtin unConstrData)
+                                                                        bf]]]]]]]]]]]])]))])
+                                    [h (lam l
+                                        (lam bh
+                                          (lam bi
+                                            (lam bj
+                                              (force (case (constr 0 bh
+                                                  (delay bi)
+                                                  (delay (case (constr 0 [g bh]
+                                                      [bj bi [c bh]]
+                                                      bj) l))) a))))))]])
+                                (lam bk
+                                  [(lam bl
+                                      (force (case (constr 0 [(builtin equalsInteger)
+                                            [b bl] (con integer 0)]
+                                          (delay [(builtin unBData) [c [f bl]]])
+                                          (delay (error))) d)))
+                                    [(builtin unConstrData) [c bk]]])]) (lam bm
+                              (lam bn
+                                (case (constr 0 [(builtin unListData) [c [g [g
+                                            [g [g [g [g [g [g bm]]]]]]]]]]
+                                    [(builtin bData) bn] (lam bo
+                                      [(lam bp
+                                          (lam bq
+                                            [(builtin equalsByteString) bp
+                                              [(builtin unBData) bq]]))
+                                        [(builtin unBData) bo]])) (lam br
+                                    (lam bs
+                                      (lam bt
+                                        (case (constr 0 (case (constr 0 [(builtin equalsInteger)
+                                                  [b [(builtin unConstrData) [i
+                                                        br (lam bu
+                                                          [(builtin equalsData)
+                                                            bu bs])]]]
+                                                  (con integer 0)]
+                                                (con bool False)
+                                                (con bool True)) d)
+                                            (con bool False)
+                                            (con bool True)) d)))))))]) [h
+                          (lam i
+                            (lam bv
+                              (lam bw
+                                (force (case (constr 0 bv
+                                    (delay (con data (Constr 1 [])))
+                                    (delay (force (case (constr 0 [bw [c bv]]
+                                        (delay [(builtin constrData)
+                                          (con integer 0) [e [c bv]
+                                            (con (list data) [])]]) (delay [i [g
+                                            bv] bw])) d)))) a)))))]]) (lam bx
+                      [(lam by [bx (lam bz [by by bz])]) (lam by
+                          [bx (lam bz [by by bz])])])])))))))))

--- a/submissions/htlc/Scalus_0.17.0_Unisay/metadata.json
+++ b/submissions/htlc/Scalus_0.17.0_Unisay/metadata.json
@@ -1,0 +1,25 @@
+{
+  "compiler": {
+    "name": "Scalus",
+    "version": "0.17.0",
+    "commit_hash": "553d4d420166d87efad7220ce288e0961cfe17c0"
+  },
+  "compilation_config": {
+    "optimization_level": "Scalus",
+    "target": "uplc",
+    "flags": ["Scalus"]
+  },
+  "contributors": [
+    {
+      "name": "Unisay",
+      "organization": "Intersect MBO"
+    }
+  ],
+  "submission": {
+    "date": "2026-05-05T17:30:00Z",
+    "source_available": true,
+    "source_repository": "https://github.com/Unisay/scalus-cape-submissions",
+    "source_commit_hash": "0c8cfdb82fff4e10cd0fdf41e69738886edd7491",
+    "implementation_notes": "Scalus 0.17.0 HTLC spending validator (`@Compile object HTLCValidator`, `Data -> Unit`). Derives FromData/ToData for HTLCDatum and HTLCRedeemer. Claim reads the upper bound of `txInfoValidRange` (finite, strictly `< timeout`); refund reads the lower bound (finite, strictly `> timeout`). Matches the production-safe convention introduced in IntersectMBO/UPLC-CAPE#170. Uses `toUplcOptimized()` with CaseConstrApply and builtin-packing; an AST-level alpha-rename pass rewrites all generated names to short purely-alphabetic identifiers (a, b, ..., z, aa, ...) before serialisation, ensuring compatibility with the plutus-core 1.45.0.0 textual parser."
+  }
+}

--- a/submissions/htlc/Scalus_0.17.0_Unisay/metrics.json
+++ b/submissions/htlc/Scalus_0.17.0_Unisay/metrics.json
@@ -1,0 +1,215 @@
+{
+  "evaluations": [
+    {
+      "cpu_units": 24688,
+      "description": "Validator fails when redeemer is raw integer 0 instead of constructor 0(preimage)",
+      "execution_result": "success",
+      "memory_units": 132,
+      "name": "redeemer_integer_0"
+    },
+    {
+      "cpu_units": 24688,
+      "description": "Validator fails when redeemer is raw integer 1 instead of constructor 1()",
+      "execution_result": "success",
+      "memory_units": 132,
+      "name": "redeemer_integer_1"
+    },
+    {
+      "cpu_units": 24688,
+      "description": "Validator fails when redeemer is bytestring instead of constructor",
+      "execution_result": "success",
+      "memory_units": 132,
+      "name": "redeemer_bytestring"
+    },
+    {
+      "cpu_units": 24688,
+      "description": "Validator fails when redeemer is list [1 2 3] instead of constructor",
+      "execution_result": "success",
+      "memory_units": 132,
+      "name": "redeemer_list"
+    },
+    {
+      "cpu_units": 2804030,
+      "description": "Validator fails when Claim is constructor 0() with no preimage field",
+      "execution_result": "success",
+      "memory_units": 970,
+      "name": "redeemer_claim_without_preimage"
+    },
+    {
+      "cpu_units": 28176765,
+      "description": "Claim at time=50 with correct preimage and recipient signature should succeed",
+      "execution_result": "success",
+      "memory_units": 78821,
+      "name": "claim_well_before_timeout"
+    },
+    {
+      "cpu_units": 28176765,
+      "description": "Claim at time=99 (just before timeout=100) with correct preimage should succeed",
+      "execution_result": "success",
+      "memory_units": 78821,
+      "name": "claim_just_before_timeout"
+    },
+    {
+      "cpu_units": 26771587,
+      "description": "Refund at time=101 (just after timeout=100) with payer signature should succeed",
+      "execution_result": "success",
+      "memory_units": 75023,
+      "name": "refund_just_after_timeout"
+    },
+    {
+      "cpu_units": 26771587,
+      "description": "Refund at time=200 with payer signature should succeed",
+      "execution_result": "success",
+      "memory_units": 75023,
+      "name": "refund_well_after_timeout"
+    },
+    {
+      "cpu_units": 8916285,
+      "description": "Claim without recipient signature should fail",
+      "execution_result": "success",
+      "memory_units": 21878,
+      "name": "claim_missing_signature"
+    },
+    {
+      "cpu_units": 10406521,
+      "description": "Claim with only payer signature (not recipient) should fail",
+      "execution_result": "success",
+      "memory_units": 21976,
+      "name": "claim_wrong_signature_payer"
+    },
+    {
+      "cpu_units": 10406521,
+      "description": "Claim with only impostor signature (not recipient) should fail",
+      "execution_result": "success",
+      "memory_units": 21976,
+      "name": "claim_wrong_signature_impostor"
+    },
+    {
+      "cpu_units": 6689729,
+      "description": "Claim with preimage #cafebabe (hash does not match) should fail",
+      "execution_result": "success",
+      "memory_units": 21136,
+      "name": "claim_wrong_preimage"
+    },
+    {
+      "cpu_units": 6689729,
+      "description": "Claim with empty preimage (hash does not match) should fail",
+      "execution_result": "success",
+      "memory_units": 21136,
+      "name": "claim_empty_preimage"
+    },
+    {
+      "cpu_units": 16188815,
+      "description": "Claim at time=100 (boundary, must be strictly before timeout) should fail",
+      "execution_result": "success",
+      "memory_units": 42879,
+      "name": "claim_at_timeout"
+    },
+    {
+      "cpu_units": 16188815,
+      "description": "Claim at time=150 (after timeout) should fail even with correct preimage",
+      "execution_result": "success",
+      "memory_units": 42879,
+      "name": "claim_after_timeout"
+    },
+    {
+      "cpu_units": 15100306,
+      "description": "Claim with from_time=50 and no upper bound (+inf) should fail; the upper bound must be finite",
+      "execution_result": "success",
+      "memory_units": 42554,
+      "name": "claim_infinite_upper_bound"
+    },
+    {
+      "cpu_units": 31016676,
+      "description": "Claim with two script inputs should fail (double satisfaction attack)",
+      "execution_result": "success",
+      "memory_units": 85267,
+      "name": "claim_double_satisfaction"
+    },
+    {
+      "cpu_units": 8005444,
+      "description": "Refund without payer signature should fail",
+      "execution_result": "success",
+      "memory_units": 21648,
+      "name": "refund_missing_signature"
+    },
+    {
+      "cpu_units": 9495680,
+      "description": "Refund with only recipient signature (not payer) should fail",
+      "execution_result": "success",
+      "memory_units": 21746,
+      "name": "refund_wrong_signature_recipient"
+    },
+    {
+      "cpu_units": 9495680,
+      "description": "Refund with only impostor signature (not payer) should fail",
+      "execution_result": "success",
+      "memory_units": 21746,
+      "name": "refund_wrong_signature_impostor"
+    },
+    {
+      "cpu_units": 15359637,
+      "description": "Refund at time=50 (before timeout) should fail",
+      "execution_result": "success",
+      "memory_units": 42681,
+      "name": "refund_before_timeout"
+    },
+    {
+      "cpu_units": 15359637,
+      "description": "Refund at time=100 (boundary, must be strictly after timeout) should fail",
+      "execution_result": "success",
+      "memory_units": 42681,
+      "name": "refund_at_timeout"
+    },
+    {
+      "cpu_units": 11256685,
+      "description": "Refund with no lower bound (-inf) should fail; the lower bound must be finite",
+      "execution_result": "success",
+      "memory_units": 22452,
+      "name": "refund_infinite_lower_bound"
+    },
+    {
+      "cpu_units": 30187498,
+      "description": "Refund with two script inputs should fail (double satisfaction attack)",
+      "execution_result": "success",
+      "memory_units": 85069,
+      "name": "refund_double_satisfaction"
+    }
+  ],
+  "execution_environment": {
+    "evaluator": "<evaluator-version>"
+  },
+  "measurements": {
+    "block_cpu_budget_pct": 0.07754169,
+    "block_memory_budget_pct": 0.1375274193548387,
+    "cpu_units": {
+      "maximum": 31016676,
+      "median": 10406521,
+      "minimum": 24688,
+      "sum": 333563144,
+      "sum_negative": 0,
+      "sum_positive": 333563144
+    },
+    "execution_fee_lovelace": 75339,
+    "memory_units": {
+      "maximum": 85267,
+      "median": 21976,
+      "minimum": 132,
+      "sum": 888890,
+      "sum_negative": 0,
+      "sum_positive": 888890
+    },
+    "reference_script_fee_lovelace": 13860,
+    "script_size_bytes": 924,
+    "scripts_per_block": 727,
+    "scripts_per_tx": 164,
+    "term_size": 924,
+    "total_fee_lovelace": 89199,
+    "tx_cpu_budget_pct": 0.31016676,
+    "tx_memory_budget_pct": 0.6090500000000001
+  },
+  "scenario": "htlc",
+  "timestamp": "2026-05-05T17:33:01Z",
+  "version": "1.0.0",
+  "notes": "<optional notes>"
+}

--- a/submissions/htlc/Scalus_0.17.0_Unisay/source/README.md
+++ b/submissions/htlc/Scalus_0.17.0_Unisay/source/README.md
@@ -1,0 +1,32 @@
+# Scalus HTLC Implementation
+
+**Source Code**: [HTLC.scala](https://github.com/Unisay/scalus-cape-submissions/blob/0c8cfdb82fff4e10cd0fdf41e69738886edd7491/src/htlc/HTLC.scala)
+
+**Repository**: <https://github.com/Unisay/scalus-cape-submissions>
+
+**Commit**: `0c8cfdb82fff4e10cd0fdf41e69738886edd7491`
+
+**Path**: `src/htlc/HTLC.scala`
+
+This submission uses Scalus compiler version 0.17.0 with a spending validator that enforces the production-safe validity-range convention (claim reads the upper bound, refund reads the lower bound — both finite and strict).
+
+The artifact is compiled with `toUplcOptimized()` (CaseConstrApply + builtin-packing). An AST-level alpha-rename pass rewrites all generated identifiers to short purely-alphabetic names (a, b, …, z, aa, …) before serialisation. This makes the output compatible with the plutus-core 1.45.0.0 textual parser without sacrificing optimised code size.
+
+## Reproducing the Compilation
+
+1. Clone the repository:
+
+   ```bash
+   git clone https://github.com/Unisay/scalus-cape-submissions
+   cd scalus-cape-submissions
+   ```
+
+2. Check out the specific commit:
+
+   ```bash
+   git checkout 0c8cfdb82fff4e10cd0fdf41e69738886edd7491
+   ```
+
+3. Follow build instructions in the repository README
+
+4. The compiled UPLC output should match `htlc.uplc` in this submission


### PR DESCRIPTION
Closes #179.

## Summary

- Adds five `Scalus_0.17.0_Unisay/` submissions (`factorial`, `factorial_naive_recursion`, `fibonacci`, `fibonacci_naive_recursion`, `htlc`) alongside the existing `Scalus_0.16.0_Unisay/` entries — the per-version delta stays visible in the report.
- Source-repo bump landed on `Unisay/scalus-cape-submissions` @ [`0c8cfdb`](https://github.com/Unisay/scalus-cape-submissions/commit/0c8cfdb82fff4e10cd0fdf41e69738886edd7491) (branch `yura/scalus-0.17.0-bump`).
- All five new submissions pass `cape submission verify` (factorial 10/10, factorial_naive_recursion 10/10, fibonacci 11/11, fibonacci_naive_recursion 11/11, htlc 25/25); `metrics.json` regenerated via `cape submission measure`.

## Source-repo migration

Scalus 0.17.0 is a breaking release: deprecated APIs marked since 0.14.x were removed and the compiler plugin is now published per Scala compiler version. The bump on `Unisay/scalus-cape-submissions` covers:

- `build.sbt`: `scalaVersion` 3.3.6 → 3.3.7, `scalusVersion` 0.16.0 → 0.17.0, plugin renamed to `scalus-plugin_3.3.7` (`%` instead of `%%` because the suffix is now baked into the artifactId).
- Imports: `scalus.Compiler.compile` → `scalus.compiler.compile`, `scalus.builtin.*` → `scalus.uplc.builtin.*`, `scalus.builtin.Builtins.*` → `scalus.uplc.builtin.Builtins.*`, removed `scalus.prelude.{fail, require}` (now reachable via `scalus.cardano.onchain.plutus.prelude.*` wildcard).
- `@Compile` got an explicit import from `scalus.compiler.Compile` (wasn't in the migration map but required after the package move).

## Per-scenario impact

| Scenario | Tests | Size 0.16 → 0.17 | CPU 0.16 → 0.17 | Notes |
|---|---|---|---|---|
| factorial | 10/10 | 416 = 416 | identical | Renamer pass produces a stable alpha-rename; .uplc byte-identical |
| factorial_naive_recursion | 10/10 | 348 → 340 | −94 ExUnits | small win |
| fibonacci | 11/11 | identical | identical | byte-identical |
| fibonacci_naive_recursion | 11/11 | identical | identical | byte-identical |
| htlc | 25/25 | 1497 → **924** (−38%) | −10.9M (−3.2%) | clear win from 0.17 optimizer (CSE/CCE, repr-aware Eq, `@UplcRepr(UplcConstr)`) |

`fibonacci_prepacked` (mentioned as a stretch goal in the issue) is intentionally not added in this PR — kept out of scope.

## Test plan

- [x] `cape submission verify submissions/{factorial,factorial_naive_recursion,fibonacci,fibonacci_naive_recursion,htlc}/Scalus_0.17.0_Unisay`
- [x] `cape submission measure …` regenerated `metrics.json` for each
- [x] `cape submission aggregate --target=current` shows both 0.16.0 and 0.17.0 entries side-by-side
- [x] `Scalus_0.16.0_Unisay/` directories untouched