### PR TITLE
Re-pin linear_vesting (mainnet and preview) to the bytestring-keyed assetAmount lookup

### DIFF
--- a/submissions/linear_vesting/Plinth_1.65.0.0_Unisay/linear_vesting.uplc
+++ b/submissions/linear_vesting/Plinth_1.65.0.0_Unisay/linear_vesting.uplc
@@ -233,7 +233,7 @@
                                                                                                                                                                                                   forced-4
                                                                                                                                                                                                   [
                                                                                                                                                                                                     forced-1
-                                                                                                                                                                                                    cse-46
+                                                                                                                                                                                                    cse-47
                                                                                                                                                                                                   ]
                                                                                                                                                                                                 ]
                                                                                                                                                                                               ]
@@ -241,7 +241,7 @@
                                                                                                                                                                                                 forced-4
                                                                                                                                                                                                 [
                                                                                                                                                                                                   forced-1
-                                                                                                                                                                                                  cse-47
+                                                                                                                                                                                                  cse-46
                                                                                                                                                                                                 ]
                                                                                                                                                                                               ]
                                                                                                                                                                                             ]
@@ -254,7 +254,7 @@
                                                                                                                                                                                                       a-49
                                                                                                                                                                                                       [
                                                                                                                                                                                                         (lam
-                                                                                                                                                                                                          lookupE-50
+                                                                                                                                                                                                          lookupBytesE-50
                                                                                                                                                                                                           [
                                                                                                                                                                                                             (lam
                                                                                                                                                                                                               cse-51
@@ -313,7 +313,7 @@
                                                                                                                                                                                                                                             ]
                                                                                                                                                                                                                                             [
                                                                                                                                                                                                                                               forced-4
-                                                                                                                                                                                                                                              cse-46
+                                                                                                                                                                                                                                              cse-47
                                                                                                                                                                                                                                             ]
                                                                                                                                                                                                                                           ]
                                                                                                                                                                                                                                         ]
@@ -720,15 +720,20 @@
                                                                                                                                                                                                                       ]
                                                                                                                                                                                                                       [
                                                                                                                                                                                                                         forced-4
-                                                                                                                                                                                                                        cse-47
+                                                                                                                                                                                                                        cse-46
                                                                                                                                                                                                                       ]
                                                                                                                                                                                                                     ]
                                                                                                                                                                                                                   ]
                                                                                                                                                                                                                 )
                                                                                                                                                                                                                 [
                                                                                                                                                                                                                   [
-                                                                                                                                                                                                                    lookupE-50
-                                                                                                                                                                                                                    a-49
+                                                                                                                                                                                                                    lookupBytesE-50
+                                                                                                                                                                                                                    [
+                                                                                                                                                                                                                      (builtin
+                                                                                                                                                                                                                        unBData
+                                                                                                                                                                                                                      )
+                                                                                                                                                                                                                      a-49
+                                                                                                                                                                                                                    ]
                                                                                                                                                                                                                   ]
                                                                                                                                                                                                                   (con
                                                                                                                                                                                                                     integer
@@ -739,12 +744,17 @@
                                                                                                                                                                                                             )
                                                                                                                                                                                                             [
                                                                                                                                                                                                               [
-                                                                                                                                                                                                                lookupE-50
+                                                                                                                                                                                                                lookupBytesE-50
                                                                                                                                                                                                                 [
-                                                                                                                                                                                                                  forced-4
+                                                                                                                                                                                                                  (builtin
+                                                                                                                                                                                                                    unBData
+                                                                                                                                                                                                                  )
                                                                                                                                                                                                                   [
-                                                                                                                                                                                                                    forced-1
-                                                                                                                                                                                                                    s-48
+                                                                                                                                                                                                                    forced-4
+                                                                                                                                                                                                                    [
+                                                                                                                                                                                                                      forced-1
+                                                                                                                                                                                                                      s-48
+                                                                                                                                                                                                                    ]
                                                                                                                                                                                                                   ]
                                                                                                                                                                                                                 ]
                                                                                                                                                                                                               ]
@@ -756,7 +766,7 @@
                                                                                                                                                                                                           ]
                                                                                                                                                                                                         )
                                                                                                                                                                                                         (lam
-                                                                                                                                                                                                          ds-66
+                                                                                                                                                                                                          k-66
                                                                                                                                                                                                           (lam
                                                                                                                                                                                                             missing-67
                                                                                                                                                                                                             (lam
@@ -811,13 +821,18 @@
                                                                                                                                                                                                                                             [
                                                                                                                                                                                                                                               [
                                                                                                                                                                                                                                                 (builtin
-                                                                                                                                                                                                                                                  equalsData
+                                                                                                                                                                                                                                                  equalsByteString
                                                                                                                                                                                                                                                 )
-                                                                                                                                                                                                                                                ds-66
+                                                                                                                                                                                                                                                k-66
                                                                                                                                                                                                                                               ]
                                                                                                                                                                                                                                               [
-                                                                                                                                                                                                                                                forced-0
-                                                                                                                                                                                                                                                h-74
+                                                                                                                                                                                                                                                (builtin
+                                                                                                                                                                                                                                                  unBData
+                                                                                                                                                                                                                                                )
+                                                                                                                                                                                                                                                [
+                                                                                                                                                                                                                                                  forced-0
+                                                                                                                                                                                                                                                  h-74
+                                                                                                                                                                                                                                                ]
                                                                                                                                                                                                                                               ]
                                                                                                                                                                                                                                             ]
                                                                                                                                                                                                                                             (delay
@@ -897,21 +912,21 @@
                                                                                                                                                                                     )
                                                                                                                                                                                     [
                                                                                                                                                                                       forced-1
-                                                                                                                                                                                      [
-                                                                                                                                                                                        forced-3
-                                                                                                                                                                                        [
-                                                                                                                                                                                          (builtin
-                                                                                                                                                                                            unConstrData
-                                                                                                                                                                                          )
-                                                                                                                                                                                          nt-44
-                                                                                                                                                                                        ]
-                                                                                                                                                                                      ]
+                                                                                                                                                                                      cse-42
                                                                                                                                                                                     ]
                                                                                                                                                                                   ]
                                                                                                                                                                                 )
                                                                                                                                                                                 [
                                                                                                                                                                                   forced-1
-                                                                                                                                                                                  cse-42
+                                                                                                                                                                                  [
+                                                                                                                                                                                    forced-3
+                                                                                                                                                                                    [
+                                                                                                                                                                                      (builtin
+                                                                                                                                                                                        unConstrData
+                                                                                                                                                                                      )
+                                                                                                                                                                                      nt-44
+                                                                                                                                                                                    ]
+                                                                                                                                                                                  ]
                                                                                                                                                                                 ]
                                                                                                                                                                               ]
                                                                                                                                                                             )
@@ -1345,7 +1360,7 @@
                                                                               a-91
                                                                               [
                                                                                 (lam
-                                                                                  periodEnd-92
+                                                                                  a-92
                                                                                   [
                                                                                     (lam
                                                                                       s-93
@@ -1383,7 +1398,7 @@
                                                                                                               (builtin
                                                                                                                 unIData
                                                                                                               )
-                                                                                                              periodEnd-92
+                                                                                                              a-92
                                                                                                             ]
                                                                                                           ]
                                                                                                           [

--- a/submissions/linear_vesting/Plinth_1.65.0.0_Unisay/metadata.json
+++ b/submissions/linear_vesting/Plinth_1.65.0.0_Unisay/metadata.json
@@ -16,10 +16,10 @@
     }
   ],
   "submission": {
-    "date": "2026-07-08T07:23:46Z",
+    "date": "2026-07-08T14:36:30Z",
     "source_available": true,
     "source_repository": "https://github.com/Unisay/plinth-cape-submissions",
-    "source_commit_hash": "f9ef6bdf4ed08ec16039600903d8af7e6c22046b",
-    "implementation_notes": "Linear vesting validator written in `do`-notation on `Plinth.Validator`, a zero-cost early-termination monad, together with the zero-cost typed decoding DSL `Plinth.Decoder.Named` (`V.do`/`N.do` via `QualifiedDo`; `IxDecoder`/`FieldAt` Peano-indexed cursor; `Plinth.Encoded` compare-without-decode). Re-optimised for CAPE metrics schema 2.0.0, whose aggregates cover only the happy-path (accept) measurements. This round's structural change decodes the `VestingDatum` on the partial-unlock path in a single 7-field region. total_fee 173470 to 59048 lovelace (-66.0%); promoted to the default artifact for this line, with the previous plain implementation retained as Plinth_1.65.0.0_Unisay_plain. Source: lib/LinearVesting.hs (+ `lib/Plinth/Validator.hs`, `lib/Plinth/Decoder/Named.hs`, `lib/Plinth/Decoder/Named/ScriptContext.hs`, `lib/Plinth/Encoded.hs`) in plinth-cape-submissions @ f9ef6bdf4ed08ec16039600903d8af7e6c22046b (branch main)."
+    "source_commit_hash": "d078652f03d31ed728c1fb63f1d9f8824218494c",
+    "implementation_notes": "Linear vesting validator written in `do`-notation on `Plinth.Validator`, a zero-cost early-termination monad, together with the zero-cost typed decoding DSL `Plinth.Decoder.Named` (`V.do`/`N.do` via `QualifiedDo`; `IxDecoder`/`FieldAt` Peano-indexed cursor; `Plinth.Encoded` compare-without-decode). This round reads the vesting-token quantity with a bytestring-keyed map lookup (`lookupBytesE`, comparing the unwrapped `CurrencySymbol`/`TokenName` keys with `equalsByteString`) rather than comparing whole `Value` keys with `equalsData`, and re-sweeps the inliner budget for the new shape. total_fee 59048 to 58343 lovelace (-1.2%, CAPE changPV measurement). The previous plain implementation stays as Plinth_1.65.0.0_Unisay_plain. Source: lib/LinearVesting.hs (+ `lib/Plinth/Validator.hs`, `lib/Plinth/Decoder/Named.hs`, `lib/Plinth/Decoder/Named/ScriptContext.hs`, `lib/Plinth/Encoded.hs`) in plinth-cape-submissions @ d078652f03d31ed728c1fb63f1d9f8824218494c (branch main)."
   }
 }

--- a/submissions/linear_vesting/Plinth_1.65.0.0_Unisay/metrics.json
+++ b/submissions/linear_vesting/Plinth_1.65.0.0_Unisay/metrics.json
@@ -1,35 +1,35 @@
 {
   "evaluations": [
     {
-      "cpu_units": 45618536,
+      "cpu_units": 41747914,
       "description": "PartialUnlock at time=11 with 900 tokens remaining should succeed (first installment unlocked)",
       "execution_result": "success",
       "included_in_aggregates": true,
-      "memory_units": 109284,
+      "memory_units": 110676,
       "name": "partial_unlock_first_installment"
     },
     {
-      "cpu_units": 45618536,
+      "cpu_units": 41747914,
       "description": "PartialUnlock at time=50 with 500 tokens remaining should succeed (half vested)",
       "execution_result": "success",
       "included_in_aggregates": true,
-      "memory_units": 109284,
+      "memory_units": 110676,
       "name": "partial_unlock_mid_vesting"
     },
     {
-      "cpu_units": 45618536,
+      "cpu_units": 41747914,
       "description": "PartialUnlock at time=91 with 100 tokens remaining should succeed (9 installments unlocked)",
       "execution_result": "success",
       "included_in_aggregates": true,
-      "memory_units": 109284,
+      "memory_units": 110676,
       "name": "partial_unlock_near_end"
     },
     {
-      "cpu_units": 45618536,
+      "cpu_units": 41747914,
       "description": "PartialUnlock at time=25 with 800 tokens remaining should succeed (between installment boundaries)",
       "execution_result": "success",
       "included_in_aggregates": true,
-      "memory_units": 109284,
+      "memory_units": 110676,
       "name": "partial_unlock_between_installments"
     },
     {
@@ -129,35 +129,35 @@
       "name": "partial_unlock_at_first_unlock"
     },
     {
-      "cpu_units": 30136315,
+      "cpu_units": 28125146,
       "description": "PartialUnlock with 0 tokens remaining in output should fail (must use FullUnlock instead)",
       "execution_result": "success",
       "included_in_aggregates": false,
-      "memory_units": 63997,
+      "memory_units": 64125,
       "name": "partial_unlock_zero_remaining"
     },
     {
-      "cpu_units": 38456586,
+      "cpu_units": 34393964,
       "description": "PartialUnlock with output tokens equal to input (1000) should fail (no tokens actually withdrawn)",
       "execution_result": "success",
       "included_in_aggregates": false,
-      "memory_units": 84600,
+      "memory_units": 84792,
       "name": "partial_unlock_not_decreasing"
     },
     {
-      "cpu_units": 38584968,
+      "cpu_units": 34522346,
       "description": "PartialUnlock at time=11 with 800 tokens remaining should fail (expected minimum 900)",
       "execution_result": "success",
       "included_in_aggregates": false,
-      "memory_units": 84602,
+      "memory_units": 84794,
       "name": "partial_unlock_wrong_remaining_too_low"
     },
     {
-      "cpu_units": 38584968,
+      "cpu_units": 34522346,
       "description": "PartialUnlock at time=11 with 950 tokens remaining should fail (must withdraw at least 1 installment)",
       "execution_result": "success",
       "included_in_aggregates": false,
-      "memory_units": 84602,
+      "memory_units": 84794,
       "name": "partial_unlock_wrong_remaining_too_high"
     },
     {
@@ -177,11 +177,11 @@
       "name": "partial_unlock_datum_missing"
     },
     {
-      "cpu_units": 47603065,
+      "cpu_units": 43540443,
       "description": "PartialUnlock with two script inputs should fail (double satisfaction attack)",
       "execution_result": "success",
       "included_in_aggregates": false,
-      "memory_units": 105604,
+      "memory_units": 105796,
       "name": "partial_unlock_double_satisfaction"
     },
     {
@@ -237,43 +237,42 @@
     "evaluator": "PlutusTx.Eval-1.45.0.0"
   },
   "measurements": {
-    "block_cpu_budget_pct": 0.11404634,
-    "block_memory_budget_pct": 0.17626451612903227,
+    "block_cpu_budget_pct": 0.10436978499999999,
+    "block_memory_budget_pct": 0.17850967741935483,
     "cpu_units": {
-      "maximum": 45618536,
-      "median": 45618536,
+      "maximum": 41747914,
+      "median": 41747914,
       "minimum": 12449469,
-      "sum": 207373082
+      "sum": 191890594
     },
     "excluded": {
       "count": 23,
       "cpu_units": {
-        "maximum": 47603065,
-        "sum": 359534681
+        "maximum": 43540443,
+        "sum": 341273024
       },
       "memory_units": {
-        "maximum": 105604,
-        "sum": 794967
+        "maximum": 105796,
+        "sum": 795863
       }
     },
-    "execution_fee_lovelace": 44183,
+    "execution_fee_lovelace": 43388,
     "memory_units": {
-      "maximum": 109284,
-      "median": 109284,
+      "maximum": 110676,
+      "median": 110676,
       "minimum": 34731,
-      "sum": 506598
+      "sum": 512166
     },
-    "reference_script_fee_lovelace": 14865,
-    "script_size_bytes": 991,
-    "scripts_per_block": 567,
-    "scripts_per_tx": 128,
-    "term_size": 979,
-    "total_fee_lovelace": 59048,
-    "tx_cpu_budget_pct": 0.45618536,
-    "tx_memory_budget_pct": 0.7806
+    "reference_script_fee_lovelace": 14955,
+    "script_size_bytes": 997,
+    "scripts_per_block": 560,
+    "scripts_per_tx": 126,
+    "term_size": 985,
+    "total_fee_lovelace": 58343,
+    "tx_cpu_budget_pct": 0.41747913999999997,
+    "tx_memory_budget_pct": 0.7905428571428572
   },
   "scenario": "linear_vesting",
-  "timestamp": "2026-07-08T07:23:47Z",
-  "version": "2.0.0",
-  "notes": "Generated using UPLC-CAPE measure tool"
+  "timestamp": "2026-07-08T14:37:18Z",
+  "version": "2.0.0"
 }

--- a/submissions/linear_vesting/Plinth_1.65.0.0_Unisay/source/README.md
+++ b/submissions/linear_vesting/Plinth_1.65.0.0_Unisay/source/README.md
@@ -1,28 +1,32 @@
-# linear_vesting Plinth 1.65.0.0 source
+# linear_vesting Plinth 1.65.0.0 (monadic) source
 
 **Repository**: <https://github.com/Unisay/plinth-cape-submissions>
 
 **Branch**: `main`
 
-**Commit**: `f9ef6bdf4ed08ec16039600903d8af7e6c22046b`
+**Commit**: `d078652f03d31ed728c1fb63f1d9f8824218494c`
 
 **Path**: `lib/LinearVesting.hs` (+ `lib/Plinth/Validator.hs`, `lib/Plinth/Decoder/Named.hs`, `lib/Plinth/Decoder/Named/ScriptContext.hs`, `lib/Plinth/Encoded.hs`)
 
-Linear vesting validator written in `do`-notation on `Plinth.Validator`, a zero-cost early-termination monad, together with the zero-cost typed decoding DSL `Plinth.Decoder.Named` (`V.do`/`N.do` via `QualifiedDo`; `IxDecoder`/`FieldAt` Peano-indexed cursor; `Plinth.Encoded` compare-without-decode). Re-optimised for CAPE metrics schema 2.0.0 (happy-path aggregates only): This round's structural change decodes the `VestingDatum` on the partial-unlock path in a single 7-field region. total_fee 173470 to 59048 lovelace (-66.0%), promoted to the default for this line.
+The monadic linear vesting validator; see the submission `metadata.json` for the latest decoder change. This is the default artifact for the mainnet 1.65.0.0 line.
 
 ## Reproducing the compilation
 
 ```bash
 git clone https://github.com/Unisay/plinth-cape-submissions
 cd plinth-cape-submissions
-git checkout f9ef6bdf4ed08ec16039600903d8af7e6c22046b
+git checkout d078652f03d31ed728c1fb63f1d9f8824218494c
 ```
 
-`CAPE_REPO` must point at the sibling UPLC-CAPE checkout (build aborts if unset); set it in `.envrc.local` (gitignored). Then:
+`CAPE_REPO` must point at the sibling UPLC-CAPE checkout; the build aborts if the variable is unset. The recommended place is `.envrc.local` (gitignored), e.g.:
+
+```sh
+export CAPE_REPO="$HOME/src/UPLC-CAPE"
+```
+
+Then enter the dev shell and run the generator:
 
 ```bash
 nix develop
 cabal run plinth-submissions
 ```
-
-The generator writes `$CAPE_REPO/submissions/linear_vesting/Plinth_1.65.0.0_Unisay/linear_vesting.uplc` (monadic is the default on `main`; the previous plain implementation is retained as `Plinth_1.65.0.0_Unisay_plain`).

--- a/submissions/linear_vesting/Plinth_1.65.0.0_Unisay/source/README.md
+++ b/submissions/linear_vesting/Plinth_1.65.0.0_Unisay/source/README.md
@@ -30,3 +30,5 @@ Then enter the dev shell and run the generator:
 nix develop
 cabal run plinth-submissions
 ```
+
+The produced UPLC writes to `$CAPE_REPO/submissions/linear_vesting/Plinth_1.65.0.0_Unisay/linear_vesting.uplc` and matches the UPLC in this submission.

--- a/submissions/linear_vesting/Plinth_1.65.0.0_Unisay_preview/linear_vesting.uplc
+++ b/submissions/linear_vesting/Plinth_1.65.0.0_Unisay_preview/linear_vesting.uplc
@@ -404,313 +404,346 @@
                                                                                                                                                                             a-62
                                                                                                                                                                             [
                                                                                                                                                                               (lam
-                                                                                                                                                                                a-63
+                                                                                                                                                                                lookupBytesE-63
                                                                                                                                                                                 [
                                                                                                                                                                                   (lam
-                                                                                                                                                                                    lookupE-64
+                                                                                                                                                                                    cse-64
                                                                                                                                                                                     [
                                                                                                                                                                                       (lam
                                                                                                                                                                                         cse-65
                                                                                                                                                                                         [
                                                                                                                                                                                           (lam
-                                                                                                                                                                                            cse-66
-                                                                                                                                                                                            [
-                                                                                                                                                                                              (lam
-                                                                                                                                                                                                newRemainingQty-67
-                                                                                                                                                                                                (case
-                                                                                                                                                                                                  [
-                                                                                                                                                                                                    [
-                                                                                                                                                                                                      (builtin
-                                                                                                                                                                                                        lessThanInteger
-                                                                                                                                                                                                      )
-                                                                                                                                                                                                      (con
-                                                                                                                                                                                                        integer
-                                                                                                                                                                                                        0
-                                                                                                                                                                                                      )
-                                                                                                                                                                                                    ]
-                                                                                                                                                                                                    newRemainingQty-67
-                                                                                                                                                                                                  ]
-                                                                                                                                                                                                  (error
-
+                                                                                                                                                                                            newRemainingQty-66
+                                                                                                                                                                                            (case
+                                                                                                                                                                                              [
+                                                                                                                                                                                                [
+                                                                                                                                                                                                  (builtin
+                                                                                                                                                                                                    lessThanInteger
                                                                                                                                                                                                   )
-                                                                                                                                                                                                  [
-                                                                                                                                                                                                    (lam
-                                                                                                                                                                                                      n-68
-                                                                                                                                                                                                      (case
-                                                                                                                                                                                                        [
-                                                                                                                                                                                                          [
-                                                                                                                                                                                                            (builtin
-                                                                                                                                                                                                              lessThanInteger
-                                                                                                                                                                                                            )
-                                                                                                                                                                                                            newRemainingQty-67
-                                                                                                                                                                                                          ]
-                                                                                                                                                                                                          [
-                                                                                                                                                                                                            [
-                                                                                                                                                                                                              cse-65
-                                                                                                                                                                                                              [
-                                                                                                                                                                                                                cse-66
-                                                                                                                                                                                                                (lam
-                                                                                                                                                                                                                  ds-69
-                                                                                                                                                                                                                  [
-                                                                                                                                                                                                                    (builtin
-                                                                                                                                                                                                                      unIData
-                                                                                                                                                                                                                    )
-                                                                                                                                                                                                                    ds-69
-                                                                                                                                                                                                                  ]
-                                                                                                                                                                                                                )
-                                                                                                                                                                                                              ]
-                                                                                                                                                                                                            ]
-                                                                                                                                                                                                            [
-                                                                                                                                                                                                              forced-1
-                                                                                                                                                                                                              [
-                                                                                                                                                                                                                forced-0
-                                                                                                                                                                                                                (case
-                                                                                                                                                                                                                  cse-52
-                                                                                                                                                                                                                  (lam
-                                                                                                                                                                                                                    l-70
-                                                                                                                                                                                                                    (lam
-                                                                                                                                                                                                                      r-71
-                                                                                                                                                                                                                      r-71
-                                                                                                                                                                                                                    )
-                                                                                                                                                                                                                  )
-                                                                                                                                                                                                                )
-                                                                                                                                                                                                              ]
-                                                                                                                                                                                                            ]
-                                                                                                                                                                                                          ]
-                                                                                                                                                                                                        ]
-                                                                                                                                                                                                        (error
+                                                                                                                                                                                                  (con
+                                                                                                                                                                                                    integer
+                                                                                                                                                                                                    0
+                                                                                                                                                                                                  )
+                                                                                                                                                                                                ]
+                                                                                                                                                                                                newRemainingQty-66
+                                                                                                                                                                                              ]
+                                                                                                                                                                                              (error
 
-                                                                                                                                                                                                        )
-                                                                                                                                                                                                        [
-                                                                                                                                                                                                          n-68
-                                                                                                                                                                                                          eta-55
-                                                                                                                                                                                                        ]
-                                                                                                                                                                                                      )
-                                                                                                                                                                                                    )
+                                                                                                                                                                                              )
+                                                                                                                                                                                              [
+                                                                                                                                                                                                (lam
+                                                                                                                                                                                                  n-67
+                                                                                                                                                                                                  (case
                                                                                                                                                                                                     [
-                                                                                                                                                                                                      (lam
-                                                                                                                                                                                                        totalInstallments-72
+                                                                                                                                                                                                      [
+                                                                                                                                                                                                        (builtin
+                                                                                                                                                                                                          lessThanInteger
+                                                                                                                                                                                                        )
+                                                                                                                                                                                                        newRemainingQty-66
+                                                                                                                                                                                                      ]
+                                                                                                                                                                                                      [
                                                                                                                                                                                                         [
-                                                                                                                                                                                                          (lam
-                                                                                                                                                                                                            vestingPeriodEnd-73
-                                                                                                                                                                                                            [
+                                                                                                                                                                                                          cse-65
+                                                                                                                                                                                                          [
+                                                                                                                                                                                                            cse-64
+                                                                                                                                                                                                            (lam
+                                                                                                                                                                                                              ds-68
+                                                                                                                                                                                                              [
+                                                                                                                                                                                                                (builtin
+                                                                                                                                                                                                                  unIData
+                                                                                                                                                                                                                )
+                                                                                                                                                                                                                ds-68
+                                                                                                                                                                                                              ]
+                                                                                                                                                                                                            )
+                                                                                                                                                                                                          ]
+                                                                                                                                                                                                        ]
+                                                                                                                                                                                                        [
+                                                                                                                                                                                                          forced-1
+                                                                                                                                                                                                          [
+                                                                                                                                                                                                            forced-0
+                                                                                                                                                                                                            (case
+                                                                                                                                                                                                              cse-52
                                                                                                                                                                                                               (lam
-                                                                                                                                                                                                                expectedRemainingQty-74
+                                                                                                                                                                                                                l-69
                                                                                                                                                                                                                 (lam
-                                                                                                                                                                                                                  eta-75
-                                                                                                                                                                                                                  (case
-                                                                                                                                                                                                                    [
-                                                                                                                                                                                                                      [
-                                                                                                                                                                                                                        (builtin
-                                                                                                                                                                                                                          equalsInteger
-                                                                                                                                                                                                                        )
-                                                                                                                                                                                                                        expectedRemainingQty-74
-                                                                                                                                                                                                                      ]
-                                                                                                                                                                                                                      newRemainingQty-67
-                                                                                                                                                                                                                    ]
-                                                                                                                                                                                                                    (error
-
-                                                                                                                                                                                                                    )
-                                                                                                                                                                                                                    [
-                                                                                                                                                                                                                      (lam
-                                                                                                                                                                                                                        nt-76
-                                                                                                                                                                                                                        (case
-                                                                                                                                                                                                                          [
-                                                                                                                                                                                                                            [
-                                                                                                                                                                                                                              (builtin
-                                                                                                                                                                                                                                equalsInteger
-                                                                                                                                                                                                                              )
-                                                                                                                                                                                                                              (con
-                                                                                                                                                                                                                                integer
-                                                                                                                                                                                                                                1
-                                                                                                                                                                                                                              )
-                                                                                                                                                                                                                            ]
-                                                                                                                                                                                                                            [
-                                                                                                                                                                                                                              (lam
-                                                                                                                                                                                                                                s-77
-                                                                                                                                                                                                                                (case
-                                                                                                                                                                                                                                  (constr
-                                                                                                                                                                                                                                    0
-                                                                                                                                                                                                                                    s-77
-                                                                                                                                                                                                                                    (con
-                                                                                                                                                                                                                                      integer
-                                                                                                                                                                                                                                      0
-                                                                                                                                                                                                                                    )
-                                                                                                                                                                                                                                    [
-                                                                                                                                                                                                                                      (builtin
-                                                                                                                                                                                                                                        unListData
-                                                                                                                                                                                                                                      )
-                                                                                                                                                                                                                                      nt-50
-                                                                                                                                                                                                                                    ]
-                                                                                                                                                                                                                                  )
-                                                                                                                                                                                                                                  s-77
-                                                                                                                                                                                                                                )
-                                                                                                                                                                                                                              )
-                                                                                                                                                                                                                              (lam
-                                                                                                                                                                                                                                s-78
-                                                                                                                                                                                                                                (lam
-                                                                                                                                                                                                                                  acc-79
-                                                                                                                                                                                                                                  (lam
-                                                                                                                                                                                                                                    xs-80
-                                                                                                                                                                                                                                    (case
-                                                                                                                                                                                                                                      xs-80
-                                                                                                                                                                                                                                      (lam
-                                                                                                                                                                                                                                        h-81
-                                                                                                                                                                                                                                        (lam
-                                                                                                                                                                                                                                          t-82
-                                                                                                                                                                                                                                          (case
-                                                                                                                                                                                                                                            (constr
-                                                                                                                                                                                                                                              0
-                                                                                                                                                                                                                                              s-78
-                                                                                                                                                                                                                                              (case
-                                                                                                                                                                                                                                                [
-                                                                                                                                                                                                                                                  [
-                                                                                                                                                                                                                                                    (builtin
-                                                                                                                                                                                                                                                      equalsData
-                                                                                                                                                                                                                                                    )
-                                                                                                                                                                                                                                                    [
-                                                                                                                                                                                                                                                      forced-1
-                                                                                                                                                                                                                                                      (case
-                                                                                                                                                                                                                                                        [
-                                                                                                                                                                                                                                                          (builtin
-                                                                                                                                                                                                                                                            unConstrData
-                                                                                                                                                                                                                                                          )
-                                                                                                                                                                                                                                                          [
-                                                                                                                                                                                                                                                            forced-1
-                                                                                                                                                                                                                                                            (case
-                                                                                                                                                                                                                                                              [
-                                                                                                                                                                                                                                                                (builtin
-                                                                                                                                                                                                                                                                  unConstrData
-                                                                                                                                                                                                                                                                )
-                                                                                                                                                                                                                                                                [
-                                                                                                                                                                                                                                                                  forced-1
-                                                                                                                                                                                                                                                                  [
-                                                                                                                                                                                                                                                                    forced-0
-                                                                                                                                                                                                                                                                    (case
-                                                                                                                                                                                                                                                                      [
-                                                                                                                                                                                                                                                                        (builtin
-                                                                                                                                                                                                                                                                          unConstrData
-                                                                                                                                                                                                                                                                        )
-                                                                                                                                                                                                                                                                        h-81
-                                                                                                                                                                                                                                                                      ]
-                                                                                                                                                                                                                                                                      (lam
-                                                                                                                                                                                                                                                                        l-83
-                                                                                                                                                                                                                                                                        (lam
-                                                                                                                                                                                                                                                                          r-84
-                                                                                                                                                                                                                                                                          r-84
-                                                                                                                                                                                                                                                                        )
-                                                                                                                                                                                                                                                                      )
-                                                                                                                                                                                                                                                                    )
-                                                                                                                                                                                                                                                                  ]
-                                                                                                                                                                                                                                                                ]
-                                                                                                                                                                                                                                                              ]
-                                                                                                                                                                                                                                                              (lam
-                                                                                                                                                                                                                                                                l-85
-                                                                                                                                                                                                                                                                (lam
-                                                                                                                                                                                                                                                                  r-86
-                                                                                                                                                                                                                                                                  r-86
-                                                                                                                                                                                                                                                                )
-                                                                                                                                                                                                                                                              )
-                                                                                                                                                                                                                                                            )
-                                                                                                                                                                                                                                                          ]
-                                                                                                                                                                                                                                                        ]
-                                                                                                                                                                                                                                                        (lam
-                                                                                                                                                                                                                                                          l-87
-                                                                                                                                                                                                                                                          (lam
-                                                                                                                                                                                                                                                            r-88
-                                                                                                                                                                                                                                                            r-88
-                                                                                                                                                                                                                                                          )
-                                                                                                                                                                                                                                                        )
-                                                                                                                                                                                                                                                      )
-                                                                                                                                                                                                                                                    ]
-                                                                                                                                                                                                                                                  ]
-                                                                                                                                                                                                                                                  nt-76
-                                                                                                                                                                                                                                                ]
-                                                                                                                                                                                                                                                acc-79
-                                                                                                                                                                                                                                                [
-                                                                                                                                                                                                                                                  [
-                                                                                                                                                                                                                                                    (builtin
-                                                                                                                                                                                                                                                      addInteger
-                                                                                                                                                                                                                                                    )
-                                                                                                                                                                                                                                                    (con
-                                                                                                                                                                                                                                                      integer
-                                                                                                                                                                                                                                                      1
-                                                                                                                                                                                                                                                    )
-                                                                                                                                                                                                                                                  ]
-                                                                                                                                                                                                                                                  acc-79
-                                                                                                                                                                                                                                                ]
-                                                                                                                                                                                                                                              )
-                                                                                                                                                                                                                                              t-82
-                                                                                                                                                                                                                                            )
-                                                                                                                                                                                                                                            s-78
-                                                                                                                                                                                                                                          )
-                                                                                                                                                                                                                                        )
-                                                                                                                                                                                                                                      )
-                                                                                                                                                                                                                                      acc-79
-                                                                                                                                                                                                                                    )
-                                                                                                                                                                                                                                  )
-                                                                                                                                                                                                                                )
-                                                                                                                                                                                                                              )
-                                                                                                                                                                                                                            ]
-                                                                                                                                                                                                                          ]
-                                                                                                                                                                                                                          (error
-
-                                                                                                                                                                                                                          )
-                                                                                                                                                                                                                          [
-                                                                                                                                                                                                                            eta-75
-                                                                                                                                                                                                                            (constr
-                                                                                                                                                                                                                              0
-                                                                                                                                                                                                                            )
-                                                                                                                                                                                                                          ]
-                                                                                                                                                                                                                        )
-                                                                                                                                                                                                                      )
-                                                                                                                                                                                                                      [
-                                                                                                                                                                                                                        forced-1
-                                                                                                                                                                                                                        (case
-                                                                                                                                                                                                                          [
-                                                                                                                                                                                                                            (builtin
-                                                                                                                                                                                                                              unConstrData
-                                                                                                                                                                                                                            )
-                                                                                                                                                                                                                            nt-53
-                                                                                                                                                                                                                          ]
-                                                                                                                                                                                                                          (lam
-                                                                                                                                                                                                                            l-89
-                                                                                                                                                                                                                            (lam
-                                                                                                                                                                                                                              r-90
-                                                                                                                                                                                                                              r-90
-                                                                                                                                                                                                                            )
-                                                                                                                                                                                                                          )
-                                                                                                                                                                                                                        )
-                                                                                                                                                                                                                      ]
-                                                                                                                                                                                                                    ]
-                                                                                                                                                                                                                  )
+                                                                                                                                                                                                                  r-70
+                                                                                                                                                                                                                  r-70
                                                                                                                                                                                                                 )
                                                                                                                                                                                                               )
-                                                                                                                                                                                                              [
-                                                                                                                                                                                                                [
-                                                                                                                                                                                                                  (builtin
-                                                                                                                                                                                                                    addInteger
-                                                                                                                                                                                                                  )
-                                                                                                                                                                                                                  (con
-                                                                                                                                                                                                                    integer
-                                                                                                                                                                                                                    1
-                                                                                                                                                                                                                  )
-                                                                                                                                                                                                                ]
+                                                                                                                                                                                                            )
+                                                                                                                                                                                                          ]
+                                                                                                                                                                                                        ]
+                                                                                                                                                                                                      ]
+                                                                                                                                                                                                    ]
+                                                                                                                                                                                                    (error
+
+                                                                                                                                                                                                    )
+                                                                                                                                                                                                    [
+                                                                                                                                                                                                      n-67
+                                                                                                                                                                                                      eta-55
+                                                                                                                                                                                                    ]
+                                                                                                                                                                                                  )
+                                                                                                                                                                                                )
+                                                                                                                                                                                                [
+                                                                                                                                                                                                  (lam
+                                                                                                                                                                                                    totalInstallments-71
+                                                                                                                                                                                                    [
+                                                                                                                                                                                                      (lam
+                                                                                                                                                                                                        vestingPeriodEnd-72
+                                                                                                                                                                                                        [
+                                                                                                                                                                                                          (lam
+                                                                                                                                                                                                            expectedRemainingQty-73
+                                                                                                                                                                                                            (lam
+                                                                                                                                                                                                              eta-74
+                                                                                                                                                                                                              (case
                                                                                                                                                                                                                 [
                                                                                                                                                                                                                   [
                                                                                                                                                                                                                     (builtin
-                                                                                                                                                                                                                      divideInteger
+                                                                                                                                                                                                                      equalsInteger
+                                                                                                                                                                                                                    )
+                                                                                                                                                                                                                    expectedRemainingQty-73
+                                                                                                                                                                                                                  ]
+                                                                                                                                                                                                                  newRemainingQty-66
+                                                                                                                                                                                                                ]
+                                                                                                                                                                                                                (error
+
+                                                                                                                                                                                                                )
+                                                                                                                                                                                                                [
+                                                                                                                                                                                                                  (lam
+                                                                                                                                                                                                                    nt-75
+                                                                                                                                                                                                                    (case
+                                                                                                                                                                                                                      [
+                                                                                                                                                                                                                        [
+                                                                                                                                                                                                                          (builtin
+                                                                                                                                                                                                                            equalsInteger
+                                                                                                                                                                                                                          )
+                                                                                                                                                                                                                          (con
+                                                                                                                                                                                                                            integer
+                                                                                                                                                                                                                            1
+                                                                                                                                                                                                                          )
+                                                                                                                                                                                                                        ]
+                                                                                                                                                                                                                        [
+                                                                                                                                                                                                                          (lam
+                                                                                                                                                                                                                            s-76
+                                                                                                                                                                                                                            (case
+                                                                                                                                                                                                                              (constr
+                                                                                                                                                                                                                                0
+                                                                                                                                                                                                                                s-76
+                                                                                                                                                                                                                                (con
+                                                                                                                                                                                                                                  integer
+                                                                                                                                                                                                                                  0
+                                                                                                                                                                                                                                )
+                                                                                                                                                                                                                                [
+                                                                                                                                                                                                                                  (builtin
+                                                                                                                                                                                                                                    unListData
+                                                                                                                                                                                                                                  )
+                                                                                                                                                                                                                                  nt-50
+                                                                                                                                                                                                                                ]
+                                                                                                                                                                                                                              )
+                                                                                                                                                                                                                              s-76
+                                                                                                                                                                                                                            )
+                                                                                                                                                                                                                          )
+                                                                                                                                                                                                                          (lam
+                                                                                                                                                                                                                            s-77
+                                                                                                                                                                                                                            (lam
+                                                                                                                                                                                                                              acc-78
+                                                                                                                                                                                                                              (lam
+                                                                                                                                                                                                                                xs-79
+                                                                                                                                                                                                                                (case
+                                                                                                                                                                                                                                  xs-79
+                                                                                                                                                                                                                                  (lam
+                                                                                                                                                                                                                                    h-80
+                                                                                                                                                                                                                                    (lam
+                                                                                                                                                                                                                                      t-81
+                                                                                                                                                                                                                                      (case
+                                                                                                                                                                                                                                        (constr
+                                                                                                                                                                                                                                          0
+                                                                                                                                                                                                                                          s-77
+                                                                                                                                                                                                                                          (case
+                                                                                                                                                                                                                                            [
+                                                                                                                                                                                                                                              [
+                                                                                                                                                                                                                                                (builtin
+                                                                                                                                                                                                                                                  equalsData
+                                                                                                                                                                                                                                                )
+                                                                                                                                                                                                                                                [
+                                                                                                                                                                                                                                                  forced-1
+                                                                                                                                                                                                                                                  (case
+                                                                                                                                                                                                                                                    [
+                                                                                                                                                                                                                                                      (builtin
+                                                                                                                                                                                                                                                        unConstrData
+                                                                                                                                                                                                                                                      )
+                                                                                                                                                                                                                                                      [
+                                                                                                                                                                                                                                                        forced-1
+                                                                                                                                                                                                                                                        (case
+                                                                                                                                                                                                                                                          [
+                                                                                                                                                                                                                                                            (builtin
+                                                                                                                                                                                                                                                              unConstrData
+                                                                                                                                                                                                                                                            )
+                                                                                                                                                                                                                                                            [
+                                                                                                                                                                                                                                                              forced-1
+                                                                                                                                                                                                                                                              [
+                                                                                                                                                                                                                                                                forced-0
+                                                                                                                                                                                                                                                                (case
+                                                                                                                                                                                                                                                                  [
+                                                                                                                                                                                                                                                                    (builtin
+                                                                                                                                                                                                                                                                      unConstrData
+                                                                                                                                                                                                                                                                    )
+                                                                                                                                                                                                                                                                    h-80
+                                                                                                                                                                                                                                                                  ]
+                                                                                                                                                                                                                                                                  (lam
+                                                                                                                                                                                                                                                                    l-82
+                                                                                                                                                                                                                                                                    (lam
+                                                                                                                                                                                                                                                                      r-83
+                                                                                                                                                                                                                                                                      r-83
+                                                                                                                                                                                                                                                                    )
+                                                                                                                                                                                                                                                                  )
+                                                                                                                                                                                                                                                                )
+                                                                                                                                                                                                                                                              ]
+                                                                                                                                                                                                                                                            ]
+                                                                                                                                                                                                                                                          ]
+                                                                                                                                                                                                                                                          (lam
+                                                                                                                                                                                                                                                            l-84
+                                                                                                                                                                                                                                                            (lam
+                                                                                                                                                                                                                                                              r-85
+                                                                                                                                                                                                                                                              r-85
+                                                                                                                                                                                                                                                            )
+                                                                                                                                                                                                                                                          )
+                                                                                                                                                                                                                                                        )
+                                                                                                                                                                                                                                                      ]
+                                                                                                                                                                                                                                                    ]
+                                                                                                                                                                                                                                                    (lam
+                                                                                                                                                                                                                                                      l-86
+                                                                                                                                                                                                                                                      (lam
+                                                                                                                                                                                                                                                        r-87
+                                                                                                                                                                                                                                                        r-87
+                                                                                                                                                                                                                                                      )
+                                                                                                                                                                                                                                                    )
+                                                                                                                                                                                                                                                  )
+                                                                                                                                                                                                                                                ]
+                                                                                                                                                                                                                                              ]
+                                                                                                                                                                                                                                              nt-75
+                                                                                                                                                                                                                                            ]
+                                                                                                                                                                                                                                            acc-78
+                                                                                                                                                                                                                                            [
+                                                                                                                                                                                                                                              [
+                                                                                                                                                                                                                                                (builtin
+                                                                                                                                                                                                                                                  addInteger
+                                                                                                                                                                                                                                                )
+                                                                                                                                                                                                                                                (con
+                                                                                                                                                                                                                                                  integer
+                                                                                                                                                                                                                                                  1
+                                                                                                                                                                                                                                                )
+                                                                                                                                                                                                                                              ]
+                                                                                                                                                                                                                                              acc-78
+                                                                                                                                                                                                                                            ]
+                                                                                                                                                                                                                                          )
+                                                                                                                                                                                                                                          t-81
+                                                                                                                                                                                                                                        )
+                                                                                                                                                                                                                                        s-77
+                                                                                                                                                                                                                                      )
+                                                                                                                                                                                                                                    )
+                                                                                                                                                                                                                                  )
+                                                                                                                                                                                                                                  acc-78
+                                                                                                                                                                                                                                )
+                                                                                                                                                                                                                              )
+                                                                                                                                                                                                                            )
+                                                                                                                                                                                                                          )
+                                                                                                                                                                                                                        ]
+                                                                                                                                                                                                                      ]
+                                                                                                                                                                                                                      (error
+
+                                                                                                                                                                                                                      )
+                                                                                                                                                                                                                      [
+                                                                                                                                                                                                                        eta-74
+                                                                                                                                                                                                                        (constr
+                                                                                                                                                                                                                          0
+                                                                                                                                                                                                                        )
+                                                                                                                                                                                                                      ]
+                                                                                                                                                                                                                    )
+                                                                                                                                                                                                                  )
+                                                                                                                                                                                                                  [
+                                                                                                                                                                                                                    forced-1
+                                                                                                                                                                                                                    (case
+                                                                                                                                                                                                                      [
+                                                                                                                                                                                                                        (builtin
+                                                                                                                                                                                                                          unConstrData
+                                                                                                                                                                                                                        )
+                                                                                                                                                                                                                        nt-53
+                                                                                                                                                                                                                      ]
+                                                                                                                                                                                                                      (lam
+                                                                                                                                                                                                                        l-88
+                                                                                                                                                                                                                        (lam
+                                                                                                                                                                                                                          r-89
+                                                                                                                                                                                                                          r-89
+                                                                                                                                                                                                                        )
+                                                                                                                                                                                                                      )
+                                                                                                                                                                                                                    )
+                                                                                                                                                                                                                  ]
+                                                                                                                                                                                                                ]
+                                                                                                                                                                                                              )
+                                                                                                                                                                                                            )
+                                                                                                                                                                                                          )
+                                                                                                                                                                                                          [
+                                                                                                                                                                                                            [
+                                                                                                                                                                                                              (builtin
+                                                                                                                                                                                                                addInteger
+                                                                                                                                                                                                              )
+                                                                                                                                                                                                              (con
+                                                                                                                                                                                                                integer
+                                                                                                                                                                                                                1
+                                                                                                                                                                                                              )
+                                                                                                                                                                                                            ]
+                                                                                                                                                                                                            [
+                                                                                                                                                                                                              [
+                                                                                                                                                                                                                (builtin
+                                                                                                                                                                                                                  divideInteger
+                                                                                                                                                                                                                )
+                                                                                                                                                                                                                [
+                                                                                                                                                                                                                  [
+                                                                                                                                                                                                                    (builtin
+                                                                                                                                                                                                                      subtractInteger
                                                                                                                                                                                                                     )
                                                                                                                                                                                                                     [
                                                                                                                                                                                                                       [
                                                                                                                                                                                                                         (builtin
-                                                                                                                                                                                                                          subtractInteger
+                                                                                                                                                                                                                          multiplyInteger
                                                                                                                                                                                                                         )
                                                                                                                                                                                                                         [
                                                                                                                                                                                                                           [
                                                                                                                                                                                                                             (builtin
-                                                                                                                                                                                                                              multiplyInteger
+                                                                                                                                                                                                                              addInteger
                                                                                                                                                                                                                             )
+                                                                                                                                                                                                                            (con
+                                                                                                                                                                                                                              integer
+                                                                                                                                                                                                                              1
+                                                                                                                                                                                                                            )
+                                                                                                                                                                                                                          ]
+                                                                                                                                                                                                                          [
+                                                                                                                                                                                                                            [
+                                                                                                                                                                                                                              (builtin
+                                                                                                                                                                                                                                divideInteger
+                                                                                                                                                                                                                              )
+                                                                                                                                                                                                                              [
+                                                                                                                                                                                                                                [
+                                                                                                                                                                                                                                  (builtin
+                                                                                                                                                                                                                                    subtractInteger
+                                                                                                                                                                                                                                  )
+                                                                                                                                                                                                                                  [
+                                                                                                                                                                                                                                    [
+                                                                                                                                                                                                                                      (builtin
+                                                                                                                                                                                                                                        subtractInteger
+                                                                                                                                                                                                                                      )
+                                                                                                                                                                                                                                      vestingPeriodEnd-72
+                                                                                                                                                                                                                                    ]
+                                                                                                                                                                                                                                    currentTime-47
+                                                                                                                                                                                                                                  ]
+                                                                                                                                                                                                                                ]
+                                                                                                                                                                                                                                (con
+                                                                                                                                                                                                                                  integer
+                                                                                                                                                                                                                                  1
+                                                                                                                                                                                                                                )
+                                                                                                                                                                                                                              ]
+                                                                                                                                                                                                                            ]
                                                                                                                                                                                                                             [
                                                                                                                                                                                                                               [
                                                                                                                                                                                                                                 (builtin
@@ -736,88 +769,44 @@
                                                                                                                                                                                                                                           (builtin
                                                                                                                                                                                                                                             subtractInteger
                                                                                                                                                                                                                                           )
-                                                                                                                                                                                                                                          vestingPeriodEnd-73
+                                                                                                                                                                                                                                          vestingPeriodEnd-72
                                                                                                                                                                                                                                         ]
-                                                                                                                                                                                                                                        currentTime-47
-                                                                                                                                                                                                                                      ]
-                                                                                                                                                                                                                                    ]
-                                                                                                                                                                                                                                    (con
-                                                                                                                                                                                                                                      integer
-                                                                                                                                                                                                                                      1
-                                                                                                                                                                                                                                    )
-                                                                                                                                                                                                                                  ]
-                                                                                                                                                                                                                                ]
-                                                                                                                                                                                                                                [
-                                                                                                                                                                                                                                  [
-                                                                                                                                                                                                                                    (builtin
-                                                                                                                                                                                                                                      addInteger
-                                                                                                                                                                                                                                    )
-                                                                                                                                                                                                                                    (con
-                                                                                                                                                                                                                                      integer
-                                                                                                                                                                                                                                      1
-                                                                                                                                                                                                                                    )
-                                                                                                                                                                                                                                  ]
-                                                                                                                                                                                                                                  [
-                                                                                                                                                                                                                                    [
-                                                                                                                                                                                                                                      (builtin
-                                                                                                                                                                                                                                        divideInteger
-                                                                                                                                                                                                                                      )
-                                                                                                                                                                                                                                      [
                                                                                                                                                                                                                                         [
                                                                                                                                                                                                                                           (builtin
-                                                                                                                                                                                                                                            subtractInteger
+                                                                                                                                                                                                                                            unIData
                                                                                                                                                                                                                                           )
-                                                                                                                                                                                                                                          [
-                                                                                                                                                                                                                                            [
-                                                                                                                                                                                                                                              (builtin
-                                                                                                                                                                                                                                                subtractInteger
-                                                                                                                                                                                                                                              )
-                                                                                                                                                                                                                                              vestingPeriodEnd-73
-                                                                                                                                                                                                                                            ]
-                                                                                                                                                                                                                                            [
-                                                                                                                                                                                                                                              (builtin
-                                                                                                                                                                                                                                                unIData
-                                                                                                                                                                                                                                              )
-                                                                                                                                                                                                                                              a-36
-                                                                                                                                                                                                                                            ]
-                                                                                                                                                                                                                                          ]
+                                                                                                                                                                                                                                          a-36
                                                                                                                                                                                                                                         ]
-                                                                                                                                                                                                                                        (con
-                                                                                                                                                                                                                                          integer
-                                                                                                                                                                                                                                          1
-                                                                                                                                                                                                                                        )
                                                                                                                                                                                                                                       ]
                                                                                                                                                                                                                                     ]
-                                                                                                                                                                                                                                    totalInstallments-72
+                                                                                                                                                                                                                                    (con
+                                                                                                                                                                                                                                      integer
+                                                                                                                                                                                                                                      1
+                                                                                                                                                                                                                                    )
                                                                                                                                                                                                                                   ]
                                                                                                                                                                                                                                 ]
+                                                                                                                                                                                                                                totalInstallments-71
                                                                                                                                                                                                                               ]
                                                                                                                                                                                                                             ]
                                                                                                                                                                                                                           ]
-                                                                                                                                                                                                                          [
-                                                                                                                                                                                                                            (builtin
-                                                                                                                                                                                                                              unIData
-                                                                                                                                                                                                                            )
-                                                                                                                                                                                                                            a-34
-                                                                                                                                                                                                                          ]
                                                                                                                                                                                                                         ]
                                                                                                                                                                                                                       ]
-                                                                                                                                                                                                                      (con
-                                                                                                                                                                                                                        integer
-                                                                                                                                                                                                                        1
-                                                                                                                                                                                                                      )
+                                                                                                                                                                                                                      [
+                                                                                                                                                                                                                        (builtin
+                                                                                                                                                                                                                          unIData
+                                                                                                                                                                                                                        )
+                                                                                                                                                                                                                        a-34
+                                                                                                                                                                                                                      ]
                                                                                                                                                                                                                     ]
                                                                                                                                                                                                                   ]
-                                                                                                                                                                                                                  totalInstallments-72
+                                                                                                                                                                                                                  (con
+                                                                                                                                                                                                                    integer
+                                                                                                                                                                                                                    1
+                                                                                                                                                                                                                  )
                                                                                                                                                                                                                 ]
                                                                                                                                                                                                               ]
+                                                                                                                                                                                                              totalInstallments-71
                                                                                                                                                                                                             ]
-                                                                                                                                                                                                          )
-                                                                                                                                                                                                          [
-                                                                                                                                                                                                            (builtin
-                                                                                                                                                                                                              unIData
-                                                                                                                                                                                                            )
-                                                                                                                                                                                                            a-38
                                                                                                                                                                                                           ]
                                                                                                                                                                                                         ]
                                                                                                                                                                                                       )
@@ -825,63 +814,64 @@
                                                                                                                                                                                                         (builtin
                                                                                                                                                                                                           unIData
                                                                                                                                                                                                         )
-                                                                                                                                                                                                        installments-41
+                                                                                                                                                                                                        a-38
                                                                                                                                                                                                       ]
                                                                                                                                                                                                     ]
-                                                                                                                                                                                                  ]
-                                                                                                                                                                                                )
-                                                                                                                                                                                              )
-                                                                                                                                                                                              [
-                                                                                                                                                                                                [
-                                                                                                                                                                                                  cse-65
+                                                                                                                                                                                                  )
                                                                                                                                                                                                   [
-                                                                                                                                                                                                    cse-66
-                                                                                                                                                                                                    (lam
-                                                                                                                                                                                                      ds-91
-                                                                                                                                                                                                      [
-                                                                                                                                                                                                        (builtin
-                                                                                                                                                                                                          unIData
-                                                                                                                                                                                                        )
-                                                                                                                                                                                                        ds-91
-                                                                                                                                                                                                      ]
+                                                                                                                                                                                                    (builtin
+                                                                                                                                                                                                      unIData
                                                                                                                                                                                                     )
-                                                                                                                                                                                                  ]
-                                                                                                                                                                                                ]
-                                                                                                                                                                                                [
-                                                                                                                                                                                                  forced-1
-                                                                                                                                                                                                  [
-                                                                                                                                                                                                    forced-0
-                                                                                                                                                                                                    (case
-                                                                                                                                                                                                      cse-56
-                                                                                                                                                                                                      (lam
-                                                                                                                                                                                                        l-92
-                                                                                                                                                                                                        (lam
-                                                                                                                                                                                                          r-93
-                                                                                                                                                                                                          r-93
-                                                                                                                                                                                                        )
-                                                                                                                                                                                                      )
-                                                                                                                                                                                                    )
+                                                                                                                                                                                                    installments-41
                                                                                                                                                                                                   ]
                                                                                                                                                                                                 ]
                                                                                                                                                                                               ]
-                                                                                                                                                                                            ]
+                                                                                                                                                                                            )
                                                                                                                                                                                           )
                                                                                                                                                                                           [
                                                                                                                                                                                             [
-                                                                                                                                                                                              lookupE-64
-                                                                                                                                                                                              a-63
+                                                                                                                                                                                              cse-65
+                                                                                                                                                                                              [
+                                                                                                                                                                                                cse-64
+                                                                                                                                                                                                (lam
+                                                                                                                                                                                                  ds-90
+                                                                                                                                                                                                  [
+                                                                                                                                                                                                    (builtin
+                                                                                                                                                                                                      unIData
+                                                                                                                                                                                                    )
+                                                                                                                                                                                                    ds-90
+                                                                                                                                                                                                  ]
+                                                                                                                                                                                                )
+                                                                                                                                                                                              ]
                                                                                                                                                                                             ]
-                                                                                                                                                                                            (con
-                                                                                                                                                                                              integer
-                                                                                                                                                                                              0
-                                                                                                                                                                                            )
+                                                                                                                                                                                            [
+                                                                                                                                                                                              forced-1
+                                                                                                                                                                                              [
+                                                                                                                                                                                                forced-0
+                                                                                                                                                                                                (case
+                                                                                                                                                                                                  cse-56
+                                                                                                                                                                                                  (lam
+                                                                                                                                                                                                    l-91
+                                                                                                                                                                                                    (lam
+                                                                                                                                                                                                      r-92
+                                                                                                                                                                                                      r-92
+                                                                                                                                                                                                    )
+                                                                                                                                                                                                  )
+                                                                                                                                                                                                )
+                                                                                                                                                                                              ]
+                                                                                                                                                                                            ]
                                                                                                                                                                                           ]
                                                                                                                                                                                         ]
                                                                                                                                                                                       )
                                                                                                                                                                                       [
                                                                                                                                                                                         [
-                                                                                                                                                                                          lookupE-64
-                                                                                                                                                                                          a-62
+                                                                                                                                                                                          lookupBytesE-63
+                                                                                                                                                                                          [
+                                                                                                                                                                                            (builtin
+                                                                                                                                                                                              unBData
+                                                                                                                                                                                            )
+                                                                                                                                                                                            a-62
+                                                                                                                                                                                          ]
                                                                                                                                                                                         ]
                                                                                                                                                                                         (con
                                                                                                                                                                                           integer
@@ -890,106 +880,125 @@
                                                                                                                                                                                       ]
                                                                                                                                                                                     ]
                                                                                                                                                                                   )
-                                                                                                                                                                                  (lam
-                                                                                                                                                                                    ds-94
-                                                                                                                                                                                    (lam
-                                                                                                                                                                                      missing-95
-                                                                                                                                                                                      (lam
-                                                                                                                                                                                        found-96
+                                                                                                                                                                                  [
+                                                                                                                                                                                    [
+                                                                                                                                                                                      lookupBytesE-63
+                                                                                                                                                                                      [
+                                                                                                                                                                                        (builtin
+                                                                                                                                                                                          unBData
+                                                                                                                                                                                        )
                                                                                                                                                                                         [
-                                                                                                                                                                                          (lam
-                                                                                                                                                                                            go-97
-                                                                                                                                                                                            (lam
-                                                                                                                                                                                              ds-98
-                                                                                                                                                                                              [
-                                                                                                                                                                                                go-97
-                                                                                                                                                                                                [
-                                                                                                                                                                                                  (builtin
-                                                                                                                                                                                                    unMapData
-                                                                                                                                                                                                  )
-                                                                                                                                                                                                  ds-98
-                                                                                                                                                                                                ]
-                                                                                                                                                                                              ]
-                                                                                                                                                                                            )
-                                                                                                                                                                                          )
+                                                                                                                                                                                          forced-1
                                                                                                                                                                                           [
-                                                                                                                                                                                            (lam
-                                                                                                                                                                                              s-99
-                                                                                                                                                                                              [
-                                                                                                                                                                                                s-99
-                                                                                                                                                                                                s-99
-                                                                                                                                                                                              ]
-                                                                                                                                                                                            )
-                                                                                                                                                                                            (lam
-                                                                                                                                                                                              s-100
-                                                                                                                                                                                              (lam
-                                                                                                                                                                                                xs-101
-                                                                                                                                                                                                (case
-                                                                                                                                                                                                  xs-101
-                                                                                                                                                                                                  (lam
-                                                                                                                                                                                                    h-102
-                                                                                                                                                                                                    (lam
-                                                                                                                                                                                                      t-103
-                                                                                                                                                                                                      (case
-                                                                                                                                                                                                        [
-                                                                                                                                                                                                          [
-                                                                                                                                                                                                            (builtin
-                                                                                                                                                                                                              equalsData
-                                                                                                                                                                                                            )
-                                                                                                                                                                                                            ds-94
-                                                                                                                                                                                                          ]
-                                                                                                                                                                                                          (case
-                                                                                                                                                                                                            h-102
-                                                                                                                                                                                                            (lam
-                                                                                                                                                                                                              l-104
-                                                                                                                                                                                                              (lam
-                                                                                                                                                                                                                r-105
-                                                                                                                                                                                                                l-104
-                                                                                                                                                                                                              )
-                                                                                                                                                                                                            )
-                                                                                                                                                                                                          )
-                                                                                                                                                                                                        ]
-                                                                                                                                                                                                        [
-                                                                                                                                                                                                          [
-                                                                                                                                                                                                            s-100
-                                                                                                                                                                                                            s-100
-                                                                                                                                                                                                          ]
-                                                                                                                                                                                                          t-103
-                                                                                                                                                                                                        ]
-                                                                                                                                                                                                        [
-                                                                                                                                                                                                          found-96
-                                                                                                                                                                                                          (case
-                                                                                                                                                                                                            h-102
-                                                                                                                                                                                                            (lam
-                                                                                                                                                                                                              l-106
-                                                                                                                                                                                                              (lam
-                                                                                                                                                                                                                r-107
-                                                                                                                                                                                                                r-107
-                                                                                                                                                                                                              )
-                                                                                                                                                                                                            )
-                                                                                                                                                                                                          )
-                                                                                                                                                                                                        ]
-                                                                                                                                                                                                      )
-                                                                                                                                                                                                    )
-                                                                                                                                                                                                  )
-                                                                                                                                                                                                  missing-95
-                                                                                                                                                                                                )
-                                                                                                                                                                                              )
-                                                                                                                                                                                            )
+                                                                                                                                                                                            forced-0
+                                                                                                                                                                                            s-61
                                                                                                                                                                                           ]
                                                                                                                                                                                         ]
-                                                                                                                                                                                      )
+                                                                                                                                                                                      ]
+                                                                                                                                                                                    ]
+                                                                                                                                                                                    (con
+                                                                                                                                                                                      integer
+                                                                                                                                                                                      0
                                                                                                                                                                                     )
-                                                                                                                                                                                  )
+                                                                                                                                                                                  ]
                                                                                                                                                                                 ]
                                                                                                                                                                               )
-                                                                                                                                                                              [
-                                                                                                                                                                                forced-1
-                                                                                                                                                                                [
-                                                                                                                                                                                  forced-0
-                                                                                                                                                                                  s-61
-                                                                                                                                                                                ]
-                                                                                                                                                                              ]
+                                                                                                                                                                              (lam
+                                                                                                                                                                                k-93
+                                                                                                                                                                                (lam
+                                                                                                                                                                                  missing-94
+                                                                                                                                                                                  (lam
+                                                                                                                                                                                    found-95
+                                                                                                                                                                                    [
+                                                                                                                                                                                      (lam
+                                                                                                                                                                                        go-96
+                                                                                                                                                                                        (lam
+                                                                                                                                                                                          ds-97
+                                                                                                                                                                                          [
+                                                                                                                                                                                            go-96
+                                                                                                                                                                                            [
+                                                                                                                                                                                              (builtin
+                                                                                                                                                                                                unMapData
+                                                                                                                                                                                              )
+                                                                                                                                                                                              ds-97
+                                                                                                                                                                                            ]
+                                                                                                                                                                                          ]
+                                                                                                                                                                                        )
+                                                                                                                                                                                      )
+                                                                                                                                                                                      [
+                                                                                                                                                                                        (lam
+                                                                                                                                                                                          s-98
+                                                                                                                                                                                          [
+                                                                                                                                                                                            s-98
+                                                                                                                                                                                            s-98
+                                                                                                                                                                                          ]
+                                                                                                                                                                                        )
+                                                                                                                                                                                        (lam
+                                                                                                                                                                                          s-99
+                                                                                                                                                                                          (lam
+                                                                                                                                                                                            xs-100
+                                                                                                                                                                                            (case
+                                                                                                                                                                                              xs-100
+                                                                                                                                                                                              (lam
+                                                                                                                                                                                                h-101
+                                                                                                                                                                                                (lam
+                                                                                                                                                                                                  t-102
+                                                                                                                                                                                                  (case
+                                                                                                                                                                                                    [
+                                                                                                                                                                                                      [
+                                                                                                                                                                                                        (builtin
+                                                                                                                                                                                                          equalsByteString
+                                                                                                                                                                                                        )
+                                                                                                                                                                                                        k-93
+                                                                                                                                                                                                      ]
+                                                                                                                                                                                                      [
+                                                                                                                                                                                                        (builtin
+                                                                                                                                                                                                          unBData
+                                                                                                                                                                                                        )
+                                                                                                                                                                                                        (case
+                                                                                                                                                                                                          h-101
+                                                                                                                                                                                                          (lam
+                                                                                                                                                                                                            l-103
+                                                                                                                                                                                                            (lam
+                                                                                                                                                                                                              r-104
+                                                                                                                                                                                                              l-103
+                                                                                                                                                                                                            )
+                                                                                                                                                                                                          )
+                                                                                                                                                                                                        )
+                                                                                                                                                                                                      ]
+                                                                                                                                                                                                    ]
+                                                                                                                                                                                                    [
+                                                                                                                                                                                                      [
+                                                                                                                                                                                                        s-99
+                                                                                                                                                                                                        s-99
+                                                                                                                                                                                                      ]
+                                                                                                                                                                                                      t-102
+                                                                                                                                                                                                    ]
+                                                                                                                                                                                                    [
+                                                                                                                                                                                                      found-95
+                                                                                                                                                                                                      (case
+                                                                                                                                                                                                        h-101
+                                                                                                                                                                                                        (lam
+                                                                                                                                                                                                          l-105
+                                                                                                                                                                                                          (lam
+                                                                                                                                                                                                            r-106
+                                                                                                                                                                                                            r-106
+                                                                                                                                                                                                          )
+                                                                                                                                                                                                        )
+                                                                                                                                                                                                      )
+                                                                                                                                                                                                    ]
+                                                                                                                                                                                                  )
+                                                                                                                                                                                                )
+                                                                                                                                                                                              )
+                                                                                                                                                                                              missing-94
+                                                                                                                                                                                            )
+                                                                                                                                                                                          )
+                                                                                                                                                                                        )
+                                                                                                                                                                                      ]
+                                                                                                                                                                                    ]
+                                                                                                                                                                                  )
+                                                                                                                                                                                )
+                                                                                                                                                                              )
                                                                                                                                                                             ]
                                                                                                                                                                           )
                                                                                                                                                                           [
@@ -1006,10 +1015,10 @@
                                                                                                                                                                           a-32
                                                                                                                                                                         ]
                                                                                                                                                                         (lam
-                                                                                                                                                                          l-108
+                                                                                                                                                                          l-107
                                                                                                                                                                           (lam
-                                                                                                                                                                            r-109
-                                                                                                                                                                            r-109
+                                                                                                                                                                            r-108
+                                                                                                                                                                            r-108
                                                                                                                                                                           )
                                                                                                                                                                         )
                                                                                                                                                                       )
@@ -1033,7 +1042,7 @@
                                                                                                                                                                 "Own output not found"
                                                                                                                                                               )
                                                                                                                                                               (lam
-                                                                                                                                                                o-110
+                                                                                                                                                                o-109
                                                                                                                                                                 [
                                                                                                                                                                   [
                                                                                                                                                                     (builtin
@@ -1046,13 +1055,13 @@
                                                                                                                                                                           (builtin
                                                                                                                                                                             unConstrData
                                                                                                                                                                           )
-                                                                                                                                                                          o-110
+                                                                                                                                                                          o-109
                                                                                                                                                                         ]
                                                                                                                                                                         (lam
-                                                                                                                                                                          l-111
+                                                                                                                                                                          l-110
                                                                                                                                                                           (lam
-                                                                                                                                                                            r-112
-                                                                                                                                                                            r-112
+                                                                                                                                                                            r-111
+                                                                                                                                                                            r-111
                                                                                                                                                                           )
                                                                                                                                                                         )
                                                                                                                                                                       )
@@ -1070,10 +1079,10 @@
                                                                                                                                                                     (case
                                                                                                                                                                       cse-42
                                                                                                                                                                       (lam
-                                                                                                                                                                        l-113
+                                                                                                                                                                        l-112
                                                                                                                                                                         (lam
-                                                                                                                                                                          r-114
-                                                                                                                                                                          r-114
+                                                                                                                                                                          r-113
+                                                                                                                                                                          r-113
                                                                                                                                                                         )
                                                                                                                                                                       )
                                                                                                                                                                     )
@@ -1090,10 +1099,10 @@
                                                                                                                                                         (case
                                                                                                                                                           cse-52
                                                                                                                                                           (lam
-                                                                                                                                                            l-115
+                                                                                                                                                            l-114
                                                                                                                                                             (lam
-                                                                                                                                                              r-116
-                                                                                                                                                              r-116
+                                                                                                                                                              r-115
+                                                                                                                                                              r-115
                                                                                                                                                             )
                                                                                                                                                           )
                                                                                                                                                         )
@@ -1121,7 +1130,7 @@
                                                                                                                                                                   "Own input not found"
                                                                                                                                                                 )
                                                                                                                                                                 (lam
-                                                                                                                                                                  i-117
+                                                                                                                                                                  i-116
                                                                                                                                                                   [
                                                                                                                                                                     [
                                                                                                                                                                       (builtin
@@ -1134,13 +1143,13 @@
                                                                                                                                                                             (builtin
                                                                                                                                                                               unConstrData
                                                                                                                                                                             )
-                                                                                                                                                                            i-117
+                                                                                                                                                                            i-116
                                                                                                                                                                           ]
                                                                                                                                                                           (lam
-                                                                                                                                                                            l-118
+                                                                                                                                                                            l-117
                                                                                                                                                                             (lam
-                                                                                                                                                                              r-119
-                                                                                                                                                                              r-119
+                                                                                                                                                                              r-118
+                                                                                                                                                                              r-118
                                                                                                                                                                             )
                                                                                                                                                                           )
                                                                                                                                                                         )
@@ -1155,10 +1164,10 @@
                                                                                                                                                             )
                                                                                                                                                           ]
                                                                                                                                                           (lam
-                                                                                                                                                            l-120
+                                                                                                                                                            l-119
                                                                                                                                                             (lam
-                                                                                                                                                              r-121
-                                                                                                                                                              r-121
+                                                                                                                                                              r-120
+                                                                                                                                                              r-120
                                                                                                                                                             )
                                                                                                                                                           )
                                                                                                                                                         )
@@ -1168,65 +1177,65 @@
                                                                                                                                                 ]
                                                                                                                                               )
                                                                                                                                               (lam
-                                                                                                                                                msg-122
+                                                                                                                                                msg-121
                                                                                                                                                 (lam
-                                                                                                                                                  p-123
+                                                                                                                                                  p-122
                                                                                                                                                   [
                                                                                                                                                     (lam
-                                                                                                                                                      go-124
+                                                                                                                                                      go-123
                                                                                                                                                       (lam
-                                                                                                                                                        ds-125
+                                                                                                                                                        ds-124
                                                                                                                                                         [
-                                                                                                                                                          go-124
+                                                                                                                                                          go-123
                                                                                                                                                           [
                                                                                                                                                             (builtin
                                                                                                                                                               unListData
                                                                                                                                                             )
-                                                                                                                                                            ds-125
+                                                                                                                                                            ds-124
                                                                                                                                                           ]
                                                                                                                                                         ]
                                                                                                                                                       )
                                                                                                                                                     )
                                                                                                                                                     [
                                                                                                                                                       (lam
-                                                                                                                                                        s-126
+                                                                                                                                                        s-125
                                                                                                                                                         [
-                                                                                                                                                          s-126
-                                                                                                                                                          s-126
+                                                                                                                                                          s-125
+                                                                                                                                                          s-125
                                                                                                                                                         ]
                                                                                                                                                       )
                                                                                                                                                       (lam
-                                                                                                                                                        s-127
+                                                                                                                                                        s-126
                                                                                                                                                         (lam
-                                                                                                                                                          xs-128
+                                                                                                                                                          xs-127
                                                                                                                                                           [
                                                                                                                                                             (case
-                                                                                                                                                              xs-128
+                                                                                                                                                              xs-127
                                                                                                                                                               (lam
-                                                                                                                                                                x-129
+                                                                                                                                                                x-128
                                                                                                                                                                 (lam
-                                                                                                                                                                  xs-130
+                                                                                                                                                                  xs-129
                                                                                                                                                                   (lam
-                                                                                                                                                                    ds-131
+                                                                                                                                                                    ds-130
                                                                                                                                                                     (case
                                                                                                                                                                       [
-                                                                                                                                                                        p-123
-                                                                                                                                                                        x-129
+                                                                                                                                                                        p-122
+                                                                                                                                                                        x-128
                                                                                                                                                                       ]
                                                                                                                                                                       [
                                                                                                                                                                         [
-                                                                                                                                                                          s-127
-                                                                                                                                                                          s-127
+                                                                                                                                                                          s-126
+                                                                                                                                                                          s-126
                                                                                                                                                                         ]
-                                                                                                                                                                        xs-130
+                                                                                                                                                                        xs-129
                                                                                                                                                                       ]
-                                                                                                                                                                      x-129
+                                                                                                                                                                      x-128
                                                                                                                                                                     )
                                                                                                                                                                   )
                                                                                                                                                                 )
                                                                                                                                                               )
                                                                                                                                                               (lam
-                                                                                                                                                                ds-132
+                                                                                                                                                                ds-131
                                                                                                                                                                 (error
 
                                                                                                                                                                 )
@@ -1249,10 +1258,10 @@
                                                                                                                                             (case
                                                                                                                                               cse-42
                                                                                                                                               (lam
-                                                                                                                                                l-133
+                                                                                                                                                l-132
                                                                                                                                                 (lam
-                                                                                                                                                  r-134
-                                                                                                                                                  r-134
+                                                                                                                                                  r-133
+                                                                                                                                                  r-133
                                                                                                                                                 )
                                                                                                                                               )
                                                                                                                                             )
@@ -1294,10 +1303,10 @@
                                                                                                                       (case
                                                                                                                         cse-42
                                                                                                                         (lam
-                                                                                                                          l-135
+                                                                                                                          l-134
                                                                                                                           (lam
-                                                                                                                            r-136
-                                                                                                                            r-136
+                                                                                                                            r-135
+                                                                                                                            r-135
                                                                                                                           )
                                                                                                                         )
                                                                                                                       )
@@ -1408,19 +1417,19 @@
                                                                       ]
                                                                     ]
                                                                     (lam
-                                                                      l-137
+                                                                      l-136
                                                                       (lam
-                                                                        r-138
-                                                                        r-138
+                                                                        r-137
+                                                                        r-137
                                                                       )
                                                                     )
                                                                   )
                                                                 ]
                                                               ]
                                                               (lam
-                                                                l-139
+                                                                l-138
                                                                 (lam
-                                                                  r-140 r-140
+                                                                  r-139 r-139
                                                                 )
                                                               )
                                                             )
@@ -1435,23 +1444,23 @@
                                                         a-8
                                                       ]
                                                       (lam
-                                                        l-141 (lam r-142 r-142)
+                                                        l-140 (lam r-141 r-141)
                                                       )
                                                     )
                                                   ]
                                                 )
                                               )
-                                              (lam ds-143 (con unit ()))
+                                              (lam ds-142 (con unit ()))
                                             ]
                                           )
                                           (lam
-                                            range-144
+                                            range-143
                                             [
                                               (lam
-                                                cse-145
+                                                cse-144
                                                 [
                                                   (lam
-                                                    cse-146
+                                                    cse-145
                                                     (case
                                                       [
                                                         [
@@ -1461,17 +1470,17 @@
                                                           (con integer 1)
                                                         ]
                                                         (case
-                                                          cse-146
+                                                          cse-145
                                                           (lam
-                                                            l-147
-                                                            (lam r-148 l-147)
+                                                            l-146
+                                                            (lam r-147 l-146)
                                                           )
                                                         )
                                                       ]
                                                       (error)
                                                       [
                                                         (lam
-                                                          t-149
+                                                          t-148
                                                           (case
                                                             [
                                                               [
@@ -1490,12 +1499,12 @@
                                                                     [
                                                                       forced-0
                                                                       (case
-                                                                        cse-145
+                                                                        cse-144
                                                                         (lam
-                                                                          l-150
+                                                                          l-149
                                                                           (lam
-                                                                            r-151
-                                                                            r-151
+                                                                            r-150
+                                                                            r-150
                                                                           )
                                                                         )
                                                                       )
@@ -1503,9 +1512,9 @@
                                                                   ]
                                                                 ]
                                                                 (lam
-                                                                  l-152
+                                                                  l-151
                                                                   (lam
-                                                                    r-153 l-152
+                                                                    r-152 l-151
                                                                   )
                                                                 )
                                                               )
@@ -1517,9 +1526,9 @@
                                                                 )
                                                                 (con integer 1)
                                                               ]
-                                                              t-149
+                                                              t-148
                                                             ]
-                                                            t-149
+                                                            t-148
                                                           )
                                                         )
                                                         [
@@ -1527,11 +1536,11 @@
                                                           [
                                                             forced-1
                                                             (case
-                                                              cse-146
+                                                              cse-145
                                                               (lam
-                                                                l-154
+                                                                l-153
                                                                 (lam
-                                                                  r-155 r-155
+                                                                  r-154 r-154
                                                                 )
                                                               )
                                                             )
@@ -1545,10 +1554,10 @@
                                                     [
                                                       forced-1
                                                       (case
-                                                        cse-145
+                                                        cse-144
                                                         (lam
-                                                          l-156
-                                                          (lam r-157 r-157)
+                                                          l-155
+                                                          (lam r-156 r-156)
                                                         )
                                                       )
                                                     ]
@@ -1562,10 +1571,10 @@
                                                   (case
                                                     [
                                                       (builtin unConstrData)
-                                                      range-144
+                                                      range-143
                                                     ]
                                                     (lam
-                                                      l-158 (lam r-159 r-159)
+                                                      l-157 (lam r-158 r-158)
                                                     )
                                                   )
                                                 ]
@@ -1575,15 +1584,15 @@
                                         ]
                                       )
                                       (lam
-                                        addr-160
+                                        addr-159
                                         (lam
-                                          signatories-161
+                                          signatories-160
                                           [
                                             (lam
-                                              cse-162
+                                              cse-161
                                               [
                                                 (lam
-                                                  go-163
+                                                  go-162
                                                   (case
                                                     [
                                                       [
@@ -1591,60 +1600,60 @@
                                                         (con integer 0)
                                                       ]
                                                       (case
-                                                        cse-162
+                                                        cse-161
                                                         (lam
-                                                          l-164
-                                                          (lam r-165 l-164)
+                                                          l-163
+                                                          (lam r-164 l-163)
                                                         )
                                                       )
                                                     ]
                                                     (error)
                                                     [
-                                                      go-163
+                                                      go-162
                                                       [
                                                         (builtin unListData)
-                                                        signatories-161
+                                                        signatories-160
                                                       ]
                                                     ]
                                                   )
                                                 )
                                                 [
-                                                  (lam s-166 [ s-166 s-166 ])
+                                                  (lam s-165 [ s-165 s-165 ])
                                                   (lam
-                                                    s-167
+                                                    s-166
                                                     (lam
-                                                      xs-168
+                                                      xs-167
                                                       (case
-                                                        xs-168
+                                                        xs-167
                                                         (lam
-                                                          h-169
+                                                          h-168
                                                           (lam
-                                                            t-170
+                                                            t-169
                                                             (case
                                                               [
                                                                 [
                                                                   (builtin
                                                                     equalsData
                                                                   )
-                                                                  h-169
+                                                                  h-168
                                                                 ]
                                                                 [
                                                                   forced-1
                                                                   (case
-                                                                    cse-162
+                                                                    cse-161
                                                                     (lam
-                                                                      l-171
+                                                                      l-170
                                                                       (lam
-                                                                        r-172
-                                                                        r-172
+                                                                        r-171
+                                                                        r-171
                                                                       )
                                                                     )
                                                                   )
                                                                 ]
                                                               ]
                                                               [
-                                                                [ s-167 s-167 ]
-                                                                t-170
+                                                                [ s-166 s-166 ]
+                                                                t-169
                                                               ]
                                                               (con bool True)
                                                             )
@@ -1664,9 +1673,9 @@
                                                 (case
                                                   [
                                                     (builtin unConstrData)
-                                                    addr-160
+                                                    addr-159
                                                   ]
-                                                  (lam l-173 (lam r-174 r-174))
+                                                  (lam l-172 (lam r-173 r-173))
                                                 )
                                               ]
                                             ]
@@ -1677,7 +1686,7 @@
                                   )
                                   (case
                                     [ (builtin unConstrData) a-7 ]
-                                    (lam l-175 (lam r-176 l-175))
+                                    (lam l-174 (lam r-175 l-174))
                                   )
                                 ]
                               )
@@ -1695,7 +1704,7 @@
               )
               (case
                 [ (builtin unConstrData) ctxData-3 ]
-                (lam l-177 (lam r-178 r-178))
+                (lam l-176 (lam r-177 r-177))
               )
             ]
           )

--- a/submissions/linear_vesting/Plinth_1.65.0.0_Unisay_preview/metadata.json
+++ b/submissions/linear_vesting/Plinth_1.65.0.0_Unisay_preview/metadata.json
@@ -17,10 +17,10 @@
     }
   ],
   "submission": {
-    "date": "2026-07-08T11:39:07Z",
+    "date": "2026-07-08T14:36:30Z",
     "source_available": true,
     "source_repository": "https://github.com/Unisay/plinth-cape-submissions",
-    "source_commit_hash": "6b75b5a3fe1cf56b195cc4222cf939a2812cee78",
-    "implementation_notes": "Compiled with Plinth 1.65.0.0 and BuiltinCasing enabled (preview line; requires plutus-core >= 1.65 \u2014 not yet on mainnet). This build additionally emits the batch-6 `dropList` builtin (van Rossem protocol version) for cursor gaps of three or more fields in the typed decoder, replacing the chained `tailList` induction with a single call whose term size does not grow with the gap; the emission is PREVIEW-gated (same track as BuiltinCasing), so the production build stays byte-identical. Source: `lib/LinearVesting.hs` (+ `lib/Plinth/Decoder.hs`, `lib/Plinth/Decoder/Named.hs`) in plinth-cape-submissions @ 6b75b5a3fe1cf56b195cc4222cf939a2812cee78."
+    "source_commit_hash": "d078652f03d31ed728c1fb63f1d9f8824218494c",
+    "implementation_notes": "Compiled with Plinth 1.65.0.0 and BuiltinCasing enabled (preview line; requires plutus-core >= 1.65 \u2014 not yet on mainnet). Emits the batch-6 `dropList` builtin for cursor gaps of three or more fields in the typed decoder (PREVIEW-gated, so the production build stays byte-identical). This round reads the vesting-token quantity with a bytestring-keyed map lookup (`lookupBytesE`, comparing the unwrapped `CurrencySymbol`/`TokenName` keys with `equalsByteString`) rather than comparing whole `Value` keys with `equalsData`, and re-sweeps the inliner budget for the new shape. total_fee 49805 to 48971 lovelace (-1.7%). Source: lib/LinearVesting.hs (+ `lib/Plinth/Decoder.hs`, `lib/Plinth/Decoder/Named.hs`, `lib/Plinth/Encoded.hs`) in plinth-cape-submissions @ d078652f03d31ed728c1fb63f1d9f8824218494c."
   }
 }

--- a/submissions/linear_vesting/Plinth_1.65.0.0_Unisay_preview/metrics.json
+++ b/submissions/linear_vesting/Plinth_1.65.0.0_Unisay_preview/metrics.json
@@ -1,35 +1,35 @@
 {
   "evaluations": [
     {
-      "cpu_units": 34969841,
+      "cpu_units": 31048617,
       "description": "PartialUnlock at time=11 with 900 tokens remaining should succeed (first installment unlocked)",
       "execution_result": "success",
       "included_in_aggregates": true,
-      "memory_units": 94649,
+      "memory_units": 95741,
       "name": "partial_unlock_first_installment"
     },
     {
-      "cpu_units": 34969841,
+      "cpu_units": 31048617,
       "description": "PartialUnlock at time=50 with 500 tokens remaining should succeed (half vested)",
       "execution_result": "success",
       "included_in_aggregates": true,
-      "memory_units": 94649,
+      "memory_units": 95741,
       "name": "partial_unlock_mid_vesting"
     },
     {
-      "cpu_units": 34969841,
+      "cpu_units": 31048617,
       "description": "PartialUnlock at time=91 with 100 tokens remaining should succeed (9 installments unlocked)",
       "execution_result": "success",
       "included_in_aggregates": true,
-      "memory_units": 94649,
+      "memory_units": 95741,
       "name": "partial_unlock_near_end"
     },
     {
-      "cpu_units": 34969841,
+      "cpu_units": 31048617,
       "description": "PartialUnlock at time=25 with 800 tokens remaining should succeed (between installment boundaries)",
       "execution_result": "success",
       "included_in_aggregates": true,
-      "memory_units": 94649,
+      "memory_units": 95741,
       "name": "partial_unlock_between_installments"
     },
     {
@@ -129,35 +129,35 @@
       "name": "partial_unlock_at_first_unlock"
     },
     {
-      "cpu_units": 24055175,
+      "cpu_units": 22042705,
       "description": "PartialUnlock with 0 tokens remaining in output should fail (must use FullUnlock instead)",
       "execution_result": "success",
       "included_in_aggregates": false,
-      "memory_units": 62612,
+      "memory_units": 62740,
       "name": "partial_unlock_zero_remaining"
     },
     {
-      "cpu_units": 31066807,
+      "cpu_units": 27001583,
       "description": "PartialUnlock with output tokens equal to input (1000) should fail (no tokens actually withdrawn)",
       "execution_result": "success",
       "included_in_aggregates": false,
-      "memory_units": 82924,
+      "memory_units": 83116,
       "name": "partial_unlock_not_decreasing"
     },
     {
-      "cpu_units": 31119140,
+      "cpu_units": 27053916,
       "description": "PartialUnlock at time=11 with 800 tokens remaining should fail (expected minimum 900)",
       "execution_result": "success",
       "included_in_aggregates": false,
-      "memory_units": 82925,
+      "memory_units": 83117,
       "name": "partial_unlock_wrong_remaining_too_low"
     },
     {
-      "cpu_units": 31119140,
+      "cpu_units": 27053916,
       "description": "PartialUnlock at time=11 with 950 tokens remaining should fail (must withdraw at least 1 installment)",
       "execution_result": "success",
       "included_in_aggregates": false,
-      "memory_units": 82925,
+      "memory_units": 83117,
       "name": "partial_unlock_wrong_remaining_too_high"
     },
     {
@@ -177,11 +177,11 @@
       "name": "partial_unlock_datum_missing"
     },
     {
-      "cpu_units": 34986538,
+      "cpu_units": 30921314,
       "description": "PartialUnlock with two script inputs should fail (double satisfaction attack)",
       "execution_result": "success",
       "included_in_aggregates": false,
-      "memory_units": 83476,
+      "memory_units": 83668,
       "name": "partial_unlock_double_satisfaction"
     },
     {
@@ -237,42 +237,42 @@
     "evaluator": "PlutusTx.Eval-1.65.0.0"
   },
   "measurements": {
-    "block_cpu_budget_pct": 0.0874246025,
-    "block_memory_budget_pct": 0.15265967741935482,
+    "block_cpu_budget_pct": 0.0776215425,
+    "block_memory_budget_pct": 0.1544209677419355,
     "cpu_units": {
-      "maximum": 34969841,
-      "median": 34969841,
+      "maximum": 31048617,
+      "median": 31048617,
       "minimum": 8160426,
-      "sum": 156200216
+      "sum": 140515320
     },
     "excluded": {
       "count": 23,
       "cpu_units": {
-        "maximum": 34986538,
-        "sum": 271324168
+        "maximum": 30921314,
+        "sum": 253050802
       },
       "memory_units": {
-        "maximum": 83476,
-        "sum": 735561
+        "maximum": 83668,
+        "sum": 736457
       }
     },
-    "execution_fee_lovelace": 36470,
+    "execution_fee_lovelace": 35591,
     "memory_units": {
-      "maximum": 94649,
-      "median": 94649,
+      "maximum": 95741,
+      "median": 95741,
       "minimum": 29135,
-      "sum": 436866
+      "sum": 441234
     },
-    "reference_script_fee_lovelace": 13335,
-    "script_size_bytes": 889,
-    "scripts_per_block": 655,
-    "scripts_per_tx": 147,
-    "term_size": 896,
-    "total_fee_lovelace": 49805,
-    "tx_cpu_budget_pct": 0.34969841,
-    "tx_memory_budget_pct": 0.6760642857142858
+    "reference_script_fee_lovelace": 13380,
+    "script_size_bytes": 892,
+    "scripts_per_block": 647,
+    "scripts_per_tx": 146,
+    "term_size": 899,
+    "total_fee_lovelace": 48971,
+    "tx_cpu_budget_pct": 0.31048617,
+    "tx_memory_budget_pct": 0.6838642857142857
   },
   "scenario": "linear_vesting",
-  "timestamp": "2026-07-08T11:39:44Z",
+  "timestamp": "2026-07-08T14:37:18Z",
   "version": "2.0.0"
 }

--- a/submissions/linear_vesting/Plinth_1.65.0.0_Unisay_preview/source/README.md
+++ b/submissions/linear_vesting/Plinth_1.65.0.0_Unisay_preview/source/README.md
@@ -4,18 +4,18 @@
 
 **Branch**: `main`
 
-**Commit**: `6b75b5a3fe1cf56b195cc4222cf939a2812cee78`
+**Commit**: `d078652f03d31ed728c1fb63f1d9f8824218494c`
 
-**Path**: `lib/LinearVesting.hs` (decoder DSL: `lib/Plinth/Decoder.hs`, `lib/Plinth/Decoder/Named.hs`)
+**Path**: `lib/LinearVesting.hs` (+ `lib/Plinth/Decoder.hs`, `lib/Plinth/Decoder/Named.hs`, `lib/Plinth/Encoded.hs`)
 
-This submission compiles `lib/LinearVesting.hs` from the Plinth source repository with the Plinth (plutus-tx-plugin) 1.65.0.0 line and the BuiltinCasing preview flag enabled. The preview build also emits the batch-6 `dropList` builtin for cursor gaps of three or more fields in the typed decoder: a single `dropList` call replaces the chained `tailList` steps and its term size does not grow with the gap. `dropList` is only accepted from the van Rossem protocol version, so the emission is gated to the preview build (the production build keeps the pure `tailList` induction and stays byte-identical). Requires `plutus-core >= 1.65.0.0` (not yet on mainnet).
+The preview build of the monadic linear vesting validator: BuiltinCasing plus the dropList decoder step, requiring `plutus-core >= 1.65.0.0` (not yet on mainnet).
 
 ## Reproducing the compilation
 
 ```bash
 git clone https://github.com/Unisay/plinth-cape-submissions
 cd plinth-cape-submissions
-git checkout 6b75b5a3fe1cf56b195cc4222cf939a2812cee78
+git checkout d078652f03d31ed728c1fb63f1d9f8824218494c
 ```
 
 `CAPE_REPO` must point at the sibling UPLC-CAPE checkout; the build aborts if the variable is unset. The recommended place is `.envrc.local` (gitignored), e.g.:
@@ -24,11 +24,9 @@ git checkout 6b75b5a3fe1cf56b195cc4222cf939a2812cee78
 export CAPE_REPO="$HOME/src/UPLC-CAPE"
 ```
 
-Then enter the dev shell and run the generator with the preview flag:
+Then enter the dev shell and run the generator:
 
 ```bash
 nix develop
 cabal run --flags=preview plinth-submissions
 ```
-
-The produced UPLC writes to `$CAPE_REPO/submissions/linear_vesting/Plinth_1.65.0.0_Unisay_preview/linear_vesting.uplc` and matches the UPLC in this submission.

--- a/submissions/linear_vesting/Plinth_1.65.0.0_Unisay_preview/source/README.md
+++ b/submissions/linear_vesting/Plinth_1.65.0.0_Unisay_preview/source/README.md
@@ -30,3 +30,5 @@ Then enter the dev shell and run the generator:
 nix develop
 cabal run --flags=preview plinth-submissions
 ```
+
+The produced UPLC writes to `$CAPE_REPO/submissions/linear_vesting/Plinth_1.65.0.0_Unisay_preview/linear_vesting.uplc` and matches the UPLC in this submission.


### PR DESCRIPTION
Updates the linear_vesting `Plinth_1.65.0.0_Unisay` default and its `Plinth_1.65.0.0_Unisay_preview` counterpart to plinth-cape-submissions `d078652` (current main HEAD). The change reads the vesting-token quantity with a bytestring-keyed map lookup (`lookupBytesE`, comparing the unwrapped `CurrencySymbol` and `TokenName` keys with `equalsByteString`) instead of comparing whole `Value` keys with `equalsData`, and re-sweeps the inliner budget for the new shape.

## Result

Happy-path `total_fee_lovelace`, measured against `scenarios/linear_vesting/cape-tests.json`:

| Submission | old fee | new fee | delta |
|---|---|---|---|
| Plinth_1.65.0.0_Unisay (mainnet, changPV) | 59048 | 58343 | -1.2% |
| Plinth_1.65.0.0_Unisay_preview (van Rossem) | 49805 | 48971 | -1.7% |

The saving is small because the win is on the compare path (`cpu.sum` drops about 7.5% mainnet and 10% preview), which the fee only partly reflects.

## What changed

Both submissions are updated in place: the `.uplc`, `metrics.json`, `metadata.json`, and `source/README.md`. The source pin moves to `d078652`; the compiler (Plinth 1.65.0.0, commit `b2db5126`) is unchanged. The mainnet default keeps its `["Plinth"]` flags, and the preview keeps `["Plinth", "BuiltinCasing"]` with `min_plutus_version = 1.65.0.0` (its preview-only `dropList` decoder step is retained on top of this change). The retained `Plinth_1.65.0.0_Unisay_plain` variant is untouched.

## Source and verification

The mainnet artifact is re-measured with the `measure` evaluator (changPV, PlutusTx.Eval 1.45.0.0); the preview with `measure-preview` (van Rossem / PV11), since the default verifier rejects preview submissions by design. Both keep all 29 expected evaluation outcomes. Both JSON files validate against the repo schemas, and all eight changed files are `treefmt` clean.
