### PR TITLE
ci: pin wimpysworld/nothing-but-nix to v10 SHA

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -60,7 +60,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Nothing but Nix - Optimize disk space
-        uses: wimpysworld/nothing-but-nix@main
+        uses: wimpysworld/nothing-but-nix@687c797a730352432950c707ab493fcc951818d7 # v10
 
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Nothing but Nix - Optimize disk space
-        uses: wimpysworld/nothing-but-nix@main
+        uses: wimpysworld/nothing-but-nix@687c797a730352432950c707ab493fcc951818d7 # v10
 
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION

Closes #212.

Both CI workflows referenced `wimpysworld/nothing-but-nix@main`, a mutable ref. This pins the action to the immutable `v10` commit `687c797a730352432950c707ab493fcc951818d7` in `pr-ci.yml` and `static.yml`, so CI runs exactly the audited action code until we deliberately bump it. The trailing `# v10` comment keeps future bumps readable.

SHA verified against the upstream repo (`git ls-remote` resolves `refs/tags/v10` to that commit).
