### PR TITLE
submissions(htlc): fix stale source commit reference in Scalus_0.16.0_Unisay

### DIFF
--- a/submissions/htlc/Scalus_0.16.0_Unisay/metadata.json
+++ b/submissions/htlc/Scalus_0.16.0_Unisay/metadata.json
@@ -19,7 +19,7 @@
     "date": "2026-04-24T12:48:44Z",
     "source_available": true,
     "source_repository": "https://github.com/Unisay/scalus-cape-submissions",
-    "source_commit_hash": "07350edfbaaa3f4c42cf116a3c360ba3098ccf3f",
-    "implementation_notes": "Scalus 0.16.0 HTLC spending validator (`@Compile object HTLCValidator`, `Data -> Unit`). Derives FromData/ToData for HTLCDatum and HTLCRedeemer. Claim reads the upper bound of `txInfoValidRange` (finite, strictly `< timeout`); refund reads the lower bound (finite, strictly `> timeout`). Matches the production-safe convention introduced in IntersectMBO/UPLC-CAPE#170. Uses `toUplcOptimized()` with CaseConstrApply and builtin-packing; an AST-level alpha-rename pass rewrites all generated names to short purely-alphabetic identifiers (a, b, ..., z, aa, ...) before serialisation, ensuring compatibility with the plutus-core 1.45.0.0 textual parser."
+    "source_commit_hash": "01d5b6b6a31655dcebe34f5a52549d2b4c12f4aa",
+    "implementation_notes": "Scalus 0.16.0 HTLC spending validator (`@Compile object HTLCValidator`, `Data -> Unit`). Derives FromData/ToData for HTLCDatum and HTLCRedeemer. Claim reads the upper bound of `txInfoValidRange` (finite, strictly `< timeout`); refund reads the lower bound (finite, strictly `> timeout`). Matches the production-safe convention introduced in IntersectMBO/UPLC-CAPE#170. Uses `toUplcOptimized(using Options.release)` with CaseConstrApply and builtin-packing (`removeTraces=true`, `generateErrorTraces=false`); an AST-level alpha-rename pass rewrites all generated names to short purely-alphabetic identifiers (a, b, ..., z, aa, ...) before serialisation, ensuring compatibility with the plutus-core 1.45.0.0 textual parser."
   }
 }

--- a/submissions/htlc/Scalus_0.16.0_Unisay/source/README.md
+++ b/submissions/htlc/Scalus_0.16.0_Unisay/source/README.md
@@ -1,16 +1,16 @@
 # Scalus HTLC Implementation
 
-**Source Code**: [HTLC.scala](https://github.com/Unisay/scalus-cape-submissions/blob/07350edfbaaa3f4c42cf116a3c360ba3098ccf3f/src/htlc/HTLC.scala)
+**Source Code**: [HTLC.scala](https://github.com/Unisay/scalus-cape-submissions/blob/01d5b6b6a31655dcebe34f5a52549d2b4c12f4aa/src/htlc/HTLC.scala)
 
 **Repository**: <https://github.com/Unisay/scalus-cape-submissions>
 
-**Commit**: `07350edfbaaa3f4c42cf116a3c360ba3098ccf3f`
+**Commit**: `01d5b6b6a31655dcebe34f5a52549d2b4c12f4aa`
 
 **Path**: `src/htlc/HTLC.scala`
 
 This submission uses Scalus compiler version 0.16.0 with a spending validator that enforces the production-safe validity-range convention (claim reads the upper bound, refund reads the lower bound — both finite and strict).
 
-The artifact is compiled with `toUplcOptimized()` (CaseConstrApply + builtin-packing). An AST-level alpha-rename pass rewrites all generated identifiers to short purely-alphabetic names (a, b, …, z, aa, …) before serialisation. This makes the output compatible with the plutus-core 1.45.0.0 textual parser without sacrificing optimised code size.
+The artifact is compiled with `toUplcOptimized(using Options.release)` (CaseConstrApply + builtin-packing, `removeTraces=true`, `generateErrorTraces=false`), matching production-typical compilation where validators fail without trace messages. An AST-level alpha-rename pass rewrites all generated identifiers to short purely-alphabetic names (a, b, …, z, aa, …) before serialisation. This makes the output compatible with the plutus-core 1.45.0.0 textual parser without sacrificing optimised code size.
 
 ## Reproducing the Compilation
 
@@ -24,7 +24,7 @@ The artifact is compiled with `toUplcOptimized()` (CaseConstrApply + builtin-pac
 2. Check out the specific commit:
 
    ```bash
-   git checkout 07350edfbaaa3f4c42cf116a3c360ba3098ccf3f
+   git checkout 01d5b6b6a31655dcebe34f5a52549d2b4c12f4aa
    ```
 
 3. Follow build instructions in the repository README


### PR DESCRIPTION
## Why

The `Scalus_0.16.0_Unisay` HTLC submission's compiled artifact was already rebuilt with `Options.release` (`removeTraces=true`, `generateErrorTraces=false`) — its `term_size` and full metrics match the source repo's post-`Options.release` commit exactly — but the pinned `source_commit_hash` in `metadata.json` and `source/README.md` still pointed at the pre-`Options.release` commit `07350ed`. Anyone checking out that commit to reproduce would get the older, larger artifact with traces intact, which does not match the committed `htlc.uplc`.

## What changes

Repoint the source reference from `07350edf…` to `01d5b6b6a31655dcebe34f5a52549d2b4c12f4aa` (the commit in `Unisay/scalus-cape-submissions` that introduced `Options.release` for the Scalus HTLC submissions), in both `metadata.json` (`source_commit_hash`) and `source/README.md` (source link, commit, checkout command). The implementation notes now state the actual compile flags (`toUplcOptimized(using Options.release)`, `removeTraces=true`, `generateErrorTraces=false`).

The `htlc.uplc` and `metrics.json` are untouched — they were already correct.

## Verification

`cape submission verify submissions/htlc/Scalus_0.16.0_Unisay` passes: 25/25 tests, metrics.json and metadata.json both schema-valid. Measuring the artifact from commit `01d5b6b` reproduces the committed metrics (fee 94378, size 1008, term_size 1014) byte-for-byte.