### PR TITLE
feat(report): reorder benchmark tabs to lead with Total Fee

### DIFF
--- a/scripts/cape-subcommands/submission/benchmark.html.tmpl
+++ b/scripts/cape-subcommands/submission/benchmark.html.tmpl
@@ -237,14 +237,14 @@
         const overMem = s => (s.metrics.tx_memory_budget_pct ?? 0) > 100;
 
         const METRICS = [
+            { key: "total_fee_lovelace",   title: "Total Fee",   subtitle: "ADA — lower is better",                                                 direction: "asc",  format: fmtFee },
+            { key: "tx_memory_budget_pct", title: "Mem Tx",      subtitle: "% of transaction memory budget — lower is better • hatched = exceeds 100%", direction: "asc",  format: fmtPct, exceedsBudget: s => (s.metrics.tx_memory_budget_pct ?? 0) > 100 },
+            { key: "tx_cpu_budget_pct",    title: "CPU Tx",      subtitle: "% of transaction CPU budget — lower is better • hatched = exceeds 100%",    direction: "asc",  format: fmtPct, exceedsBudget: s => (s.metrics.tx_cpu_budget_pct    ?? 0) > 100 },
+            { key: "scripts_per_tx",       title: "Scripts/Tx",  subtitle: "Scripts per transaction — higher is better • 0 = exceeds transaction budget", direction: "desc", format: fmtInt, exceedsBudget: s => s.metrics.scripts_per_tx === 0 },
             { key: "cpu_units",            title: "CPU",         subtitle: "CPU units — lower is better • hatched = exceeds Tx CPU budget",        direction: "asc",  format: fmtInt,  exceedsBudget: overCpu },
             { key: "memory_units",         title: "Mem",         subtitle: "Memory units — lower is better • hatched = exceeds Tx memory budget",  direction: "asc",  format: fmtInt,  exceedsBudget: overMem },
             { key: "script_size_bytes",    title: "Flat Size",   subtitle: "Script (flat) size in bytes — lower is better",                         direction: "asc",  format: fmtInt },
             { key: "term_size",            title: "AST Size",    subtitle: "AST nodes — lower is better",                                           direction: "asc",  format: fmtInt },
-            { key: "total_fee_lovelace",   title: "Total Fee",   subtitle: "ADA — lower is better",                                                 direction: "asc",  format: fmtFee },
-            { key: "tx_cpu_budget_pct",    title: "CPU Tx",      subtitle: "% of transaction CPU budget — lower is better • hatched = exceeds 100%",    direction: "asc",  format: fmtPct, exceedsBudget: s => (s.metrics.tx_cpu_budget_pct    ?? 0) > 100 },
-            { key: "tx_memory_budget_pct", title: "Mem Tx",      subtitle: "% of transaction memory budget — lower is better • hatched = exceeds 100%", direction: "asc",  format: fmtPct, exceedsBudget: s => (s.metrics.tx_memory_budget_pct ?? 0) > 100 },
-            { key: "scripts_per_tx",       title: "Scripts/Tx",  subtitle: "Scripts per transaction — higher is better • 0 = exceeds transaction budget", direction: "desc", format: fmtInt, exceedsBudget: s => s.metrics.scripts_per_tx === 0 },
         ];
 
         function fmtInt(n) {


### PR DESCRIPTION
## Summary

Closes #189.

Raw CPU units were the default landing tab, but they're the least informative metric for a reader comparing submissions. Reorder so the most decision-relevant metrics come first.

**New tab order:** Total Fee → Mem Tx % → CPU Tx % → Scripts/Tx → CPU → Mem → Flat Size → AST Size.

Single source of truth is the `METRICS` array in `scripts/cape-subcommands/submission/benchmark.html.tmpl`; the default-tab logic (`return METRICS[0].key`) follows the array order automatically. Existing `#tab=<key>` URL fragments keep working since they reference keys, not positions. Regenerated `report/benchmarks/*.html` to reflect the new order (no `.json` data changes).