### PR TITLE
measure: derive evaluator label from linked plutus-core version

### DIFF
--- a/measure-app/Main.hs
+++ b/measure-app/Main.hs
@@ -410,8 +410,15 @@ writeDetailedMetrics program evaluations metricsFile = do
   currentTime <- getCurrentTime
   let timestamp = toText $ formatTime defaultTimeLocale "%Y-%m-%dT%H:%M:%SZ" currentTime
 
-  -- Create execution environment info
-  let execEnv = Json.object [("evaluator", Json.String "PlutusTx.Eval-1.52.0.0")]
+  -- Create execution environment info. Tag the evaluator with the
+  -- plutus-core version linked into this binary so production
+  -- (cabal.project) and preview (cabal.project.preview) reports
+  -- carry distinct, accurate labels.
+  let evaluatorLabel = "PlutusTx.Eval-" <> VERSION_plutus_core :: String
+  -- Also emit the label on stdout so the bash wrapper
+  -- (cape_write_metrics_json) can lift it into the production metrics.
+  putStrLn ("Evaluator: " <> evaluatorLabel)
+  let execEnv = Json.object [("evaluator", Json.String (toText evaluatorLabel))]
 
   -- Create complete metrics object
   let metrics =

--- a/submissions/ecd/Plinth_1.45.0.0_Unisay/metrics.json
+++ b/submissions/ecd/Plinth_1.45.0.0_Unisay/metrics.json
@@ -100,7 +100,7 @@
     }
   ],
   "execution_environment": {
-    "evaluator": "unknown"
+    "evaluator": "PlutusTx.Eval-1.45.0.0"
   },
   "measurements": {
     "block_cpu_budget_pct": 0.009427672500000001,
@@ -132,7 +132,7 @@
     "tx_memory_budget_pct": 0.11154285714285715
   },
   "scenario": "ecd",
-  "timestamp": "2025-11-04T10:30:13Z",
+  "timestamp": "2026-05-20T17:35:12Z",
   "version": "1.0.0",
   "notes": "Generated using UPLC-CAPE measure tool"
 }

--- a/submissions/ecd/Plinth_1.61.0.0_Unisay/metrics.json
+++ b/submissions/ecd/Plinth_1.61.0.0_Unisay/metrics.json
@@ -100,7 +100,7 @@
     }
   ],
   "execution_environment": {
-    "evaluator": "PlutusTx.Eval-1.52.0.0"
+    "evaluator": "PlutusTx.Eval-1.61.0.0"
   },
   "measurements": {
     "block_cpu_budget_pct": 0.0059669375,
@@ -132,6 +132,6 @@
     "tx_memory_budget_pct": 0.07007142857142858
   },
   "scenario": "ecd",
-  "timestamp": "2026-03-31T11:39:13Z",
+  "timestamp": "2026-05-20T17:35:25Z",
   "version": "1.0.0"
 }

--- a/submissions/ecd/Plinth_1.64.0.0_Unisay/metrics.json
+++ b/submissions/ecd/Plinth_1.64.0.0_Unisay/metrics.json
@@ -100,7 +100,7 @@
     }
   ],
   "execution_environment": {
-    "evaluator": "unknown"
+    "evaluator": "PlutusTx.Eval-1.45.0.0"
   },
   "measurements": {
     "block_cpu_budget_pct": 0.008547672499999999,
@@ -132,7 +132,7 @@
     "tx_memory_budget_pct": 0.09582857142857143
   },
   "scenario": "ecd",
-  "timestamp": "2026-05-20T15:32:01Z",
+  "timestamp": "2026-05-20T17:35:12Z",
   "version": "1.0.0",
   "notes": "Generated using UPLC-CAPE measure tool"
 }

--- a/submissions/factorial/Plutarch_1.11.0_SeungheonOh_exbudget/metrics.json
+++ b/submissions/factorial/Plutarch_1.11.0_SeungheonOh_exbudget/metrics.json
@@ -72,7 +72,7 @@
     }
   ],
   "execution_environment": {
-    "evaluator": "unknown"
+    "evaluator": "PlutusTx.Eval-1.45.0.0"
   },
   "measurements": {
     "block_cpu_budget_pct": 0.022901375,
@@ -104,7 +104,7 @@
     "tx_memory_budget_pct": 0.2376714285714286
   },
   "scenario": "factorial",
-  "timestamp": "2025-10-23T14:41:52Z",
+  "timestamp": "2026-05-20T17:35:12Z",
   "version": "1.0.0",
   "notes": "Generated using UPLC-CAPE measure tool"
 }

--- a/submissions/factorial/Plutarch_1.11.0_SeungheonOh_size/metrics.json
+++ b/submissions/factorial/Plutarch_1.11.0_SeungheonOh_size/metrics.json
@@ -72,7 +72,7 @@
     }
   ],
   "execution_environment": {
-    "evaluator": "unknown"
+    "evaluator": "PlutusTx.Eval-1.45.0.0"
   },
   "measurements": {
     "block_cpu_budget_pct": 0.023021375,
@@ -104,7 +104,7 @@
     "tx_memory_budget_pct": 0.2398142857142857
   },
   "scenario": "factorial",
-  "timestamp": "2025-10-23T14:41:52Z",
+  "timestamp": "2026-05-20T17:35:12Z",
   "version": "1.0.0",
   "notes": "Generated using UPLC-CAPE measure tool"
 }

--- a/submissions/factorial/Scalus_0.12.1_Unisay/metrics.json
+++ b/submissions/factorial/Scalus_0.12.1_Unisay/metrics.json
@@ -72,7 +72,7 @@
     }
   ],
   "execution_environment": {
-    "evaluator": "<evaluator-version>"
+    "evaluator": "PlutusTx.Eval-1.45.0.0"
   },
   "measurements": {
     "block_cpu_budget_pct": 0.023021375,
@@ -104,7 +104,7 @@
     "tx_memory_budget_pct": 0.2398142857142857
   },
   "scenario": "factorial",
-  "timestamp": "2025-10-23T14:41:52Z",
+  "timestamp": "2026-05-20T17:35:13Z",
   "version": "1.0.0",
   "notes": "Placeholder metrics - actual measurements to be performed by UPLC-CAPE benchmark framework"
 }

--- a/submissions/factorial/Scalus_0.16.0_Unisay/metrics.json
+++ b/submissions/factorial/Scalus_0.16.0_Unisay/metrics.json
@@ -72,7 +72,7 @@
     }
   ],
   "execution_environment": {
-    "evaluator": "<evaluator-version>"
+    "evaluator": "PlutusTx.Eval-1.45.0.0"
   },
   "measurements": {
     "block_cpu_budget_pct": 0.023021375,
@@ -104,7 +104,7 @@
     "tx_memory_budget_pct": 0.2398142857142857
   },
   "scenario": "factorial",
-  "timestamp": "2026-04-21T12:32:26Z",
+  "timestamp": "2026-05-20T17:35:13Z",
   "version": "1.0.0",
   "notes": "<optional notes>"
 }

--- a/submissions/factorial/Scalus_0.17.0_Unisay/metrics.json
+++ b/submissions/factorial/Scalus_0.17.0_Unisay/metrics.json
@@ -72,7 +72,7 @@
     }
   ],
   "execution_environment": {
-    "evaluator": "<evaluator-version>"
+    "evaluator": "PlutusTx.Eval-1.45.0.0"
   },
   "measurements": {
     "block_cpu_budget_pct": 0.023021375,
@@ -104,7 +104,7 @@
     "tx_memory_budget_pct": 0.2398142857142857
   },
   "scenario": "factorial",
-  "timestamp": "2026-05-05T17:29:18Z",
+  "timestamp": "2026-05-20T17:35:13Z",
   "version": "1.0.0",
   "notes": "<optional notes>"
 }

--- a/submissions/factorial_naive_recursion/OpShin_1.0.0_nielstron/metrics.json
+++ b/submissions/factorial_naive_recursion/OpShin_1.0.0_nielstron/metrics.json
@@ -72,7 +72,7 @@
     }
   ],
   "execution_environment": {
-    "evaluator": "unknown"
+    "evaluator": "PlutusTx.Eval-1.45.0.0"
   },
   "measurements": {
     "block_cpu_budget_pct": 0.044181374999999995,
@@ -104,7 +104,7 @@
     "tx_memory_budget_pct": 0.6176714285714285
   },
   "scenario": "factorial_naive_recursion",
-  "timestamp": "2025-10-23T14:41:53Z",
+  "timestamp": "2026-05-20T17:35:13Z",
   "version": "1.0.0",
   "notes": "Generated using UPLC-CAPE measure tool"
 }

--- a/submissions/factorial_naive_recursion/Pebble_0.1.2_michele-nuzzi/metrics.json
+++ b/submissions/factorial_naive_recursion/Pebble_0.1.2_michele-nuzzi/metrics.json
@@ -72,7 +72,7 @@
     }
   ],
   "execution_environment": {
-    "evaluator": "unknown"
+    "evaluator": "PlutusTx.Eval-1.45.0.0"
   },
   "measurements": {
     "block_cpu_budget_pct": 0.0194448475,
@@ -104,7 +104,7 @@
     "tx_memory_budget_pct": 0.18905714285714284
   },
   "scenario": "factorial_naive_recursion",
-  "timestamp": "2025-11-25T13:50:57Z",
+  "timestamp": "2026-05-20T17:35:13Z",
   "version": "1.0.0",
   "notes": "Generated using UPLC-CAPE measure tool"
 }

--- a/submissions/factorial_naive_recursion/Plinth_1.45.0.0_Unisay/metrics.json
+++ b/submissions/factorial_naive_recursion/Plinth_1.45.0.0_Unisay/metrics.json
@@ -72,7 +72,7 @@
     }
   ],
   "execution_environment": {
-    "evaluator": "unknown"
+    "evaluator": "PlutusTx.Eval-1.45.0.0"
   },
   "measurements": {
     "block_cpu_budget_pct": 0.026021375,
@@ -104,7 +104,7 @@
     "tx_memory_budget_pct": 0.2933857142857143
   },
   "scenario": "factorial_naive_recursion",
-  "timestamp": "2025-10-23T14:41:53Z",
+  "timestamp": "2026-05-20T17:35:14Z",
   "version": "1.0.0",
   "notes": "Generated using UPLC-CAPE measure tool"
 }

--- a/submissions/factorial_naive_recursion/Plinth_1.61.0.0_Unisay/metrics.json
+++ b/submissions/factorial_naive_recursion/Plinth_1.61.0.0_Unisay/metrics.json
@@ -72,7 +72,7 @@
     }
   ],
   "execution_environment": {
-    "evaluator": "PlutusTx.Eval-1.52.0.0"
+    "evaluator": "PlutusTx.Eval-1.61.0.0"
   },
   "measurements": {
     "block_cpu_budget_pct": 0.0174297825,
@@ -104,6 +104,6 @@
     "tx_memory_budget_pct": 0.18400714285714284
   },
   "scenario": "factorial_naive_recursion",
-  "timestamp": "2026-03-31T11:39:13Z",
+  "timestamp": "2026-05-20T17:35:25Z",
   "version": "1.0.0"
 }

--- a/submissions/factorial_naive_recursion/Plinth_1.64.0.0_Unisay/metrics.json
+++ b/submissions/factorial_naive_recursion/Plinth_1.64.0.0_Unisay/metrics.json
@@ -72,7 +72,7 @@
     }
   ],
   "execution_environment": {
-    "evaluator": "unknown"
+    "evaluator": "PlutusTx.Eval-1.45.0.0"
   },
   "measurements": {
     "block_cpu_budget_pct": 0.023021375,
@@ -104,7 +104,7 @@
     "tx_memory_budget_pct": 0.2398142857142857
   },
   "scenario": "factorial_naive_recursion",
-  "timestamp": "2026-05-20T15:32:13Z",
+  "timestamp": "2026-05-20T17:35:14Z",
   "version": "1.0.0",
   "notes": "Generated using UPLC-CAPE measure tool"
 }

--- a/submissions/factorial_naive_recursion/Plutarch_1.11.0_SeungheonOh/metrics.json
+++ b/submissions/factorial_naive_recursion/Plutarch_1.11.0_SeungheonOh/metrics.json
@@ -72,7 +72,7 @@
     }
   ],
   "execution_environment": {
-    "evaluator": "unknown"
+    "evaluator": "PlutusTx.Eval-1.45.0.0"
   },
   "measurements": {
     "block_cpu_budget_pct": 0.026021375,
@@ -104,7 +104,7 @@
     "tx_memory_budget_pct": 0.2933857142857143
   },
   "scenario": "factorial_naive_recursion",
-  "timestamp": "2025-10-23T14:41:53Z",
+  "timestamp": "2026-05-20T17:35:14Z",
   "version": "1.0.0",
   "notes": "Generated using UPLC-CAPE measure tool"
 }

--- a/submissions/factorial_naive_recursion/Scalus_0.12.1_Unisay/metrics.json
+++ b/submissions/factorial_naive_recursion/Scalus_0.12.1_Unisay/metrics.json
@@ -72,7 +72,7 @@
     }
   ],
   "execution_environment": {
-    "evaluator": "<evaluator-version>"
+    "evaluator": "PlutusTx.Eval-1.45.0.0"
   },
   "measurements": {
     "block_cpu_budget_pct": 0.025781375000000002,
@@ -104,7 +104,7 @@
     "tx_memory_budget_pct": 0.28909999999999997
   },
   "scenario": "factorial_naive_recursion",
-  "timestamp": "2025-10-23T14:41:54Z",
+  "timestamp": "2026-05-20T17:35:14Z",
   "version": "1.0.0",
   "notes": "Placeholder metrics - actual measurements to be performed by UPLC-CAPE benchmark framework"
 }

--- a/submissions/factorial_naive_recursion/Scalus_0.16.0_Unisay/metrics.json
+++ b/submissions/factorial_naive_recursion/Scalus_0.16.0_Unisay/metrics.json
@@ -72,7 +72,7 @@
     }
   ],
   "execution_environment": {
-    "evaluator": "<evaluator-version>"
+    "evaluator": "PlutusTx.Eval-1.45.0.0"
   },
   "measurements": {
     "block_cpu_budget_pct": 0.025661374999999997,
@@ -104,7 +104,7 @@
     "tx_memory_budget_pct": 0.28695714285714286
   },
   "scenario": "factorial_naive_recursion",
-  "timestamp": "2026-04-21T12:32:34Z",
+  "timestamp": "2026-05-20T17:35:14Z",
   "version": "1.0.0",
   "notes": "<optional notes>"
 }

--- a/submissions/factorial_naive_recursion/Scalus_0.17.0_Unisay/metrics.json
+++ b/submissions/factorial_naive_recursion/Scalus_0.17.0_Unisay/metrics.json
@@ -72,7 +72,7 @@
     }
   ],
   "execution_environment": {
-    "evaluator": "<evaluator-version>"
+    "evaluator": "PlutusTx.Eval-1.45.0.0"
   },
   "measurements": {
     "block_cpu_budget_pct": 0.026021375,
@@ -104,7 +104,7 @@
     "tx_memory_budget_pct": 0.2933857142857143
   },
   "scenario": "factorial_naive_recursion",
-  "timestamp": "2026-05-05T17:30:20Z",
+  "timestamp": "2026-05-20T17:35:15Z",
   "version": "1.0.0",
   "notes": "<optional notes>"
 }

--- a/submissions/factorial_naive_recursion/Scalus_0.17.0_Unisay_vanrossem/metrics.json
+++ b/submissions/factorial_naive_recursion/Scalus_0.17.0_Unisay_vanrossem/metrics.json
@@ -72,7 +72,7 @@
     }
   ],
   "execution_environment": {
-    "evaluator": "PlutusTx.Eval-1.52.0.0"
+    "evaluator": "PlutusTx.Eval-1.61.0.0"
   },
   "measurements": {
     "block_cpu_budget_pct": 0.0204297825,
@@ -104,6 +104,6 @@
     "tx_memory_budget_pct": 0.23757857142857144
   },
   "scenario": "factorial_naive_recursion",
-  "timestamp": "2026-05-06T13:50:26Z",
+  "timestamp": "2026-05-20T17:35:25Z",
   "version": "1.0.0"
 }

--- a/submissions/fibonacci/Aiken_1.1.19_KtorZ_prepacked/metrics.json
+++ b/submissions/fibonacci/Aiken_1.1.19_KtorZ_prepacked/metrics.json
@@ -79,7 +79,7 @@
     }
   ],
   "execution_environment": {
-    "evaluator": "<evaluator-version>"
+    "evaluator": "PlutusTx.Eval-1.45.0.0"
   },
   "measurements": {
     "block_cpu_budget_pct": 0.0055121375,
@@ -111,7 +111,7 @@
     "tx_memory_budget_pct": 0.033664285714285716
   },
   "scenario": "fibonacci",
-  "timestamp": "2025-10-23T14:41:54Z",
+  "timestamp": "2026-05-20T17:35:15Z",
   "version": "1.0.0",
   "notes": "<optional notes>"
 }

--- a/submissions/fibonacci/Aiken_1.1.19_KtorZ_tailrec/metrics.json
+++ b/submissions/fibonacci/Aiken_1.1.19_KtorZ_tailrec/metrics.json
@@ -79,7 +79,7 @@
     }
   ],
   "execution_environment": {
-    "evaluator": "<evaluator-version>"
+    "evaluator": "PlutusTx.Eval-1.45.0.0"
   },
   "measurements": {
     "block_cpu_budget_pct": 0.048574825,
@@ -111,7 +111,7 @@
     "tx_memory_budget_pct": 0.5138857142857143
   },
   "scenario": "fibonacci",
-  "timestamp": "2025-10-23T14:41:54Z",
+  "timestamp": "2026-05-20T17:35:15Z",
   "version": "1.0.0",
   "notes": "<optional notes>"
 }

--- a/submissions/fibonacci/OpShin_1.0.0_nielstron/metrics.json
+++ b/submissions/fibonacci/OpShin_1.0.0_nielstron/metrics.json
@@ -79,7 +79,7 @@
     }
   ],
   "execution_environment": {
-    "evaluator": "unknown"
+    "evaluator": "PlutusTx.Eval-1.45.0.0"
   },
   "measurements": {
     "block_cpu_budget_pct": 0.1532416325,
@@ -111,7 +111,7 @@
     "tx_memory_budget_pct": 2.3661000000000003
   },
   "scenario": "fibonacci",
-  "timestamp": "2025-10-23T14:41:55Z",
+  "timestamp": "2026-05-20T17:35:15Z",
   "version": "1.0.0",
   "notes": "Generated using UPLC-CAPE measure tool"
 }

--- a/submissions/fibonacci/Plinth_1.45.0.0_Unisay/metrics.json
+++ b/submissions/fibonacci/Plinth_1.45.0.0_Unisay/metrics.json
@@ -79,7 +79,7 @@
     }
   ],
   "execution_environment": {
-    "evaluator": "<evaluator-version>"
+    "evaluator": "PlutusTx.Eval-1.45.0.0"
   },
   "measurements": {
     "block_cpu_budget_pct": 0.058617800000000005,
@@ -111,7 +111,7 @@
     "tx_memory_budget_pct": 0.6924857142857144
   },
   "scenario": "fibonacci",
-  "timestamp": "2025-11-07T14:35:08Z",
+  "timestamp": "2026-05-20T17:35:16Z",
   "version": "1.0.0",
   "notes": "<optional notes>"
 }

--- a/submissions/fibonacci/Plinth_1.61.0.0_Unisay/metrics.json
+++ b/submissions/fibonacci/Plinth_1.61.0.0_Unisay/metrics.json
@@ -79,7 +79,7 @@
     }
   ],
   "execution_environment": {
-    "evaluator": "PlutusTx.Eval-1.52.0.0"
+    "evaluator": "PlutusTx.Eval-1.61.0.0"
   },
   "measurements": {
     "block_cpu_budget_pct": 0.041354615,
@@ -111,6 +111,6 @@
     "tx_memory_budget_pct": 0.4723
   },
   "scenario": "fibonacci",
-  "timestamp": "2026-03-31T11:39:13Z",
+  "timestamp": "2026-05-20T17:35:25Z",
   "version": "1.0.0"
 }

--- a/submissions/fibonacci/Plinth_1.64.0.0_Unisay/metrics.json
+++ b/submissions/fibonacci/Plinth_1.64.0.0_Unisay/metrics.json
@@ -79,7 +79,7 @@
     }
   ],
   "execution_environment": {
-    "evaluator": "unknown"
+    "evaluator": "PlutusTx.Eval-1.45.0.0"
   },
   "measurements": {
     "block_cpu_budget_pct": 0.06329086249999999,
@@ -111,7 +111,7 @@
     "tx_memory_budget_pct": 0.6912357142857143
   },
   "scenario": "fibonacci",
-  "timestamp": "2026-05-20T15:32:14Z",
+  "timestamp": "2026-05-20T17:35:16Z",
   "version": "1.0.0",
   "notes": "Generated using UPLC-CAPE measure tool"
 }

--- a/submissions/fibonacci/Plutarch_1.11.0_SeungheonOh_exbudget/metrics.json
+++ b/submissions/fibonacci/Plutarch_1.11.0_SeungheonOh_exbudget/metrics.json
@@ -79,7 +79,7 @@
     }
   ],
   "execution_environment": {
-    "evaluator": "unknown"
+    "evaluator": "PlutusTx.Eval-1.45.0.0"
   },
   "measurements": {
     "block_cpu_budget_pct": 397.983518045,
@@ -111,7 +111,7 @@
     "tx_memory_budget_pct": 4170.696585714286
   },
   "scenario": "fibonacci",
-  "timestamp": "2025-10-23T14:41:55Z",
+  "timestamp": "2026-05-20T17:35:16Z",
   "version": "1.0.0",
   "notes": "Generated using UPLC-CAPE measure tool"
 }

--- a/submissions/fibonacci/Plutarch_1.11.0_SeungheonOh_prepacked/metrics.json
+++ b/submissions/fibonacci/Plutarch_1.11.0_SeungheonOh_prepacked/metrics.json
@@ -79,7 +79,7 @@
     }
   ],
   "execution_environment": {
-    "evaluator": "<evaluator-version>"
+    "evaluator": "PlutusTx.Eval-1.45.0.0"
   },
   "measurements": {
     "block_cpu_budget_pct": 0.0043633275,
@@ -111,7 +111,7 @@
     "tx_memory_budget_pct": 0.021492857142857143
   },
   "scenario": "fibonacci",
-  "timestamp": "2025-10-23T14:41:55Z",
+  "timestamp": "2026-05-20T17:35:16Z",
   "version": "1.0.0",
   "notes": "<optional notes>"
 }

--- a/submissions/fibonacci/Plutarch_1.11.0_SeungheonOh_size/metrics.json
+++ b/submissions/fibonacci/Plutarch_1.11.0_SeungheonOh_size/metrics.json
@@ -79,7 +79,7 @@
     }
   ],
   "execution_environment": {
-    "evaluator": "unknown"
+    "evaluator": "PlutusTx.Eval-1.45.0.0"
   },
   "measurements": {
     "block_cpu_budget_pct": 397.983638045,
@@ -111,7 +111,7 @@
     "tx_memory_budget_pct": 4170.698728571429
   },
   "scenario": "fibonacci",
-  "timestamp": "2025-10-23T14:41:56Z",
+  "timestamp": "2026-05-20T17:35:17Z",
   "version": "1.0.0",
   "notes": "Generated using UPLC-CAPE measure tool"
 }

--- a/submissions/fibonacci/Scalus_0.12.1_Unisay/metrics.json
+++ b/submissions/fibonacci/Scalus_0.12.1_Unisay/metrics.json
@@ -79,7 +79,7 @@
     }
   ],
   "execution_environment": {
-    "evaluator": "<evaluator-version>"
+    "evaluator": "PlutusTx.Eval-1.45.0.0"
   },
   "measurements": {
     "block_cpu_budget_pct": 397.983638045,
@@ -111,7 +111,7 @@
     "tx_memory_budget_pct": 4170.698728571429
   },
   "scenario": "fibonacci",
-  "timestamp": "2025-10-23T14:41:57Z",
+  "timestamp": "2026-05-20T17:35:17Z",
   "version": "1.0.0",
   "notes": "<optional notes>"
 }

--- a/submissions/fibonacci/Scalus_0.12.1_nau_prepacked/metrics.json
+++ b/submissions/fibonacci/Scalus_0.12.1_nau_prepacked/metrics.json
@@ -79,7 +79,7 @@
     }
   ],
   "execution_environment": {
-    "evaluator": "unknown"
+    "evaluator": "PlutusTx.Eval-1.45.0.0"
   },
   "measurements": {
     "block_cpu_budget_pct": 0.0043633275,
@@ -111,7 +111,7 @@
     "tx_memory_budget_pct": 0.021492857142857143
   },
   "scenario": "fibonacci",
-  "timestamp": "2025-10-23T14:41:56Z",
+  "timestamp": "2026-05-20T17:35:17Z",
   "version": "1.0.0",
   "notes": "Generated using UPLC-CAPE measure tool"
 }

--- a/submissions/fibonacci/Scalus_0.16.0_Unisay/metrics.json
+++ b/submissions/fibonacci/Scalus_0.16.0_Unisay/metrics.json
@@ -79,7 +79,7 @@
     }
   ],
   "execution_environment": {
-    "evaluator": "<evaluator-version>"
+    "evaluator": "PlutusTx.Eval-1.45.0.0"
   },
   "measurements": {
     "block_cpu_budget_pct": 397.983638045,
@@ -111,7 +111,7 @@
     "tx_memory_budget_pct": 4170.698728571429
   },
   "scenario": "fibonacci",
-  "timestamp": "2026-04-21T12:32:34Z",
+  "timestamp": "2026-05-20T17:35:18Z",
   "version": "1.0.0",
   "notes": "<optional notes>"
 }

--- a/submissions/fibonacci/Scalus_0.16.0_Unisay_prepacked/metrics.json
+++ b/submissions/fibonacci/Scalus_0.16.0_Unisay_prepacked/metrics.json
@@ -79,7 +79,7 @@
     }
   ],
   "execution_environment": {
-    "evaluator": "<evaluator-version>"
+    "evaluator": "PlutusTx.Eval-1.45.0.0"
   },
   "measurements": {
     "block_cpu_budget_pct": 0.0043633275,
@@ -111,7 +111,7 @@
     "tx_memory_budget_pct": 0.021492857142857143
   },
   "scenario": "fibonacci",
-  "timestamp": "2026-04-21T12:32:35Z",
+  "timestamp": "2026-05-20T17:35:18Z",
   "version": "1.0.0",
   "notes": "<optional notes>"
 }

--- a/submissions/fibonacci/Scalus_0.17.0_Unisay/metrics.json
+++ b/submissions/fibonacci/Scalus_0.17.0_Unisay/metrics.json
@@ -79,7 +79,7 @@
     }
   ],
   "execution_environment": {
-    "evaluator": "<evaluator-version>"
+    "evaluator": "PlutusTx.Eval-1.45.0.0"
   },
   "measurements": {
     "block_cpu_budget_pct": 397.983638045,
@@ -111,7 +111,7 @@
     "tx_memory_budget_pct": 4170.698728571429
   },
   "scenario": "fibonacci",
-  "timestamp": "2026-05-05T17:31:11Z",
+  "timestamp": "2026-05-20T17:35:18Z",
   "version": "1.0.0",
   "notes": "<optional notes>"
 }

--- a/submissions/fibonacci_naive_recursion/Aiken_1.1.17_KtorZ/metrics.json
+++ b/submissions/fibonacci_naive_recursion/Aiken_1.1.17_KtorZ/metrics.json
@@ -79,7 +79,7 @@
     }
   ],
   "execution_environment": {
-    "evaluator": "PlutusTx.Eval-1.52.0.0"
+    "evaluator": "PlutusTx.Eval-1.45.0.0"
   },
   "measurements": {
     "block_cpu_budget_pct": 388.272398045,
@@ -111,7 +111,7 @@
     "tx_memory_budget_pct": 3997.2837285714286
   },
   "scenario": "fibonacci_naive_recursion",
-  "timestamp": "2025-10-23T14:41:57Z",
+  "timestamp": "2026-05-20T17:35:19Z",
   "version": "1.0.0",
   "notes": "Generated using UPLC-CAPE measure tool"
 }

--- a/submissions/fibonacci_naive_recursion/Pebble_0.1.2_michele-nuzzi/metrics.json
+++ b/submissions/fibonacci_naive_recursion/Pebble_0.1.2_michele-nuzzi/metrics.json
@@ -79,7 +79,7 @@
     }
   ],
   "execution_environment": {
-    "evaluator": "unknown"
+    "evaluator": "PlutusTx.Eval-1.45.0.0"
   },
   "measurements": {
     "block_cpu_budget_pct": 350.3093145575,
@@ -111,7 +111,7 @@
     "tx_memory_budget_pct": 3303.6230142857144
   },
   "scenario": "fibonacci_naive_recursion",
-  "timestamp": "2025-11-25T13:50:50Z",
+  "timestamp": "2026-05-20T17:35:19Z",
   "version": "1.0.0",
   "notes": "Generated using UPLC-CAPE measure tool"
 }

--- a/submissions/fibonacci_naive_recursion/Plinth_1.45.0.0_Unisay/metrics.json
+++ b/submissions/fibonacci_naive_recursion/Plinth_1.45.0.0_Unisay/metrics.json
@@ -79,7 +79,7 @@
     }
   ],
   "execution_environment": {
-    "evaluator": "unknown"
+    "evaluator": "PlutusTx.Eval-1.45.0.0"
   },
   "measurements": {
     "block_cpu_budget_pct": 485.386118045,
@@ -111,7 +111,7 @@
     "tx_memory_budget_pct": 5731.4573
   },
   "scenario": "fibonacci_naive_recursion",
-  "timestamp": "2025-10-23T14:41:58Z",
+  "timestamp": "2026-05-20T17:35:20Z",
   "version": "1.0.0",
   "notes": "Generated using UPLC-CAPE measure tool"
 }

--- a/submissions/fibonacci_naive_recursion/Plinth_1.61.0.0_Unisay/metrics.json
+++ b/submissions/fibonacci_naive_recursion/Plinth_1.61.0.0_Unisay/metrics.json
@@ -79,7 +79,7 @@
     }
   ],
   "execution_environment": {
-    "evaluator": "PlutusTx.Eval-1.52.0.0"
+    "evaluator": "PlutusTx.Eval-1.61.0.0"
   },
   "measurements": {
     "block_cpu_budget_pct": 293.5563468825,
@@ -111,6 +111,6 @@
     "tx_memory_budget_pct": 3128.4574071428574
   },
   "scenario": "fibonacci_naive_recursion",
-  "timestamp": "2026-03-31T11:39:13Z",
+  "timestamp": "2026-05-20T17:35:25Z",
   "version": "1.0.0"
 }

--- a/submissions/fibonacci_naive_recursion/Plinth_1.64.0.0_Unisay/metrics.json
+++ b/submissions/fibonacci_naive_recursion/Plinth_1.64.0.0_Unisay/metrics.json
@@ -79,7 +79,7 @@
     }
   ],
   "execution_environment": {
-    "evaluator": "unknown"
+    "evaluator": "PlutusTx.Eval-1.45.0.0"
   },
   "measurements": {
     "block_cpu_budget_pct": 397.983638045,
@@ -111,7 +111,7 @@
     "tx_memory_budget_pct": 4170.698728571429
   },
   "scenario": "fibonacci_naive_recursion",
-  "timestamp": "2026-05-20T15:32:16Z",
+  "timestamp": "2026-05-20T17:35:20Z",
   "version": "1.0.0",
   "notes": "Generated using UPLC-CAPE measure tool"
 }

--- a/submissions/fibonacci_naive_recursion/Plutarch_1.11.0_SeungheonOh/metrics.json
+++ b/submissions/fibonacci_naive_recursion/Plutarch_1.11.0_SeungheonOh/metrics.json
@@ -79,7 +79,7 @@
     }
   ],
   "execution_environment": {
-    "evaluator": "unknown"
+    "evaluator": "PlutusTx.Eval-1.45.0.0"
   },
   "measurements": {
     "block_cpu_budget_pct": 456.25191804499997,
@@ -111,7 +111,7 @@
     "tx_memory_budget_pct": 5211.203728571429
   },
   "scenario": "fibonacci_naive_recursion",
-  "timestamp": "2025-10-23T14:41:58Z",
+  "timestamp": "2026-05-20T17:35:20Z",
   "version": "1.0.0",
   "notes": "Generated using UPLC-CAPE measure tool"
 }

--- a/submissions/fibonacci_naive_recursion/Scalus_0.12.1_Unisay/metrics.json
+++ b/submissions/fibonacci_naive_recursion/Scalus_0.12.1_Unisay/metrics.json
@@ -79,7 +79,7 @@
     }
   ],
   "execution_environment": {
-    "evaluator": "<evaluator-version>"
+    "evaluator": "PlutusTx.Eval-1.45.0.0"
   },
   "measurements": {
     "block_cpu_budget_pct": 368.350423085,
@@ -111,7 +111,7 @@
     "tx_memory_budget_pct": 4069.0473285714284
   },
   "scenario": "fibonacci_naive_recursion",
-  "timestamp": "2025-10-23T14:41:59Z",
+  "timestamp": "2026-05-20T17:35:21Z",
   "version": "1.0.0",
   "notes": "<optional notes>"
 }

--- a/submissions/fibonacci_naive_recursion/Scalus_0.16.0_Unisay/metrics.json
+++ b/submissions/fibonacci_naive_recursion/Scalus_0.16.0_Unisay/metrics.json
@@ -79,7 +79,7 @@
     }
   ],
   "execution_environment": {
-    "evaluator": "<evaluator-version>"
+    "evaluator": "PlutusTx.Eval-1.45.0.0"
   },
   "measurements": {
     "block_cpu_budget_pct": 368.350303085,
@@ -111,7 +111,7 @@
     "tx_memory_budget_pct": 4069.0451857142853
   },
   "scenario": "fibonacci_naive_recursion",
-  "timestamp": "2026-04-21T12:32:36Z",
+  "timestamp": "2026-05-20T17:35:21Z",
   "version": "1.0.0",
   "notes": "<optional notes>"
 }

--- a/submissions/fibonacci_naive_recursion/Scalus_0.17.0_Unisay/metrics.json
+++ b/submissions/fibonacci_naive_recursion/Scalus_0.17.0_Unisay/metrics.json
@@ -79,7 +79,7 @@
     }
   ],
   "execution_environment": {
-    "evaluator": "<evaluator-version>"
+    "evaluator": "PlutusTx.Eval-1.45.0.0"
   },
   "measurements": {
     "block_cpu_budget_pct": 368.350303085,
@@ -111,7 +111,7 @@
     "tx_memory_budget_pct": 4069.0451857142853
   },
   "scenario": "fibonacci_naive_recursion",
-  "timestamp": "2026-05-05T17:32:05Z",
+  "timestamp": "2026-05-20T17:35:21Z",
   "version": "1.0.0",
   "notes": "<optional notes>"
 }

--- a/submissions/fibonacci_naive_recursion/Scalus_0.17.0_Unisay_vanrossem/metrics.json
+++ b/submissions/fibonacci_naive_recursion/Scalus_0.17.0_Unisay_vanrossem/metrics.json
@@ -79,7 +79,7 @@
     }
   ],
   "execution_environment": {
-    "evaluator": "PlutusTx.Eval-1.52.0.0"
+    "evaluator": "PlutusTx.Eval-1.61.0.0"
   },
   "measurements": {
     "block_cpu_budget_pct": 262.4549015625,
@@ -111,6 +111,6 @@
     "tx_memory_budget_pct": 3097.6713214285714
   },
   "scenario": "fibonacci_naive_recursion",
-  "timestamp": "2026-05-06T13:50:27Z",
+  "timestamp": "2026-05-20T17:35:25Z",
   "version": "1.0.0"
 }

--- a/submissions/htlc/Plinth_1.45.0.0_Unisay/metrics.json
+++ b/submissions/htlc/Plinth_1.45.0.0_Unisay/metrics.json
@@ -177,7 +177,7 @@
     }
   ],
   "execution_environment": {
-    "evaluator": "PlutusTx.Eval-1.52.0.0"
+    "evaluator": "PlutusTx.Eval-1.45.0.0"
   },
   "measurements": {
     "block_cpu_budget_pct": 0.0955627875,
@@ -209,7 +209,7 @@
     "tx_memory_budget_pct": 0.8993714285714285
   },
   "scenario": "htlc",
-  "timestamp": "2026-05-11T15:17:00Z",
+  "timestamp": "2026-05-20T17:35:22Z",
   "version": "1.0.0",
   "notes": "Generated using UPLC-CAPE measure tool"
 }

--- a/submissions/htlc/Plinth_1.61.0.0_Unisay/metrics.json
+++ b/submissions/htlc/Plinth_1.61.0.0_Unisay/metrics.json
@@ -177,7 +177,7 @@
     }
   ],
   "execution_environment": {
-    "evaluator": "PlutusTx.Eval-1.52.0.0"
+    "evaluator": "PlutusTx.Eval-1.61.0.0"
   },
   "measurements": {
     "block_cpu_budget_pct": 0.05609871500000001,
@@ -209,6 +209,6 @@
     "tx_memory_budget_pct": 0.60065
   },
   "scenario": "htlc",
-  "timestamp": "2026-05-11T16:03:29Z",
+  "timestamp": "2026-05-20T17:35:25Z",
   "version": "1.0.0"
 }

--- a/submissions/htlc/Plinth_1.64.0.0_Unisay/metrics.json
+++ b/submissions/htlc/Plinth_1.64.0.0_Unisay/metrics.json
@@ -177,7 +177,7 @@
     }
   ],
   "execution_environment": {
-    "evaluator": "unknown"
+    "evaluator": "PlutusTx.Eval-1.45.0.0"
   },
   "measurements": {
     "block_cpu_budget_pct": 0.09658494249999999,
@@ -209,7 +209,7 @@
     "tx_memory_budget_pct": 0.8994142857142857
   },
   "scenario": "htlc",
-  "timestamp": "2026-05-20T15:32:18Z",
+  "timestamp": "2026-05-20T17:35:22Z",
   "version": "1.0.0",
   "notes": "Generated using UPLC-CAPE measure tool"
 }

--- a/submissions/htlc/Scalus_0.16.0_Unisay/metrics.json
+++ b/submissions/htlc/Scalus_0.16.0_Unisay/metrics.json
@@ -177,7 +177,7 @@
     }
   ],
   "execution_environment": {
-    "evaluator": "<evaluator-version>"
+    "evaluator": "PlutusTx.Eval-1.45.0.0"
   },
   "measurements": {
     "block_cpu_budget_pct": 0.076131005,
@@ -209,7 +209,7 @@
     "tx_memory_budget_pct": 0.6318214285714285
   },
   "scenario": "htlc",
-  "timestamp": "2026-05-05T10:17:55Z",
+  "timestamp": "2026-05-20T17:35:22Z",
   "version": "1.0.0",
   "notes": "<optional notes>"
 }

--- a/submissions/htlc/Scalus_0.17.0_Unisay/metrics.json
+++ b/submissions/htlc/Scalus_0.17.0_Unisay/metrics.json
@@ -177,7 +177,7 @@
     }
   ],
   "execution_environment": {
-    "evaluator": "<evaluator-version>"
+    "evaluator": "PlutusTx.Eval-1.45.0.0"
   },
   "measurements": {
     "block_cpu_budget_pct": 0.07754169,
@@ -209,7 +209,7 @@
     "tx_memory_budget_pct": 0.6090500000000001
   },
   "scenario": "htlc",
-  "timestamp": "2026-05-05T17:33:01Z",
+  "timestamp": "2026-05-20T17:35:22Z",
   "version": "1.0.0",
   "notes": "<optional notes>"
 }

--- a/submissions/htlc/Scalus_0.17.0_Unisay_vanrossem/metrics.json
+++ b/submissions/htlc/Scalus_0.17.0_Unisay_vanrossem/metrics.json
@@ -177,7 +177,7 @@
     }
   ],
   "execution_environment": {
-    "evaluator": "PlutusTx.Eval-1.52.0.0"
+    "evaluator": "PlutusTx.Eval-1.61.0.0"
   },
   "measurements": {
     "block_cpu_budget_pct": 0.05868365749999999,
@@ -209,6 +209,6 @@
     "tx_memory_budget_pct": 0.4590214285714286
   },
   "scenario": "htlc",
-  "timestamp": "2026-05-06T13:50:27Z",
+  "timestamp": "2026-05-20T17:35:25Z",
   "version": "1.0.0"
 }

--- a/submissions/linear_vesting/Plinth_1.45.0.0_Unisay/metrics.json
+++ b/submissions/linear_vesting/Plinth_1.45.0.0_Unisay/metrics.json
@@ -205,7 +205,7 @@
     }
   ],
   "execution_environment": {
-    "evaluator": "unknown"
+    "evaluator": "PlutusTx.Eval-1.45.0.0"
   },
   "measurements": {
     "block_cpu_budget_pct": 0.42018583,
@@ -237,7 +237,7 @@
     "tx_memory_budget_pct": 4.296692857142857
   },
   "scenario": "linear_vesting",
-  "timestamp": "2026-04-27T11:32:38Z",
+  "timestamp": "2026-05-20T17:35:23Z",
   "version": "1.0.0",
   "notes": "Generated using UPLC-CAPE measure tool"
 }

--- a/submissions/linear_vesting/Plinth_1.61.0.0_Unisay/metrics.json
+++ b/submissions/linear_vesting/Plinth_1.61.0.0_Unisay/metrics.json
@@ -205,7 +205,7 @@
     }
   ],
   "execution_environment": {
-    "evaluator": "PlutusTx.Eval-1.52.0.0"
+    "evaluator": "PlutusTx.Eval-1.61.0.0"
   },
   "measurements": {
     "block_cpu_budget_pct": 0.2609566875,
@@ -237,6 +237,6 @@
     "tx_memory_budget_pct": 2.7041285714285714
   },
   "scenario": "linear_vesting",
-  "timestamp": "2026-04-27T11:33:39Z",
+  "timestamp": "2026-05-20T17:35:25Z",
   "version": "1.0.0"
 }

--- a/submissions/linear_vesting/Plinth_1.64.0.0_Unisay/metrics.json
+++ b/submissions/linear_vesting/Plinth_1.64.0.0_Unisay/metrics.json
@@ -205,7 +205,7 @@
     }
   ],
   "execution_environment": {
-    "evaluator": "unknown"
+    "evaluator": "PlutusTx.Eval-1.45.0.0"
   },
   "measurements": {
     "block_cpu_budget_pct": 0.34328858,
@@ -237,7 +237,7 @@
     "tx_memory_budget_pct": 3.3299785714285712
   },
   "scenario": "linear_vesting",
-  "timestamp": "2026-05-20T15:32:19Z",
+  "timestamp": "2026-05-20T17:35:23Z",
   "version": "1.0.0",
   "notes": "Generated using UPLC-CAPE measure tool"
 }

--- a/submissions/two_party_escrow/Plinth_1.45.0.0_Unisay/metrics.json
+++ b/submissions/two_party_escrow/Plinth_1.45.0.0_Unisay/metrics.json
@@ -331,7 +331,7 @@
     }
   ],
   "execution_environment": {
-    "evaluator": "unknown"
+    "evaluator": "PlutusTx.Eval-1.45.0.0"
   },
   "measurements": {
     "block_cpu_budget_pct": 0.46908058500000005,
@@ -363,7 +363,7 @@
     "tx_memory_budget_pct": 5.0845
   },
   "scenario": "two_party_escrow",
-  "timestamp": "2026-04-27T11:32:39Z",
+  "timestamp": "2026-05-20T17:35:23Z",
   "version": "1.0.0",
   "notes": "Generated using UPLC-CAPE measure tool"
 }

--- a/submissions/two_party_escrow/Plinth_1.61.0.0_Unisay/metrics.json
+++ b/submissions/two_party_escrow/Plinth_1.61.0.0_Unisay/metrics.json
@@ -331,7 +331,7 @@
     }
   ],
   "execution_environment": {
-    "evaluator": "PlutusTx.Eval-1.52.0.0"
+    "evaluator": "PlutusTx.Eval-1.61.0.0"
   },
   "measurements": {
     "block_cpu_budget_pct": 0.2724410075,
@@ -363,6 +363,6 @@
     "tx_memory_budget_pct": 3.094185714285714
   },
   "scenario": "two_party_escrow",
-  "timestamp": "2026-04-27T11:33:39Z",
+  "timestamp": "2026-05-20T17:35:25Z",
   "version": "1.0.0"
 }

--- a/submissions/two_party_escrow/Plinth_1.64.0.0_Unisay/metrics.json
+++ b/submissions/two_party_escrow/Plinth_1.64.0.0_Unisay/metrics.json
@@ -331,7 +331,7 @@
     }
   ],
   "execution_environment": {
-    "evaluator": "unknown"
+    "evaluator": "PlutusTx.Eval-1.45.0.0"
   },
   "measurements": {
     "block_cpu_budget_pct": 0.4502147325,
@@ -363,7 +363,7 @@
     "tx_memory_budget_pct": 4.607814285714286
   },
   "scenario": "two_party_escrow",
-  "timestamp": "2026-05-20T15:32:21Z",
+  "timestamp": "2026-05-20T17:35:23Z",
   "version": "1.0.0",
   "notes": "Generated using UPLC-CAPE measure tool"
 }


### PR DESCRIPTION
## Summary

- `execution_environment.evaluator` in every `metrics.json` used to read the literal `"PlutusTx.Eval-1.52.0.0"` — a value that never matched the plutus-core baseline actually linked into `measure` (1.45.0.0) or `measure-preview` (1.61.0.0, 1.64.0.0 once #199 lands). Production metrics that went through the bash wrapper showed `"unknown"` instead.
- Read `VERSION_plutus_core` (cabal-emitted CPP macro) at build time and use it as the suffix; also echo the result as `Evaluator: …` on stdout so `cape_write_metrics_json` lifts it into production metrics instead of falling back to `"unknown"`.
- Refreshes every `metrics.json` under `submissions/` via `cape submission measure --all` and `cape submission measure --all --preview`. 44 entries now read `PlutusTx.Eval-1.45.0.0`, 10 read `PlutusTx.Eval-1.61.0.0`.

Closes #201