### PR TITLE
fix(adr): use full slug in ADR-0005 superseded-by link

### DIFF
--- a/doc/adr/0005-custom-builtindata-text-encoding-for-test-cases.md
+++ b/doc/adr/0005-custom-builtindata-text-encoding-for-test-cases.md
@@ -1,6 +1,6 @@
 # Custom BuiltinData Text Encoding for Test Cases
 
-- Status: superseded by [0006](0006-standard-builtindata-formats-with-json-type-dispatch.md)
+- Status: superseded by [0006-standard-builtindata-formats-with-json-type-dispatch](0006-standard-builtindata-formats-with-json-type-dispatch.md)
 - Date: 2025-08-20
 - Tags: testing, builtin-data, parsing, unified-test-system
 


### PR DESCRIPTION
## Summary

- Fixes #183 — Pages deploy has been red since #177 because log4brains rejects the `[0006]` link text in ADR-0005's status line and aborts the ADR site build, which then leaves the `cp -r adr-site deploy/adr` step with nothing to copy.
- Spells the link text as the full slug `0006-standard-builtindata-formats-with-json-type-dispatch`, mirroring the previous fix in 77b5a3a.

## Test plan
- [x] `nix develop --command adr build --out ./adr-site --basePath /UPLC-CAPE/adr` finishes cleanly with all 12 ADRs generated and no `FATAL` from log4brains.
- [ ] On merge, the `Deploy static content to Pages` workflow on `main` succeeds and the published report's preview section shows Scalus alongside Plinth.