### PR TITLE
submissions: fix stale source commit reference in three Scalus 0.16.0 submissions

### DIFF
--- a/submissions/factorial_naive_recursion/Scalus_0.16.0_Unisay/metadata.json
+++ b/submissions/factorial_naive_recursion/Scalus_0.16.0_Unisay/metadata.json
@@ -19,7 +19,7 @@
     "date": "2026-04-21T12:00:00Z",
     "source_available": true,
     "source_repository": "https://github.com/Unisay/scalus-cape-submissions",
-    "source_commit_hash": "2126a807bbe2a744e2b924bda3099881e09d969f",
-    "implementation_notes": "Scalus with default options (naive recursive implementation, no optimization). AST-level alpha-rename pass applied: all generated identifiers rewritten to short purely-alphabetic names before serialisation."
+    "source_commit_hash": "01d5b6b6a31655dcebe34f5a52549d2b4c12f4aa",
+    "implementation_notes": "Scalus with Options.release (naive recursive implementation, no optimization; removeTraces=true and generateErrorTraces=false have no visible effect here since the source has no fail()/require() calls to strip). AST-level alpha-rename pass applied: all generated identifiers rewritten to short purely-alphabetic names before serialisation."
   }
 }

--- a/submissions/factorial_naive_recursion/Scalus_0.16.0_Unisay/source/README.md
+++ b/submissions/factorial_naive_recursion/Scalus_0.16.0_Unisay/source/README.md
@@ -1,14 +1,14 @@
 # Scalus Factorial Naive Recursion Implementation
 
-**Source Code**: [FactorialNaiveRecursion.scala](https://github.com/Unisay/scalus-cape-submissions/blob/2126a807bbe2a744e2b924bda3099881e09d969f/src/factorial_naive_recursion/FactorialNaiveRecursion.scala)
+**Source Code**: [FactorialNaiveRecursion.scala](https://github.com/Unisay/scalus-cape-submissions/blob/01d5b6b6a31655dcebe34f5a52549d2b4c12f4aa/src/factorial_naive_recursion/FactorialNaiveRecursion.scala)
 
 **Repository**: <https://github.com/Unisay/scalus-cape-submissions>
 
-**Commit**: `2126a807bbe2a744e2b924bda3099881e09d969f`
+**Commit**: `01d5b6b6a31655dcebe34f5a52549d2b4c12f4aa`
 
 **Path**: `src/factorial_naive_recursion/FactorialNaiveRecursion.scala`
 
-This submission uses Scalus compiler version 0.16.0 with a naive recursive implementation (no optimization, per scenario specification).
+This submission uses Scalus compiler version 0.16.0 with a naive recursive implementation (no optimization, per scenario specification), compiled with `Options.release`. `removeTraces=true`/`generateErrorTraces=false` have no visible effect on this scenario since the source has no `fail()`/`require()` calls to strip.
 
 ## Reproducing the Compilation
 
@@ -22,7 +22,7 @@ This submission uses Scalus compiler version 0.16.0 with a naive recursive imple
 2. Check out the specific commit:
 
    ```bash
-   git checkout 2126a807bbe2a744e2b924bda3099881e09d969f
+   git checkout 01d5b6b6a31655dcebe34f5a52549d2b4c12f4aa
    ```
 
 3. Follow build instructions in the repository README

--- a/submissions/fibonacci/Scalus_0.16.0_Unisay_prepacked/metadata.json
+++ b/submissions/fibonacci/Scalus_0.16.0_Unisay_prepacked/metadata.json
@@ -19,7 +19,7 @@
     "date": "2026-04-21T12:00:00Z",
     "source_available": true,
     "source_repository": "https://github.com/Unisay/scalus-cape-submissions",
-    "source_commit_hash": "2126a807bbe2a744e2b924bda3099881e09d969f",
-    "implementation_notes": "Optimized prepacked implementation using pre-computed Fibonacci numbers stored in a ByteString for O(1) constant-time lookup. Pre-computed values for fib(0) through fib(25), each encoded as 3 bytes in big-endian format. AST-level alpha-rename pass applied: all generated identifiers rewritten to short purely-alphabetic names before serialisation."
+    "source_commit_hash": "01d5b6b6a31655dcebe34f5a52549d2b4c12f4aa",
+    "implementation_notes": "Optimized prepacked implementation using pre-computed Fibonacci numbers stored in a ByteString for O(1) constant-time lookup. Pre-computed values for fib(0) through fib(25), each encoded as 3 bytes in big-endian format. Compiled with Options.release (removeTraces=true, generateErrorTraces=false have no visible effect here since the source has no fail()/require() calls to strip). AST-level alpha-rename pass applied: all generated identifiers rewritten to short purely-alphabetic names before serialisation."
   }
 }

--- a/submissions/fibonacci/Scalus_0.16.0_Unisay_prepacked/metadata.json
+++ b/submissions/fibonacci/Scalus_0.16.0_Unisay_prepacked/metadata.json
@@ -20,6 +20,6 @@
     "source_available": true,
     "source_repository": "https://github.com/Unisay/scalus-cape-submissions",
     "source_commit_hash": "01d5b6b6a31655dcebe34f5a52549d2b4c12f4aa",
-    "implementation_notes": "Optimized prepacked implementation using pre-computed Fibonacci numbers stored in a ByteString for O(1) constant-time lookup. Pre-computed values for fib(0) through fib(25), each encoded as 3 bytes in big-endian format. Compiled with Options.release (removeTraces=true, generateErrorTraces=false have no visible effect here since the source has no fail()/require() calls to strip). AST-level alpha-rename pass applied: all generated identifiers rewritten to short purely-alphabetic names before serialisation."
+    "implementation_notes": "Optimized prepacked implementation using pre-computed Fibonacci numbers stored in a ByteString for O(1) constant-time lookup. Pre-computed values for fib(0) through fib(25), each encoded as 3 bytes in big-endian format. Compiled with Options.release (removeTraces=true and generateErrorTraces=false have no visible effect here since the source has no fail()/require() calls to strip). AST-level alpha-rename pass applied: all generated identifiers rewritten to short purely-alphabetic names before serialisation."
   }
 }

--- a/submissions/fibonacci/Scalus_0.16.0_Unisay_prepacked/source/README.md
+++ b/submissions/fibonacci/Scalus_0.16.0_Unisay_prepacked/source/README.md
@@ -1,14 +1,14 @@
 # Scalus Fibonacci Prepacked Implementation
 
-**Source Code**: [FibonacciPrepacked.scala](https://github.com/Unisay/scalus-cape-submissions/blob/2126a807bbe2a744e2b924bda3099881e09d969f/src/fibonacci_prepacked/FibonacciPrepacked.scala)
+**Source Code**: [FibonacciPrepacked.scala](https://github.com/Unisay/scalus-cape-submissions/blob/01d5b6b6a31655dcebe34f5a52549d2b4c12f4aa/src/fibonacci_prepacked/FibonacciPrepacked.scala)
 
 **Repository**: <https://github.com/Unisay/scalus-cape-submissions>
 
-**Commit**: `2126a807bbe2a744e2b924bda3099881e09d969f`
+**Commit**: `01d5b6b6a31655dcebe34f5a52549d2b4c12f4aa`
 
 **Path**: `src/fibonacci_prepacked/FibonacciPrepacked.scala`
 
-This submission uses Scalus compiler version 0.16.0 with a prepacked optimization approach for O(1) constant-time lookup.
+This submission uses Scalus compiler version 0.16.0 with a prepacked optimization approach for O(1) constant-time lookup, compiled with `Options.release`. `removeTraces=true`/`generateErrorTraces=false` have no visible effect on this scenario since the source has no `fail()`/`require()` calls to strip.
 
 ## Implementation Approach
 
@@ -29,7 +29,7 @@ This submission uses Scalus compiler version 0.16.0 with a prepacked optimizatio
 2. Check out the specific commit:
 
    ```bash
-   git checkout 2126a807bbe2a744e2b924bda3099881e09d969f
+   git checkout 01d5b6b6a31655dcebe34f5a52549d2b4c12f4aa
    ```
 
 3. Run the compilation:

--- a/submissions/fibonacci_naive_recursion/Scalus_0.16.0_Unisay/metadata.json
+++ b/submissions/fibonacci_naive_recursion/Scalus_0.16.0_Unisay/metadata.json
@@ -19,7 +19,7 @@
     "date": "2026-04-21T12:00:00Z",
     "source_available": true,
     "source_repository": "https://github.com/Unisay/scalus-cape-submissions",
-    "source_commit_hash": "2126a807bbe2a744e2b924bda3099881e09d969f",
-    "implementation_notes": "Scalus with default options (naive recursive implementation, no optimization). AST-level alpha-rename pass applied: all generated identifiers rewritten to short purely-alphabetic names before serialisation."
+    "source_commit_hash": "01d5b6b6a31655dcebe34f5a52549d2b4c12f4aa",
+    "implementation_notes": "Scalus with Options.release (naive recursive implementation, no optimization; removeTraces=true and generateErrorTraces=false have no visible effect here since the source has no fail()/require() calls to strip). AST-level alpha-rename pass applied: all generated identifiers rewritten to short purely-alphabetic names before serialisation."
   }
 }

--- a/submissions/fibonacci_naive_recursion/Scalus_0.16.0_Unisay/source/README.md
+++ b/submissions/fibonacci_naive_recursion/Scalus_0.16.0_Unisay/source/README.md
@@ -1,14 +1,14 @@
 # Scalus Fibonacci Naive Recursion Implementation
 
-**Source Code**: [FibonacciNaiveRecursion.scala](https://github.com/Unisay/scalus-cape-submissions/blob/2126a807bbe2a744e2b924bda3099881e09d969f/src/fibonacci_naive_recursion/FibonacciNaiveRecursion.scala)
+**Source Code**: [FibonacciNaiveRecursion.scala](https://github.com/Unisay/scalus-cape-submissions/blob/01d5b6b6a31655dcebe34f5a52549d2b4c12f4aa/src/fibonacci_naive_recursion/FibonacciNaiveRecursion.scala)
 
 **Repository**: <https://github.com/Unisay/scalus-cape-submissions>
 
-**Commit**: `2126a807bbe2a744e2b924bda3099881e09d969f`
+**Commit**: `01d5b6b6a31655dcebe34f5a52549d2b4c12f4aa`
 
 **Path**: `src/fibonacci_naive_recursion/FibonacciNaiveRecursion.scala`
 
-This submission uses Scalus compiler version 0.16.0 with a naive recursive implementation (no optimization, per scenario specification).
+This submission uses Scalus compiler version 0.16.0 with a naive recursive implementation (no optimization, per scenario specification), compiled with `Options.release`. `removeTraces=true`/`generateErrorTraces=false` have no visible effect on this scenario since the source has no `fail()`/`require()` calls to strip.
 
 ## Reproducing the Compilation
 
@@ -22,7 +22,7 @@ This submission uses Scalus compiler version 0.16.0 with a naive recursive imple
 2. Check out the specific commit:
 
    ```bash
-   git checkout 2126a807bbe2a744e2b924bda3099881e09d969f
+   git checkout 01d5b6b6a31655dcebe34f5a52549d2b4c12f4aa
    ```
 
 3. Follow build instructions in the repository README


### PR DESCRIPTION
## Summary

- Follows up on the same fix already applied to `submissions/htlc/Scalus_0.16.0_Unisay` (#222): three more Scalus 0.16.0 submissions pinned the pre-`Options.release` source commit `2126a807` and described "default options" compilation, when the source repo switched all four Scalus scenarios to `Options.release` back in commit `01d5b6b`.
- Verified byte-for-byte (after pretty-printing with the in-repo formatter) that none of these three needed a rebuild: `factorial_naive_recursion`, `fibonacci_naive_recursion`, and `fibonacci`'s `_prepacked` variant have no `fail()`/`require()` calls in their source, so `removeTraces=true`/`generateErrorTraces=false` have no visible effect on the compiled output — only `htlc` (which does call `fail()`/`require()`) actually changed size when `Options.release` landed.
- Repoints `source_commit_hash` to `01d5b6b` and updates `implementation_notes`/`source/README.md` in all three submissions to describe the compile flags accurately.

## Test plan

- [x] `cape submission verify` on all three touched submissions — all pass unchanged (10/10, 11/11, 11/11)
- [x] `.uplc` and `metrics.json` are untouched in the diff — doc-only change