### PR TITLE
preview evaluator: bump plutus-core 1.64 → 1.65

### DIFF
--- a/cabal.project.preview
+++ b/cabal.project.preview
@@ -2,15 +2,24 @@
 -- This file is used to build against a newer plutus-core version
 -- that may include features not yet deployed on Cardano mainnet.
 --
--- Usage: cabal --project-file=cabal.project.preview build plinth-submissions
+-- Usage: cabal --project-file=cabal.project.preview build measure-preview
 
 import: cabal.project
 
--- Use latest CHaP index-state to access plutus-core 1.64.0.0
-index-state: cardano-haskell-packages 2026-05-15T00:00:00Z
+-- Use a CHaP index-state new enough to resolve plutus-core 1.65.0.0
+index-state: cardano-haskell-packages 2026-05-28T00:00:00Z
 
 -- Enable preview flag to build Preview.* modules with BuiltinCasing
 flags: +preview
+
+-- Pin plutus-* to the latest released line (1.65) so the haskell.nix shell's
+-- globally installed 1.45 cannot win the solve. Mirrors the constraints used
+-- in plinth-cape-submissions/cabal.project.
+constraints:
+    plutus-core       ^>=1.65
+  , plutus-ledger-api ^>=1.65
+  , plutus-tx         ^>=1.65
+  , plutus-tx-plugin  ^>=1.65
 
 -- Relax version constraints to accept newer plutus packages
 allow-newer:

--- a/submissions/ecd/Plinth_1.61.0.0_Unisay_preview/metrics.json
+++ b/submissions/ecd/Plinth_1.61.0.0_Unisay_preview/metrics.json
@@ -100,7 +100,7 @@
     }
   ],
   "execution_environment": {
-    "evaluator": "PlutusTx.Eval-1.64.0.0"
+    "evaluator": "PlutusTx.Eval-1.65.0.0"
   },
   "measurements": {
     "block_cpu_budget_pct": 0.0059710475,
@@ -132,6 +132,6 @@
     "tx_memory_budget_pct": 0.07007142857142858
   },
   "scenario": "ecd",
-  "timestamp": "2026-05-20T17:58:06Z",
+  "timestamp": "2026-06-22T16:07:17Z",
   "version": "1.0.0"
 }

--- a/submissions/ecd/Plinth_1.64.0.0_Unisay_preview/metrics.json
+++ b/submissions/ecd/Plinth_1.64.0.0_Unisay_preview/metrics.json
@@ -100,7 +100,7 @@
     }
   ],
   "execution_environment": {
-    "evaluator": "PlutusTx.Eval-1.64.0.0"
+    "evaluator": "PlutusTx.Eval-1.65.0.0"
   },
   "measurements": {
     "block_cpu_budget_pct": 0.0049310475,
@@ -132,6 +132,6 @@
     "tx_memory_budget_pct": 0.051500000000000004
   },
   "scenario": "ecd",
-  "timestamp": "2026-05-22T12:38:42Z",
+  "timestamp": "2026-06-22T16:07:17Z",
   "version": "1.0.0"
 }

--- a/submissions/ecd/Plinth_1.65.0.0_Unisay_preview/metrics.json
+++ b/submissions/ecd/Plinth_1.65.0.0_Unisay_preview/metrics.json
@@ -100,7 +100,7 @@
     }
   ],
   "execution_environment": {
-    "evaluator": "PlutusTx.Eval-1.64.0.0"
+    "evaluator": "PlutusTx.Eval-1.65.0.0"
   },
   "measurements": {
     "block_cpu_budget_pct": 0.0049310475,
@@ -132,6 +132,6 @@
     "tx_memory_budget_pct": 0.051500000000000004
   },
   "scenario": "ecd",
-  "timestamp": "2026-06-22T14:31:04Z",
+  "timestamp": "2026-06-22T16:07:18Z",
   "version": "1.0.0"
 }

--- a/submissions/factorial_naive_recursion/Plinth_1.61.0.0_Unisay_preview/metrics.json
+++ b/submissions/factorial_naive_recursion/Plinth_1.61.0.0_Unisay_preview/metrics.json
@@ -72,7 +72,7 @@
     }
   ],
   "execution_environment": {
-    "evaluator": "PlutusTx.Eval-1.64.0.0"
+    "evaluator": "PlutusTx.Eval-1.65.0.0"
   },
   "measurements": {
     "block_cpu_budget_pct": 0.0174297825,
@@ -104,6 +104,6 @@
     "tx_memory_budget_pct": 0.18400714285714284
   },
   "scenario": "factorial_naive_recursion",
-  "timestamp": "2026-05-20T17:58:06Z",
+  "timestamp": "2026-06-22T16:07:18Z",
   "version": "1.0.0"
 }

--- a/submissions/factorial_naive_recursion/Plinth_1.64.0.0_Unisay_preview/metrics.json
+++ b/submissions/factorial_naive_recursion/Plinth_1.64.0.0_Unisay_preview/metrics.json
@@ -72,7 +72,7 @@
     }
   ],
   "execution_environment": {
-    "evaluator": "PlutusTx.Eval-1.64.0.0"
+    "evaluator": "PlutusTx.Eval-1.65.0.0"
   },
   "measurements": {
     "block_cpu_budget_pct": 0.0174297825,
@@ -104,6 +104,6 @@
     "tx_memory_budget_pct": 0.18400714285714284
   },
   "scenario": "factorial_naive_recursion",
-  "timestamp": "2026-05-20T17:58:06Z",
+  "timestamp": "2026-06-22T16:07:18Z",
   "version": "1.0.0"
 }

--- a/submissions/factorial_naive_recursion/Plinth_1.65.0.0_Unisay_preview/metrics.json
+++ b/submissions/factorial_naive_recursion/Plinth_1.65.0.0_Unisay_preview/metrics.json
@@ -72,7 +72,7 @@
     }
   ],
   "execution_environment": {
-    "evaluator": "PlutusTx.Eval-1.64.0.0"
+    "evaluator": "PlutusTx.Eval-1.65.0.0"
   },
   "measurements": {
     "block_cpu_budget_pct": 0.0174297825,
@@ -104,6 +104,6 @@
     "tx_memory_budget_pct": 0.18400714285714284
   },
   "scenario": "factorial_naive_recursion",
-  "timestamp": "2026-06-22T14:31:04Z",
+  "timestamp": "2026-06-22T16:07:18Z",
   "version": "1.0.0"
 }

--- a/submissions/factorial_naive_recursion/Scalus_0.17.0_Unisay_vanrossem/metrics.json
+++ b/submissions/factorial_naive_recursion/Scalus_0.17.0_Unisay_vanrossem/metrics.json
@@ -72,7 +72,7 @@
     }
   ],
   "execution_environment": {
-    "evaluator": "PlutusTx.Eval-1.64.0.0"
+    "evaluator": "PlutusTx.Eval-1.65.0.0"
   },
   "measurements": {
     "block_cpu_budget_pct": 0.0204297825,
@@ -104,6 +104,6 @@
     "tx_memory_budget_pct": 0.23757857142857144
   },
   "scenario": "factorial_naive_recursion",
-  "timestamp": "2026-05-20T17:58:06Z",
+  "timestamp": "2026-06-22T16:07:18Z",
   "version": "1.0.0"
 }

--- a/submissions/fibonacci/Plinth_1.61.0.0_Unisay_preview/metrics.json
+++ b/submissions/fibonacci/Plinth_1.61.0.0_Unisay_preview/metrics.json
@@ -79,7 +79,7 @@
     }
   ],
   "execution_environment": {
-    "evaluator": "PlutusTx.Eval-1.64.0.0"
+    "evaluator": "PlutusTx.Eval-1.65.0.0"
   },
   "measurements": {
     "block_cpu_budget_pct": 0.041354615,
@@ -111,6 +111,6 @@
     "tx_memory_budget_pct": 0.4723
   },
   "scenario": "fibonacci",
-  "timestamp": "2026-05-20T17:58:06Z",
+  "timestamp": "2026-06-22T16:07:18Z",
   "version": "1.0.0"
 }

--- a/submissions/fibonacci/Plinth_1.64.0.0_Unisay_preview/metrics.json
+++ b/submissions/fibonacci/Plinth_1.64.0.0_Unisay_preview/metrics.json
@@ -79,7 +79,7 @@
     }
   ],
   "execution_environment": {
-    "evaluator": "PlutusTx.Eval-1.64.0.0"
+    "evaluator": "PlutusTx.Eval-1.65.0.0"
   },
   "measurements": {
     "block_cpu_budget_pct": 0.041354615,
@@ -111,6 +111,6 @@
     "tx_memory_budget_pct": 0.4723
   },
   "scenario": "fibonacci",
-  "timestamp": "2026-05-20T17:58:06Z",
+  "timestamp": "2026-06-22T16:07:18Z",
   "version": "1.0.0"
 }

--- a/submissions/fibonacci/Plinth_1.65.0.0_Unisay_preview/metrics.json
+++ b/submissions/fibonacci/Plinth_1.65.0.0_Unisay_preview/metrics.json
@@ -79,7 +79,7 @@
     }
   ],
   "execution_environment": {
-    "evaluator": "PlutusTx.Eval-1.64.0.0"
+    "evaluator": "PlutusTx.Eval-1.65.0.0"
   },
   "measurements": {
     "block_cpu_budget_pct": 0.0414454275,
@@ -111,6 +111,6 @@
     "tx_memory_budget_pct": 0.4723
   },
   "scenario": "fibonacci",
-  "timestamp": "2026-06-22T14:31:05Z",
+  "timestamp": "2026-06-22T16:07:18Z",
   "version": "1.0.0"
 }

--- a/submissions/fibonacci_naive_recursion/Plinth_1.61.0.0_Unisay_preview/metrics.json
+++ b/submissions/fibonacci_naive_recursion/Plinth_1.61.0.0_Unisay_preview/metrics.json
@@ -79,7 +79,7 @@
     }
   ],
   "execution_environment": {
-    "evaluator": "PlutusTx.Eval-1.64.0.0"
+    "evaluator": "PlutusTx.Eval-1.65.0.0"
   },
   "measurements": {
     "block_cpu_budget_pct": 293.5563468825,
@@ -111,6 +111,6 @@
     "tx_memory_budget_pct": 3128.4574071428574
   },
   "scenario": "fibonacci_naive_recursion",
-  "timestamp": "2026-05-20T17:58:06Z",
+  "timestamp": "2026-06-22T16:07:18Z",
   "version": "1.0.0"
 }

--- a/submissions/fibonacci_naive_recursion/Plinth_1.64.0.0_Unisay_preview/metrics.json
+++ b/submissions/fibonacci_naive_recursion/Plinth_1.64.0.0_Unisay_preview/metrics.json
@@ -79,7 +79,7 @@
     }
   ],
   "execution_environment": {
-    "evaluator": "PlutusTx.Eval-1.64.0.0"
+    "evaluator": "PlutusTx.Eval-1.65.0.0"
   },
   "measurements": {
     "block_cpu_budget_pct": 293.5563468825,
@@ -111,6 +111,6 @@
     "tx_memory_budget_pct": 3128.4574071428574
   },
   "scenario": "fibonacci_naive_recursion",
-  "timestamp": "2026-05-20T17:58:07Z",
+  "timestamp": "2026-06-22T16:07:19Z",
   "version": "1.0.0"
 }

--- a/submissions/fibonacci_naive_recursion/Plinth_1.65.0.0_Unisay_preview/metrics.json
+++ b/submissions/fibonacci_naive_recursion/Plinth_1.65.0.0_Unisay_preview/metrics.json
@@ -79,7 +79,7 @@
     }
   ],
   "execution_environment": {
-    "evaluator": "PlutusTx.Eval-1.64.0.0"
+    "evaluator": "PlutusTx.Eval-1.65.0.0"
   },
   "measurements": {
     "block_cpu_budget_pct": 293.5563468825,
@@ -111,6 +111,6 @@
     "tx_memory_budget_pct": 3128.4574071428574
   },
   "scenario": "fibonacci_naive_recursion",
-  "timestamp": "2026-06-22T14:31:05Z",
+  "timestamp": "2026-06-22T16:07:19Z",
   "version": "1.0.0"
 }

--- a/submissions/fibonacci_naive_recursion/Scalus_0.17.0_Unisay_vanrossem/metrics.json
+++ b/submissions/fibonacci_naive_recursion/Scalus_0.17.0_Unisay_vanrossem/metrics.json
@@ -79,7 +79,7 @@
     }
   ],
   "execution_environment": {
-    "evaluator": "PlutusTx.Eval-1.64.0.0"
+    "evaluator": "PlutusTx.Eval-1.65.0.0"
   },
   "measurements": {
     "block_cpu_budget_pct": 262.4549015625,
@@ -111,6 +111,6 @@
     "tx_memory_budget_pct": 3097.6713214285714
   },
   "scenario": "fibonacci_naive_recursion",
-  "timestamp": "2026-05-20T17:58:07Z",
+  "timestamp": "2026-06-22T16:07:19Z",
   "version": "1.0.0"
 }

--- a/submissions/htlc/Plinth_1.61.0.0_Unisay_preview/metrics.json
+++ b/submissions/htlc/Plinth_1.61.0.0_Unisay_preview/metrics.json
@@ -177,7 +177,7 @@
     }
   ],
   "execution_environment": {
-    "evaluator": "PlutusTx.Eval-1.64.0.0"
+    "evaluator": "PlutusTx.Eval-1.65.0.0"
   },
   "measurements": {
     "block_cpu_budget_pct": 0.056093875,
@@ -209,6 +209,6 @@
     "tx_memory_budget_pct": 0.60065
   },
   "scenario": "htlc",
-  "timestamp": "2026-05-20T17:58:07Z",
+  "timestamp": "2026-06-22T16:07:19Z",
   "version": "1.0.0"
 }

--- a/submissions/htlc/Plinth_1.64.0.0_Unisay/metrics.json
+++ b/submissions/htlc/Plinth_1.64.0.0_Unisay/metrics.json
@@ -209,7 +209,6 @@
     "tx_memory_budget_pct": 0.60585
   },
   "scenario": "htlc",
-  "timestamp": "2026-06-22T16:09:06Z",
-  "version": "1.0.0",
-  "notes": "Generated using UPLC-CAPE measure tool"
+  "timestamp": "2026-05-22T13:20:24Z",
+  "version": "1.0.0"
 }

--- a/submissions/htlc/Plinth_1.64.0.0_Unisay/metrics.json
+++ b/submissions/htlc/Plinth_1.64.0.0_Unisay/metrics.json
@@ -209,6 +209,7 @@
     "tx_memory_budget_pct": 0.60585
   },
   "scenario": "htlc",
-  "timestamp": "2026-05-22T13:20:24Z",
-  "version": "1.0.0"
+  "timestamp": "2026-06-22T16:09:06Z",
+  "version": "1.0.0",
+  "notes": "Generated using UPLC-CAPE measure tool"
 }

--- a/submissions/htlc/Plinth_1.64.0.0_Unisay_preview/metrics.json
+++ b/submissions/htlc/Plinth_1.64.0.0_Unisay_preview/metrics.json
@@ -177,7 +177,7 @@
     }
   ],
   "execution_environment": {
-    "evaluator": "PlutusTx.Eval-1.64.0.0"
+    "evaluator": "PlutusTx.Eval-1.65.0.0"
   },
   "measurements": {
     "block_cpu_budget_pct": 0.043555605,
@@ -209,6 +209,6 @@
     "tx_memory_budget_pct": 0.4520642857142857
   },
   "scenario": "htlc",
-  "timestamp": "2026-05-22T13:20:24Z",
+  "timestamp": "2026-06-22T16:07:19Z",
   "version": "1.0.0"
 }

--- a/submissions/htlc/Plinth_1.65.0.0_Unisay_preview/metrics.json
+++ b/submissions/htlc/Plinth_1.65.0.0_Unisay_preview/metrics.json
@@ -177,7 +177,7 @@
     }
   ],
   "execution_environment": {
-    "evaluator": "PlutusTx.Eval-1.64.0.0"
+    "evaluator": "PlutusTx.Eval-1.65.0.0"
   },
   "measurements": {
     "block_cpu_budget_pct": 0.0381264725,
@@ -209,6 +209,6 @@
     "tx_memory_budget_pct": 0.38475
   },
   "scenario": "htlc",
-  "timestamp": "2026-06-22T14:31:06Z",
+  "timestamp": "2026-06-22T16:07:19Z",
   "version": "1.0.0"
 }

--- a/submissions/htlc/Scalus_0.17.0_Unisay_vanrossem/metrics.json
+++ b/submissions/htlc/Scalus_0.17.0_Unisay_vanrossem/metrics.json
@@ -177,7 +177,7 @@
     }
   ],
   "execution_environment": {
-    "evaluator": "PlutusTx.Eval-1.64.0.0"
+    "evaluator": "PlutusTx.Eval-1.65.0.0"
   },
   "measurements": {
     "block_cpu_budget_pct": 0.058679934999999996,
@@ -209,6 +209,6 @@
     "tx_memory_budget_pct": 0.4590214285714286
   },
   "scenario": "htlc",
-  "timestamp": "2026-05-20T17:58:07Z",
+  "timestamp": "2026-06-22T16:07:19Z",
   "version": "1.0.0"
 }

--- a/submissions/linear_vesting/Plinth_1.61.0.0_Unisay_preview/metrics.json
+++ b/submissions/linear_vesting/Plinth_1.61.0.0_Unisay_preview/metrics.json
@@ -205,7 +205,7 @@
     }
   ],
   "execution_environment": {
-    "evaluator": "PlutusTx.Eval-1.64.0.0"
+    "evaluator": "PlutusTx.Eval-1.65.0.0"
   },
   "measurements": {
     "block_cpu_budget_pct": 0.26095716500000005,
@@ -237,6 +237,6 @@
     "tx_memory_budget_pct": 2.7041285714285714
   },
   "scenario": "linear_vesting",
-  "timestamp": "2026-05-20T17:58:07Z",
+  "timestamp": "2026-06-22T16:07:19Z",
   "version": "1.0.0"
 }

--- a/submissions/linear_vesting/Plinth_1.64.0.0_Unisay/metrics.json
+++ b/submissions/linear_vesting/Plinth_1.64.0.0_Unisay/metrics.json
@@ -237,6 +237,7 @@
     "tx_memory_budget_pct": 3.3307214285714286
   },
   "scenario": "linear_vesting",
-  "timestamp": "2026-05-22T13:20:25Z",
-  "version": "1.0.0"
+  "timestamp": "2026-06-22T16:09:09Z",
+  "version": "1.0.0",
+  "notes": "Generated using UPLC-CAPE measure tool"
 }

--- a/submissions/linear_vesting/Plinth_1.64.0.0_Unisay/metrics.json
+++ b/submissions/linear_vesting/Plinth_1.64.0.0_Unisay/metrics.json
@@ -237,7 +237,6 @@
     "tx_memory_budget_pct": 3.3307214285714286
   },
   "scenario": "linear_vesting",
-  "timestamp": "2026-06-22T16:09:09Z",
-  "version": "1.0.0",
-  "notes": "Generated using UPLC-CAPE measure tool"
+  "timestamp": "2026-05-22T13:20:25Z",
+  "version": "1.0.0"
 }

--- a/submissions/linear_vesting/Plinth_1.64.0.0_Unisay_preview/metrics.json
+++ b/submissions/linear_vesting/Plinth_1.64.0.0_Unisay_preview/metrics.json
@@ -205,7 +205,7 @@
     }
   ],
   "execution_environment": {
-    "evaluator": "PlutusTx.Eval-1.64.0.0"
+    "evaluator": "PlutusTx.Eval-1.65.0.0"
   },
   "measurements": {
     "block_cpu_budget_pct": 0.2297035675,
@@ -237,6 +237,6 @@
     "tx_memory_budget_pct": 2.388935714285714
   },
   "scenario": "linear_vesting",
-  "timestamp": "2026-05-22T13:20:26Z",
+  "timestamp": "2026-06-22T16:07:19Z",
   "version": "1.0.0"
 }

--- a/submissions/linear_vesting/Plinth_1.65.0.0_Unisay_preview/metrics.json
+++ b/submissions/linear_vesting/Plinth_1.65.0.0_Unisay_preview/metrics.json
@@ -205,7 +205,7 @@
     }
   ],
   "execution_environment": {
-    "evaluator": "PlutusTx.Eval-1.64.0.0"
+    "evaluator": "PlutusTx.Eval-1.65.0.0"
   },
   "measurements": {
     "block_cpu_budget_pct": 0.21866356750000002,
@@ -237,6 +237,6 @@
     "tx_memory_budget_pct": 2.175885714285714
   },
   "scenario": "linear_vesting",
-  "timestamp": "2026-06-22T14:31:06Z",
+  "timestamp": "2026-06-22T16:07:20Z",
   "version": "1.0.0"
 }

--- a/submissions/two_party_escrow/Plinth_1.61.0.0_Unisay_preview/metrics.json
+++ b/submissions/two_party_escrow/Plinth_1.61.0.0_Unisay_preview/metrics.json
@@ -331,7 +331,7 @@
     }
   ],
   "execution_environment": {
-    "evaluator": "PlutusTx.Eval-1.64.0.0"
+    "evaluator": "PlutusTx.Eval-1.65.0.0"
   },
   "measurements": {
     "block_cpu_budget_pct": 0.272436545,
@@ -363,6 +363,6 @@
     "tx_memory_budget_pct": 3.094185714285714
   },
   "scenario": "two_party_escrow",
-  "timestamp": "2026-05-20T17:58:07Z",
+  "timestamp": "2026-06-22T16:07:20Z",
   "version": "1.0.0"
 }

--- a/submissions/two_party_escrow/Plinth_1.64.0.0_Unisay_preview/metrics.json
+++ b/submissions/two_party_escrow/Plinth_1.64.0.0_Unisay_preview/metrics.json
@@ -331,7 +331,7 @@
     }
   ],
   "execution_environment": {
-    "evaluator": "PlutusTx.Eval-1.64.0.0"
+    "evaluator": "PlutusTx.Eval-1.65.0.0"
   },
   "measurements": {
     "block_cpu_budget_pct": 0.274049955,
@@ -363,6 +363,6 @@
     "tx_memory_budget_pct": 3.1048428571428572
   },
   "scenario": "two_party_escrow",
-  "timestamp": "2026-05-20T17:58:07Z",
+  "timestamp": "2026-06-22T16:07:20Z",
   "version": "1.0.0"
 }

--- a/submissions/two_party_escrow/Plinth_1.65.0.0_Unisay_preview/metrics.json
+++ b/submissions/two_party_escrow/Plinth_1.65.0.0_Unisay_preview/metrics.json
@@ -331,7 +331,7 @@
     }
   ],
   "execution_environment": {
-    "evaluator": "PlutusTx.Eval-1.64.0.0"
+    "evaluator": "PlutusTx.Eval-1.65.0.0"
   },
   "measurements": {
     "block_cpu_budget_pct": 0.2636935875,
@@ -363,6 +363,6 @@
     "tx_memory_budget_pct": 2.919842857142857
   },
   "scenario": "two_party_escrow",
-  "timestamp": "2026-06-22T14:31:06Z",
+  "timestamp": "2026-06-22T16:07:20Z",
   "version": "1.0.0"
 }


### PR DESCRIPTION
## Why

Follow-up to PRs #215 + #216. The plinth-cape-submissions agent flagged after delivering the 1.65 preview submissions: the preview evaluator still reports `PlutusTx.Eval-1.64.0.0` even though the 1.65 preview artifacts had landed. Cause: `cabal.project.preview` was pinned to CHaP index-state `2026-05-15` with no explicit `plutus-*` constraint, so cabal solved to `plutus-core 1.64.0.0` and `measure-preview` baked that label into every preview `metrics.json` — including the brand-new 1.65 preview ones.

The numbers themselves are unaffected (1.65's runtime is backward-compatible with the 1.64 cost model), but the evaluator label is what makes the 1.65 preview numbers canonical for downstream consumers.

## What changes

`cabal.project.preview`:

- CHaP index-state bumped `2026-05-15` → `2026-05-28` (1.65 lives on CHaP from this date forward).
- Explicit `constraints: plutus-{core,ledger-api,tx,tx-plugin} ^>=1.65` mirroring `plinth-cape-submissions/cabal.project` so the haskell.nix shell's globally installed 1.45 can't win the solve.
- Comment corrected: `to access plutus-core 1.64.0.0` → `to resolve plutus-core 1.65.0.0`; `cabal build plinth-submissions` → `cabal build measure-preview` (the latter is the actual binary this project file builds — the former lives in the sibling `plinth-cape-submissions` checkout).

24 `metrics.json` files updated in lock-step. Each diff is the same shape:

```diff
-    "evaluator": "PlutusTx.Eval-1.64.0.0"
+    "evaluator": "PlutusTx.Eval-1.65.0.0"
   ...
-  "timestamp": "2026-MM-DDTHH:MM:SSZ",
+  "timestamp": "2026-06-22T16:07:18Z",
```

All measurement values (`cpu_units`, `memory_units`, `script_size_bytes`, `term_size`, fee components) are byte-identical to the prior commit — confirmed by `git diff` filtered for `evaluator|timestamp`.

## Verification

- [x] `nix develop` + `cabal --project-file=cabal.project.preview build measure-preview` builds against `plutus-ledger-api-1.65.0.0`.
- [x] `cape submission measure --preview` (iterates every preview submission) re-stamps the evaluator label and produces identical measurements; 24 files touched.
- [x] `bash scripts/cape-subcommands/test/test.sh` — 53/53.
- [x] CI (Build Measure Executable, validate).

## Out of scope

- Bumping the mainnet `cabal.project` (still on `plutus-core 1.45`). Production reports use the mainline 1.45 cost model deliberately — that's the canonical Cardano runtime today.
- Re-measuring mainnet submissions. `cape submission verify --all` would rewrite mainnet `metrics.json` files with locally-computed numbers (the dev-vs-CI drift documented in CLAUDE.md), and the new evaluator doesn't apply to them anyway.