### PR TITLE
fix(verify,measure): reject submission-local cape-tests.json

### DIFF
--- a/scripts/cape-subcommands/submission/measure.sh
+++ b/scripts/cape-subcommands/submission/measure.sh
@@ -95,17 +95,17 @@ measure_uplc_file() {
   local scenario
   scenario="$(infer_scenario_from_path "$uplc_file")"
 
+  if [[ -z "$scenario" ]]; then
+    cape_error "Unable to infer scenario for $rel_uplc. Test specification is required."
+    cape_error "Ensure the UPLC file is in a proper submission directory structure."
+    exit 1
+  fi
+
   local submission_dir
   submission_dir="$(dirname "$uplc_file")"
   if [[ -f "$submission_dir/cape-tests.json" ]]; then
     cape_error "Submission-local cape-tests.json is not allowed in $(cape_relpath "$submission_dir")."
     cape_error "Tests belong to the scenario; remove $(cape_relpath "$submission_dir/cape-tests.json") and rely on scenarios/$scenario/cape-tests.json."
-    exit 1
-  fi
-
-  if [[ -z "$scenario" ]]; then
-    cape_error "Unable to infer scenario for $rel_uplc. Test specification is required."
-    cape_error "Ensure the UPLC file is in a proper submission directory structure."
     exit 1
   fi
 

--- a/scripts/cape-subcommands/submission/measure.sh
+++ b/scripts/cape-subcommands/submission/measure.sh
@@ -95,32 +95,32 @@ measure_uplc_file() {
   local scenario
   scenario="$(infer_scenario_from_path "$uplc_file")"
 
-  local tests_flag=()
-  # Prefer a submission-local cape-tests.json when available
+  # Tests are part of the scenario contract. A submission must not ship its
+  # own cape-tests.json: measurements must run against the trusted scenario
+  # tests, not rules supplied by the evaluatee.
   local submission_dir
   submission_dir="$(dirname "$uplc_file")"
-  local submission_tests="$submission_dir/cape-tests.json"
-  if [[ -f "$submission_tests" ]]; then
-    cape_debug "Using submission tests: $(cape_relpath "$submission_tests")"
-    tests_flag+=("-t" "$submission_tests")
-  else
-    if [[ -n "$scenario" ]]; then
-      local tests_file
-      tests_file="$(resolve_tests_for_scenario "$scenario")"
-      if [[ -n "$tests_file" ]]; then
-        cape_debug "Using scenario tests: $(cape_relpath "$tests_file")"
-        tests_flag+=("-t" "$tests_file")
-      else
-        cape_error "No cape-tests.json found for scenario '$scenario'. Test specification is required."
-        cape_error "Create scenarios/$scenario/cape-tests.json with test cases."
-        exit 1
-      fi
-    else
-      cape_error "Unable to infer scenario for $rel_uplc. Test specification is required."
-      cape_error "Ensure the UPLC file is in a proper submission directory structure."
-      exit 1
-    fi
+  if [[ -f "$submission_dir/cape-tests.json" ]]; then
+    cape_error "Submission-local cape-tests.json is not allowed in $(cape_relpath "$submission_dir")."
+    cape_error "Tests belong to the scenario; remove $(cape_relpath "$submission_dir/cape-tests.json") and rely on scenarios/$scenario/cape-tests.json."
+    exit 1
   fi
+
+  if [[ -z "$scenario" ]]; then
+    cape_error "Unable to infer scenario for $rel_uplc. Test specification is required."
+    cape_error "Ensure the UPLC file is in a proper submission directory structure."
+    exit 1
+  fi
+
+  local tests_file
+  tests_file="$(resolve_tests_for_scenario "$scenario")"
+  if [[ -z "$tests_file" ]]; then
+    cape_error "No cape-tests.json found for scenario '$scenario'. Test specification is required."
+    cape_error "Create scenarios/$scenario/cape-tests.json with test cases."
+    exit 1
+  fi
+  cape_debug "Using scenario tests: $(cape_relpath "$tests_file")"
+  local tests_flag=("-t" "$tests_file")
 
   local tmp_raw stdout_tmp
   tmp_raw="$(cape_mktemp)"
@@ -210,7 +210,7 @@ measure_all_submissions() {
     local metadata_file="$submission_dir/metadata.json"
     if [[ -f "$metadata_file" ]]; then
       local min_ver
-      min_ver=$(jq -r '.compilation_config.min_plutus_version // ""' "$metadata_file" 2>/dev/null || true)
+      min_ver=$(jq -r '.compilation_config.min_plutus_version // ""' "$metadata_file" 2> /dev/null || true)
       if cape_is_preview_submission "$min_ver"; then
         cape_info "Skipping preview submission: submissions/${submission_dir#$SUBMISSIONS_ROOT/} (requires plutus-core >= $min_ver)"
         continue
@@ -248,7 +248,7 @@ measure_preview_submissions() {
     local metadata_file="$submission_dir/metadata.json"
     if [[ -f "$metadata_file" ]]; then
       local min_ver
-      min_ver=$(jq -r '.compilation_config.min_plutus_version // ""' "$metadata_file" 2>/dev/null || true)
+      min_ver=$(jq -r '.compilation_config.min_plutus_version // ""' "$metadata_file" 2> /dev/null || true)
       if ! cape_is_preview_submission "$min_ver"; then
         continue
       fi
@@ -285,7 +285,7 @@ measure_preview_submissions() {
     local tmp_raw stdout_tmp
     tmp_raw="$(cape_mktemp)"
     stdout_tmp="$(cape_mktemp)"
-    if (cd "$PROJECT_ROOT" && $preview_measure_cmd -i "$uplc_file" -t "$tests_file" -o "$tmp_raw" 2>/dev/null) > "$stdout_tmp" 2>&1; then
+    if (cd "$PROJECT_ROOT" && $preview_measure_cmd -i "$uplc_file" -t "$tests_file" -o "$tmp_raw" 2> /dev/null) > "$stdout_tmp" 2>&1; then
       # Patch scenario field and write final metrics
       jq --arg s "$scenario" '.scenario = $s' "$tmp_raw" > "$submission_dir/metrics.json"
       cape_success "  ✓ Measured: $rel_path"
@@ -377,7 +377,7 @@ main() {
     local meta="$dir_to_measure/metadata.json"
     if [[ -f "$meta" ]]; then
       local min_ver
-      min_ver=$(jq -r '.compilation_config.min_plutus_version // ""' "$meta" 2>/dev/null || true)
+      min_ver=$(jq -r '.compilation_config.min_plutus_version // ""' "$meta" 2> /dev/null || true)
       if cape_is_preview_submission "$min_ver"; then
         cape_error "Submission requires plutus-core >= $min_ver but the evaluator only supports $CAPE_CURRENT_PLUTUS_VERSION."
         cape_error "Use 'cape submission measure --preview' to evaluate with a compatible version."

--- a/scripts/cape-subcommands/submission/measure.sh
+++ b/scripts/cape-subcommands/submission/measure.sh
@@ -95,9 +95,6 @@ measure_uplc_file() {
   local scenario
   scenario="$(infer_scenario_from_path "$uplc_file")"
 
-  # Tests are part of the scenario contract. A submission must not ship its
-  # own cape-tests.json: measurements must run against the trusted scenario
-  # tests, not rules supplied by the evaluatee.
   local submission_dir
   submission_dir="$(dirname "$uplc_file")"
   if [[ -f "$submission_dir/cape-tests.json" ]]; then

--- a/scripts/cape-subcommands/submission/verify.sh
+++ b/scripts/cape-subcommands/submission/verify.sh
@@ -81,31 +81,30 @@ verify_submission_dir() {
   local scenario
   scenario="$(infer_scenario_from_path "$submission_dir")"
 
-  local tests_flag=()
-
-  # Prefer a submission-local cape-tests.json when available
-  local submission_tests="$submission_dir/cape-tests.json"
-  if [[ -f "$submission_tests" ]]; then
-    cape_debug "Using submission tests: $(cape_relpath "$submission_tests")"
-    tests_flag+=("-t" "$submission_tests")
-  else
-    if [[ -n "$scenario" ]]; then
-      local tests_file
-      tests_file="$(resolve_tests_for_scenario "$scenario")"
-      if [[ -n "$tests_file" ]]; then
-        cape_debug "Using scenario tests: $(cape_relpath "$tests_file")"
-        tests_flag+=("-t" "$tests_file")
-      else
-        cape_error "No cape-tests.json found for scenario '$scenario'. Test specification is required."
-        cape_error "Create scenarios/$scenario/cape-tests.json with test cases."
-        return 1
-      fi
-    else
-      cape_error "Unable to infer scenario for $rel_dir. Test specification is required."
-      cape_error "Ensure submission follows the correct directory structure."
-      return 1
-    fi
+  # Tests are part of the scenario contract. A submission must not ship its
+  # own cape-tests.json: a green CI signal must reflect the trusted scenario
+  # tests, not rules supplied by the evaluatee.
+  if [[ -f "$submission_dir/cape-tests.json" ]]; then
+    cape_error "Submission-local cape-tests.json is not allowed in $rel_dir."
+    cape_error "Tests belong to the scenario; remove $(cape_relpath "$submission_dir/cape-tests.json") and rely on scenarios/$scenario/cape-tests.json."
+    return 1
   fi
+
+  if [[ -z "$scenario" ]]; then
+    cape_error "Unable to infer scenario for $rel_dir. Test specification is required."
+    cape_error "Ensure submission follows the correct directory structure."
+    return 1
+  fi
+
+  local tests_file
+  tests_file="$(resolve_tests_for_scenario "$scenario")"
+  if [[ -z "$tests_file" ]]; then
+    cape_error "No cape-tests.json found for scenario '$scenario'. Test specification is required."
+    cape_error "Create scenarios/$scenario/cape-tests.json with test cases."
+    return 1
+  fi
+  cape_debug "Using scenario tests: $(cape_relpath "$tests_file")"
+  local tests_flag=("-t" "$tests_file")
 
   local tmp_metrics tmp_stdout
   tmp_metrics="$(cape_mktemp)"
@@ -303,7 +302,7 @@ main() {
       local meta="$submission_dir/metadata.json"
       if [[ -f "$meta" ]]; then
         local min_ver
-        min_ver=$(jq -r '.compilation_config.min_plutus_version // ""' "$meta" 2>/dev/null || true)
+        min_ver=$(jq -r '.compilation_config.min_plutus_version // ""' "$meta" 2> /dev/null || true)
         if cape_is_preview_submission "$min_ver"; then
           cape_info "Skipping preview submission: ${submission_dir#$SUBMISSIONS_ROOT/}"
           continue
@@ -326,7 +325,7 @@ main() {
     local meta="$TARGET/metadata.json"
     if [[ -f "$meta" ]]; then
       local min_ver
-      min_ver=$(jq -r '.compilation_config.min_plutus_version // ""' "$meta" 2>/dev/null || true)
+      min_ver=$(jq -r '.compilation_config.min_plutus_version // ""' "$meta" 2> /dev/null || true)
       if cape_is_preview_submission "$min_ver"; then
         cape_error "Submission requires plutus-core >= $min_ver but the evaluator only supports $CAPE_CURRENT_PLUTUS_VERSION."
         cape_error "Use 'cape submission measure --preview' to evaluate with a compatible version."

--- a/scripts/cape-subcommands/submission/verify.sh
+++ b/scripts/cape-subcommands/submission/verify.sh
@@ -81,15 +81,15 @@ verify_submission_dir() {
   local scenario
   scenario="$(infer_scenario_from_path "$submission_dir")"
 
-  if [[ -f "$submission_dir/cape-tests.json" ]]; then
-    cape_error "Submission-local cape-tests.json is not allowed in $rel_dir."
-    cape_error "Tests belong to the scenario; remove $(cape_relpath "$submission_dir/cape-tests.json") and rely on scenarios/$scenario/cape-tests.json."
-    return 1
-  fi
-
   if [[ -z "$scenario" ]]; then
     cape_error "Unable to infer scenario for $rel_dir. Test specification is required."
     cape_error "Ensure submission follows the correct directory structure."
+    return 1
+  fi
+
+  if [[ -f "$submission_dir/cape-tests.json" ]]; then
+    cape_error "Submission-local cape-tests.json is not allowed in $rel_dir."
+    cape_error "Tests belong to the scenario; remove $(cape_relpath "$submission_dir/cape-tests.json") and rely on scenarios/$scenario/cape-tests.json."
     return 1
   fi
 

--- a/scripts/cape-subcommands/submission/verify.sh
+++ b/scripts/cape-subcommands/submission/verify.sh
@@ -81,9 +81,6 @@ verify_submission_dir() {
   local scenario
   scenario="$(infer_scenario_from_path "$submission_dir")"
 
-  # Tests are part of the scenario contract. A submission must not ship its
-  # own cape-tests.json: a green CI signal must reflect the trusted scenario
-  # tests, not rules supplied by the evaluatee.
   if [[ -f "$submission_dir/cape-tests.json" ]]; then
     cape_error "Submission-local cape-tests.json is not allowed in $rel_dir."
     cape_error "Tests belong to the scenario; remove $(cape_relpath "$submission_dir/cape-tests.json") and rely on scenarios/$scenario/cape-tests.json."

--- a/scripts/cape-subcommands/test/test.sh
+++ b/scripts/cape-subcommands/test/test.sh
@@ -162,45 +162,6 @@ run_uplc_validation() {
   fi
 }
 
-# Regression test for advisory GHSA-4rp3-v4vj-q537: verify must reject a
-# submission that ships its own cape-tests.json. Tests are part of the
-# scenario contract; the evaluatee must not be able to override them.
-test_submission_local_tests_rejected() {
-  if [[ -t 1 && -z "${NO_COLOR:-}" ]]; then
-    echo -e "\033[0;34mINFO:\033[0m Testing security: submission-local cape-tests.json is rejected..."
-  else
-    echo "INFO: Testing security: submission-local cape-tests.json is rejected..."
-  fi
-
-  local victim_dir
-  victim_dir="$(find "$SANDBOX_DIR/submissions/fibonacci" -mindepth 1 -maxdepth 1 -type d ! -name 'TEMPLATE' 2> /dev/null | head -n1)"
-  if [[ -z "$victim_dir" ]]; then
-    if [[ -t 1 && -z "${NO_COLOR:-}" ]]; then
-      echo -e "\033[0;33mWARN:\033[0m No fibonacci submission in sandbox; skipping advisory regression test."
-    else
-      echo "WARN: No fibonacci submission in sandbox; skipping advisory regression test."
-    fi
-    return 0
-  fi
-
-  local planted="$victim_dir/cape-tests.json"
-  cat > "$planted" << 'JSON'
-{
-  "version": "2.0.0",
-  "tests": [
-    { "name": "attacker_controlled", "inputs": [], "expected": { "type": "error" } }
-  ]
-}
-JSON
-
-  run_test "submission-local cape-tests.json rejected" \
-    "(cd \"$PROJECT_ROOT\" && PROJECT_ROOT=\"$SANDBOX_DIR\" bash \"$REPO_ROOT/scripts/cape.sh\" submission verify \"$victim_dir\")" \
-    30 \
-    "fail"
-
-  rm -f "$planted"
-}
-
 # Setup clean test environment
 setup_test_env() {
   TEST_TMP_DIR="$(cape_mktemp_dir)"
@@ -378,9 +339,6 @@ main() {
 
   # UPLC validation - test actual UPLC execution for all submissions
   run_uplc_validation
-
-  # Security regression test for advisory GHSA-4rp3-v4vj-q537
-  test_submission_local_tests_rejected
 
   if [[ -t 1 && -z "${NO_COLOR:-}" ]]; then
     echo -e "\033[0;34mINFO:\033[0m Test suite completed!"

--- a/scripts/cape-subcommands/test/test.sh
+++ b/scripts/cape-subcommands/test/test.sh
@@ -162,6 +162,45 @@ run_uplc_validation() {
   fi
 }
 
+# Regression test for advisory GHSA-4rp3-v4vj-q537: verify must reject a
+# submission that ships its own cape-tests.json. Tests are part of the
+# scenario contract; the evaluatee must not be able to override them.
+test_submission_local_tests_rejected() {
+  if [[ -t 1 && -z "${NO_COLOR:-}" ]]; then
+    echo -e "\033[0;34mINFO:\033[0m Testing security: submission-local cape-tests.json is rejected..."
+  else
+    echo "INFO: Testing security: submission-local cape-tests.json is rejected..."
+  fi
+
+  local victim_dir
+  victim_dir="$(find "$SANDBOX_DIR/submissions/fibonacci" -mindepth 1 -maxdepth 1 -type d ! -name 'TEMPLATE' 2> /dev/null | head -n1)"
+  if [[ -z "$victim_dir" ]]; then
+    if [[ -t 1 && -z "${NO_COLOR:-}" ]]; then
+      echo -e "\033[0;33mWARN:\033[0m No fibonacci submission in sandbox; skipping advisory regression test."
+    else
+      echo "WARN: No fibonacci submission in sandbox; skipping advisory regression test."
+    fi
+    return 0
+  fi
+
+  local planted="$victim_dir/cape-tests.json"
+  cat > "$planted" << 'JSON'
+{
+  "version": "2.0.0",
+  "tests": [
+    { "name": "attacker_controlled", "inputs": [], "expected": { "type": "error" } }
+  ]
+}
+JSON
+
+  run_test "submission-local cape-tests.json rejected" \
+    "(cd \"$PROJECT_ROOT\" && PROJECT_ROOT=\"$SANDBOX_DIR\" bash \"$REPO_ROOT/scripts/cape.sh\" submission verify \"$victim_dir\")" \
+    30 \
+    "fail"
+
+  rm -f "$planted"
+}
+
 # Setup clean test environment
 setup_test_env() {
   TEST_TMP_DIR="$(cape_mktemp_dir)"
@@ -339,6 +378,9 @@ main() {
 
   # UPLC validation - test actual UPLC execution for all submissions
   run_uplc_validation
+
+  # Security regression test for advisory GHSA-4rp3-v4vj-q537
+  test_submission_local_tests_rejected
 
   if [[ -t 1 && -z "${NO_COLOR:-}" ]]; then
     echo -e "\033[0;34mINFO:\033[0m Test suite completed!"


### PR DESCRIPTION
## Summary

- Removes the precedence rule that let a submission's own `cape-tests.json` shadow the trusted `scenarios/<scenario>/cape-tests.json` during `cape submission verify` and `cape submission measure`.
- Hard-errors if a `cape-tests.json` is found inside a submission directory; tests are part of the scenario contract and the evaluatee must not influence them.
- Adds a regression test that plants a fake `cape-tests.json` into a fibonacci submission and asserts `verify` rejects it.

## Context

Reported externally as GHSA-4rp3-v4vj-q537. Classifying it as a code-quality / hardening defect rather than a security vulnerability, consistent with the Security Council's reading: every submission lands through a structural PR review, no legitimate flow produces a submission-local `cape-tests.json`, and the override branch was a leftover from the old `verifier.uplc` workflow. The fix removes a dead code path and closes the override on principle.

Closes #187.
Refs GHSA-4rp3-v4vj-q537.