### PR TITLE
scripts: invoke measure commands via array, not string

### DIFF
--- a/scripts/cape-subcommands/submission/measure.sh
+++ b/scripts/cape-subcommands/submission/measure.sh
@@ -124,10 +124,10 @@ measure_uplc_file() {
   stdout_tmp="$(cape_mktemp)"
 
   local measure_cmd
-  measure_cmd="$(cape_measure_binary)"
+  mapfile -t measure_cmd < <(cape_measure_binary)
 
   if [[ $VERBOSE -eq 1 ]]; then
-    if ! (cd "$PROJECT_ROOT" && $measure_cmd -i "$uplc_file" "${tests_flag[@]}" -o "$tmp_raw" 2> /dev/null) 2>&1 | tee "$stdout_tmp"; then
+    if ! (cd "$PROJECT_ROOT" && "${measure_cmd[@]}" -i "$uplc_file" "${tests_flag[@]}" -o "$tmp_raw" 2> /dev/null) 2>&1 | tee "$stdout_tmp"; then
       cape_error "✗ Failed to measure UPLC program ($rel_uplc)"
       echo ""
       cape_error "Test execution details:"
@@ -136,7 +136,7 @@ measure_uplc_file() {
       return 1
     fi
   else
-    if ! (cd "$PROJECT_ROOT" && $measure_cmd -i "$uplc_file" "${tests_flag[@]}" -o "$tmp_raw" 2> /dev/null) > "$stdout_tmp" 2>&1; then
+    if ! (cd "$PROJECT_ROOT" && "${measure_cmd[@]}" -i "$uplc_file" "${tests_flag[@]}" -o "$tmp_raw" 2> /dev/null) > "$stdout_tmp" 2>&1; then
       cape_error "✗ Failed to measure UPLC program ($rel_uplc)"
       echo ""
       cape_error "Test execution details:"
@@ -234,8 +234,8 @@ measure_preview_submissions() {
   local overall_errors=0
   local found_any=0
   local preview_measure_cmd
-  preview_measure_cmd="$(cape_measure_preview_binary)"
-  cape_info "Using preview measure: $preview_measure_cmd"
+  mapfile -t preview_measure_cmd < <(cape_measure_preview_binary)
+  cape_info "Using preview measure: ${preview_measure_cmd[*]}"
 
   local submission_dir
   while IFS= read -r submission_dir; do
@@ -282,7 +282,7 @@ measure_preview_submissions() {
     local tmp_raw stdout_tmp
     tmp_raw="$(cape_mktemp)"
     stdout_tmp="$(cape_mktemp)"
-    if (cd "$PROJECT_ROOT" && $preview_measure_cmd -i "$uplc_file" -t "$tests_file" -o "$tmp_raw" 2> /dev/null) > "$stdout_tmp" 2>&1; then
+    if (cd "$PROJECT_ROOT" && "${preview_measure_cmd[@]}" -i "$uplc_file" -t "$tests_file" -o "$tmp_raw" 2> /dev/null) > "$stdout_tmp" 2>&1; then
       # Patch scenario field and write final metrics
       jq --arg s "$scenario" '.scenario = $s' "$tmp_raw" > "$submission_dir/metrics.json"
       cape_success "  ✓ Measured: $rel_path"

--- a/scripts/cape-subcommands/submission/measure.sh
+++ b/scripts/cape-subcommands/submission/measure.sh
@@ -235,7 +235,7 @@ measure_preview_submissions() {
   local found_any=0
   local preview_measure_cmd
   mapfile -t preview_measure_cmd < <(cape_measure_preview_binary)
-  cape_info "Using preview measure: ${preview_measure_cmd[*]}"
+  cape_info "Using preview measure: $(printf '%s ' "${preview_measure_cmd[@]}")"
 
   local submission_dir
   while IFS= read -r submission_dir; do

--- a/scripts/cape-subcommands/submission/verify.sh
+++ b/scripts/cape-subcommands/submission/verify.sh
@@ -108,18 +108,18 @@ verify_submission_dir() {
   tmp_stdout="$(cape_mktemp)"
 
   local measure_cmd
-  measure_cmd="$(cape_measure_binary)"
-  cape_debug "Using measure command: $measure_cmd"
+  mapfile -t measure_cmd < <(cape_measure_binary)
+  cape_debug "Using measure command: ${measure_cmd[*]}"
 
   local measure_rc
   if [[ $VERBOSE -eq 1 ]]; then
-    if (cd "$PROJECT_ROOT" && $measure_cmd -i "$uplc_file" "${tests_flag[@]}" -o "$tmp_metrics" 2>&1) | tee "$tmp_stdout"; then
+    if (cd "$PROJECT_ROOT" && "${measure_cmd[@]}" -i "$uplc_file" "${tests_flag[@]}" -o "$tmp_metrics" 2>&1) | tee "$tmp_stdout"; then
       measure_rc=0
     else
       measure_rc=1
     fi
   else
-    if (cd "$PROJECT_ROOT" && $measure_cmd -i "$uplc_file" "${tests_flag[@]}" -o "$tmp_metrics" 2> /dev/null) > "$tmp_stdout"; then
+    if (cd "$PROJECT_ROOT" && "${measure_cmd[@]}" -i "$uplc_file" "${tests_flag[@]}" -o "$tmp_metrics" 2> /dev/null) > "$tmp_stdout"; then
       measure_rc=0
     else
       measure_rc=1

--- a/scripts/cape-subcommands/submission/verify.sh
+++ b/scripts/cape-subcommands/submission/verify.sh
@@ -109,7 +109,7 @@ verify_submission_dir() {
 
   local measure_cmd
   mapfile -t measure_cmd < <(cape_measure_binary)
-  cape_debug "Using measure command: ${measure_cmd[*]}"
+  cape_debug "Using measure command: $(printf '%s ' "${measure_cmd[@]}")"
 
   local measure_rc
   if [[ $VERBOSE -eq 1 ]]; then

--- a/scripts/lib/cape_common.sh
+++ b/scripts/lib/cape_common.sh
@@ -175,39 +175,44 @@ cape_each_submission_dir() {
   done
 }
 
-# Get the measure binary path or fallback to cabal run
-# Returns either a direct binary path or "cabal run measure --"
+# Print the measure command, one word per line. Callers must read into an
+# array (e.g. `mapfile -t measure_cmd < <(cape_measure_binary)`) and invoke
+# via `"${measure_cmd[@]}"`. One-word-per-line output is what makes the
+# multi-word `cabal run measure --` fallback safe under the scripts'
+# `IFS=$'\n\t'`, which strips space-splitting and would otherwise try to
+# exec the whole string as a single command name (exit 127).
 cape_measure_binary() {
   local binary_path
 
   # First, check if measure is available in PATH (e.g., from nix build)
   if binary_path=$(command -v measure 2> /dev/null) && [[ -x "$binary_path" ]]; then
-    echo "$binary_path"
+    printf '%s\n' "$binary_path"
     return
   fi
 
   # Try to get the binary path from cabal
   if binary_path=$(cd "$PROJECT_ROOT" && cabal list-bin measure 2> /dev/null) && [[ -x "$binary_path" ]]; then
-    echo "$binary_path"
+    printf '%s\n' "$binary_path"
   else
     # Fallback to cabal run if binary detection fails
-    echo "cabal run measure --"
+    printf '%s\n' cabal run measure --
   fi
 }
 
-# Locate measure-preview binary (built against preview plutus-core)
+# Locate measure-preview binary (built against preview plutus-core).
+# Same one-word-per-line contract as cape_measure_binary.
 cape_measure_preview_binary() {
   local binary_path
 
   if binary_path=$(command -v measure-preview 2> /dev/null) && [[ -x "$binary_path" ]]; then
-    echo "$binary_path"
+    printf '%s\n' "$binary_path"
     return
   fi
 
   if binary_path=$(cd "$PROJECT_ROOT" && cabal --project-file=cabal.project.preview list-bin measure-preview 2> /dev/null) && [[ -x "$binary_path" ]]; then
-    echo "$binary_path"
+    printf '%s\n' "$binary_path"
   else
-    echo "cabal --project-file=cabal.project.preview run measure-preview --"
+    printf '%s\n' cabal --project-file=cabal.project.preview run measure-preview --
   fi
 }
 


### PR DESCRIPTION

# scripts: invoke measure commands via array, not string

`cape_measure_binary` and `cape_measure_preview_binary` fall back to multi-word command lines like `cabal run measure --` when no binary is on `PATH` and `cabal list-bin` cannot locate one. Callers store the value in a variable and rely on unquoted expansion to split it into argv.

The cape scripts run under `IFS=$'\n\t'` (no space), so unquoted expansion produces a single token rather than splitting on space. Bash then tries to exec the whole string as one command and exits 127 ("command not found"). The script's outer error handling swallows that into a misleading `sed ... failed with exit code 1` in the failure-report pipeline.

This was latent on `main` until #206 always-took the fallback path; PR #206's CI failed at the first preview submission with that opaque message.

## Repro on `main` before this PR

```bash
IFS=$'\n\t'
cmd="cabal --project-file=cabal.project.preview run measure-preview --"
$cmd --help
# bash: cabal --project-file=cabal.project.preview run measure-preview --: command not found
# exit 127
```

## Fix

- `cape_measure_binary` and `cape_measure_preview_binary` now print one word per line. `IFS` already includes newline, so the contract matches the surrounding scripts.
- `measure.sh` and `verify.sh` read the helper output into a bash array via `mapfile -t` and invoke as `"${measure_cmd[@]}"`, which bypasses IFS-driven word-splitting entirely.

No change to which binary gets picked; only the invocation mechanism is hardened.

## Test plan

- [x] `cape submission measure --preview` succeeds end-to-end locally against the fallback `cabal run` path (the failing scenario from UPLC-CAPE PR #206 CI)
- [x] `cape submission measure` (production path) still works against a `cabal list-bin`-resolved binary
- [x] `cape submission verify` still works
