### PR TITLE
report: per-submission breakdown of measurements and checks (#231)

### DIFF
--- a/scripts/cape-subcommands/submission/benchmark.html.tmpl
+++ b/scripts/cape-subcommands/submission/benchmark.html.tmpl
@@ -235,7 +235,6 @@
     <script>
     (function () {
         const BENCHMARK = "{{.benchmark}}";
-        const REPO_MAIN = "https://github.com/IntersectMBO/UPLC-CAPE/blob/main";
 
         // `exceedsBudget` says whether a submission blew the Cardano protocol limit for this metric.
         // Exceeding submissions get a full-width hatched bar; non-exceeding bars are normalised
@@ -310,9 +309,11 @@
             return parts.join("");
         }
 
+        // Link to the per-submission evaluation breakdown page emitted alongside
+        // this scenario page at benchmarks/<scenario>/<submission_dir>.html.
         function submissionLink(sub) {
             if (!sub.submission_dir) return null;
-            return `${REPO_MAIN}/submissions/${BENCHMARK}/${sub.submission_dir}`;
+            return `${encodeURIComponent(BENCHMARK)}/${encodeURIComponent(sub.submission_dir)}.html`;
         }
 
         function sortForMetric(submissions, metric) {
@@ -359,7 +360,7 @@
                 const labelHtml = submissionLabelHtml(sub);
                 const link = submissionLink(sub);
                 const labelCell = link
-                    ? `<a href="${link}" target="_blank" rel="noopener">${labelHtml}</a>`
+                    ? `<a href="${link}" title="Per-evaluation breakdown">${labelHtml}</a>`
                     : labelHtml;
                 const valueEsc = escapeHtml(formatted);
                 const isEmpty = value === 0;
@@ -448,8 +449,8 @@
                 note.textContent =
                     `Aggregates cover expected on-chain evaluations only; ${excluded} ` +
                     `evaluations (failure-path checks and/or pending measurements) are ` +
-                    `measured per submission but excluded — see each submission's ` +
-                    `metrics.json for their cost.`;
+                    `measured per submission but excluded — open a submission's ` +
+                    `breakdown (click its label) for the per-evaluation cost.`;
             }
         }
 

--- a/scripts/cape-subcommands/submission/report.help.tmpl
+++ b/scripts/cape-subcommands/submission/report.help.tmpl
@@ -14,6 +14,9 @@ Options:
 The report includes:
 - Main index page (report/index.html) listing all benchmarks
 - Individual benchmark report pages (report/benchmarks/<benchmark>.html)
+- Per-submission evaluation breakdown pages
+  (report/benchmarks/<benchmark>/<submission_dir>.html), linked from each
+  submission row on the benchmark page
 - 4 PNG chart images per benchmark comparing submissions by:
   - CPU Units: Execution cost in CPU units
   - Memory Units: Memory consumption
@@ -25,6 +28,7 @@ Each submission is labeled as: {language}_{version}_{user}
 Output:
   report/index.html                           # Main index with all benchmarks
   report/benchmarks/<benchmark>.html          # Individual benchmark reports
+  report/benchmarks/<benchmark>/<dir>.html    # Per-submission evaluation breakdowns
   report/benchmarks/images/<benchmark>_*.png  # Chart image files
 
 Examples:

--- a/scripts/cape-subcommands/submission/report.sh
+++ b/scripts/cape-subcommands/submission/report.sh
@@ -139,26 +139,35 @@ fi
 # it, so we fill it eagerly via `aggregate_csv_cache` before entering any loop.
 declare -A AGGREGATE_CSV=()
 
-# Populate AGGREGATE_CSV[<target_filter>] if not already set. Call from the outer
+# Map a target filter to its cache key. The unfiltered case uses an empty
+# filter string, but bash 5.3 rejects an empty associative-array subscript
+# ("bad array subscript"), so fold it to a non-empty sentinel that can't
+# collide with a real target name.
+csv_cache_key() { printf '%s' "${1:-__unfiltered__}"; }
+
+# Populate AGGREGATE_CSV[<key>] if not already set. Call from the outer
 # shell before using fetch_benchmark_csv in a $(...) context.
 aggregate_csv_cache() {
   local target_filter="${1:-}"
-  if [ -n "${AGGREGATE_CSV[$target_filter]+set}" ]; then
+  local key
+  key=$(csv_cache_key "$target_filter")
+  if [ -n "${AGGREGATE_CSV[$key]+set}" ]; then
     return 0
   fi
   local aggregate_args=()
   if [ -n "$target_filter" ]; then
     aggregate_args+=("--target=$target_filter")
   fi
-  AGGREGATE_CSV[$target_filter]=$($CAPE_CMD submission aggregate "${aggregate_args[@]}")
+  AGGREGATE_CSV[$key]=$($CAPE_CMD submission aggregate "${aggregate_args[@]}")
 }
 
 # Fetch CSV rows for one benchmark, dropping template placeholders and rows with empty core metrics.
 fetch_benchmark_csv() {
   local benchmark="$1"
   local target_filter="${2:-}"
-  local csv_data
-  csv_data=$(printf '%s' "${AGGREGATE_CSV[$target_filter]:-}" | grep "^$benchmark," || true)
+  local key csv_data
+  key=$(csv_cache_key "$target_filter")
+  csv_data=$(printf '%s' "${AGGREGATE_CSV[$key]:-}" | grep "^$benchmark," || true)
   if [ -z "$csv_data" ]; then
     return 0
   fi
@@ -322,6 +331,109 @@ EOF
     echo "ERROR: Template rendering failed" >&2
     exit 1
   fi
+}
+
+# Render per-submission evaluation breakdown pages under
+# report/benchmarks/<benchmark>/<submission_dir>.html. Each page lists every
+# evaluation from that submission's metrics.json (measurements = included in
+# aggregates, checks = excluded). The breakdown is read directly from
+# metrics.json rather than the positional aggregate CSV, which can't carry a
+# variable-length evaluation list.
+generate_submission_detail_pages() {
+  local benchmark="$1"
+  local output_dir="$2"
+  local target_filter="${3:-}"
+
+  local csv_data
+  csv_data=$(fetch_benchmark_csv "$benchmark" "$target_filter")
+  [ -n "$csv_data" ] || return 0
+
+  local detail_dir="$output_dir/benchmarks/$benchmark"
+  local abs_template_path="$SCRIPT_DIR/submission-detail.html.tmpl"
+
+  if [[ $DRY_RUN -eq 1 ]]; then
+    log_info "[dry-run] Would render submission detail pages under $detail_dir/"
+    return 0
+  fi
+
+  local ts
+  ts=$(date '+%Y-%m-%d %H:%M:%S %Z')
+  mkdir -p "$detail_dir"
+
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    local language version user variant submission_dir
+    language=$(csv_field "$line" "language")
+    version=$(csv_field "$line" "version")
+    user=$(csv_field "$line" "user")
+    variant=$(csv_field "$line" "variant")
+    submission_dir=$(csv_field "$line" "submission_dir")
+
+    [ -n "$submission_dir" ] || continue
+    local metrics_path="$PROJECT_ROOT/submissions/$benchmark/$submission_dir/metrics.json"
+    if [ ! -f "$metrics_path" ]; then
+      log_warn "metrics.json not found for $benchmark/$submission_dir, skipping detail page"
+      continue
+    fi
+
+    local label="$language $version"
+    if [ -n "$variant" ] && [ "$variant" != "default" ]; then
+      label="$label · $variant"
+    fi
+    label="$label · $user"
+
+    local source_url="https://github.com/IntersectMBO/UPLC-CAPE/blob/main/submissions/$benchmark/$submission_dir"
+
+    local temp_json
+    temp_json=$(mktemp_json)
+    jq \
+      --arg benchmark "$benchmark" \
+      --arg submission_dir "$submission_dir" \
+      --arg label "$label" \
+      --arg compiler "$language" \
+      --arg version "$version" \
+      --arg variant "$variant" \
+      --arg user "$user" \
+      --arg source_url "$source_url" \
+      --arg timestamp "$ts" \
+      '
+      def commafy:
+        (tostring | explode | reverse) as $rev
+        | [range(0; ($rev | length)) as $i
+           | (($rev[$i:$i+1]) | implode)
+             + (if ($i > 0 and ($i % 3 == 0)) then "," else "" end)]
+        | reverse | join("");
+      def row: {
+        name, description, execution_result,
+        cpu_units, memory_units,
+        cpu_fmt: (.cpu_units | commafy),
+        mem_fmt: (.memory_units | commafy)
+      };
+      (.evaluations // []) as $evals
+      | ($evals | map(select(.included_in_aggregates))       | map(row)) as $measurements
+      | ($evals | map(select(.included_in_aggregates | not)) | map(row)) as $checks
+      | {
+          benchmark: $benchmark,
+          submission_dir: $submission_dir,
+          label: $label,
+          compiler: $compiler,
+          version: $version,
+          variant: $variant,
+          user: $user,
+          source_url: $source_url,
+          timestamp: $timestamp,
+          measurements: $measurements,
+          checks: $checks,
+          measurements_count: ($measurements | length),
+          checks_count: ($checks | length)
+        }
+      ' "$metrics_path" > "$temp_json"
+
+    if ! gomplate -f "$abs_template_path" -c .="$temp_json" > "$detail_dir/${submission_dir}.html"; then
+      echo "ERROR: Submission detail template rendering failed for $benchmark/$submission_dir" >&2
+      exit 1
+    fi
+  done <<< "$csv_data"
 }
 
 # Build filtered benchmark stats from CSV data (consumed by index.html.tmpl).
@@ -591,6 +703,10 @@ generate_index_report() {
 EOF
 
   local first=true
+  # `benchmark` is localized so this loop doesn't clobber the caller's
+  # `benchmark` variable (the single-benchmark entry point reads it after
+  # this returns, for its success messages).
+  local benchmark
   while read -r benchmark; do
     if [ -n "$benchmark" ]; then
       if [ "$first" = "false" ]; then
@@ -860,6 +976,8 @@ if [ "$1" = "--all" ]; then
         generate_individual_benchmark_report "$benchmark" "$report_dir"
       fi
 
+      generate_submission_detail_pages "$benchmark" "$report_dir" "current"
+
       if [ -n "$benchmarks_with_submissions" ]; then
         benchmarks_with_submissions="${benchmarks_with_submissions}\n"
       fi
@@ -877,6 +995,7 @@ if [ "$1" = "--all" ]; then
     echo "   📄 $report_dir/index.html (main index)"
     echo "   📊 Individual benchmark reports in $report_dir/benchmarks/"
     echo "   📦 Benchmark data JSON in $report_dir/benchmarks/<scenario>.json"
+    echo "   🔍 Per-submission breakdowns in $report_dir/benchmarks/<scenario>/<submission_dir>.html"
   else
     echo "Error: No submissions found for report generation" >&2
     exit 1
@@ -960,6 +1079,7 @@ else
     fi
 
     generate_individual_benchmark_report "$benchmark" "$report_dir"
+    generate_submission_detail_pages "$benchmark" "$report_dir"
   else
     echo "No submissions found for benchmark: $benchmark. Creating placeholder page."
     generate_no_submissions_report "$benchmark" "$report_dir"
@@ -971,6 +1091,7 @@ else
   echo "   📄 $report_dir/index.html (main index)"
   echo "   📊 Individual benchmark report: $report_dir/benchmarks/${benchmark}.html"
   echo "   📦 Benchmark data JSON: $report_dir/benchmarks/${benchmark}.json"
+  echo "   🔍 Per-submission breakdowns: $report_dir/benchmarks/${benchmark}/<submission_dir>.html"
   echo ""
   echo "Open the main report with: xdg-open $report_dir/index.html 2>/dev/null || echo \"Open: $report_dir/index.html\""
 fi

--- a/scripts/cape-subcommands/submission/report.sh
+++ b/scripts/cape-subcommands/submission/report.sh
@@ -403,8 +403,16 @@ generate_submission_detail_pages() {
            | (($rev[$i:$i+1]) | implode)
              + (if ($i > 0 and ($i % 3 == 0)) then "," else "" end)]
         | reverse | join("");
+      # gomplate renders *.html.tmpl with Go text/template (no auto-escaping),
+      # so every interpolated string must be HTML-escaped here. Free-form
+      # fields like an evaluation description can legitimately contain < > &.
+      def esc:
+        gsub("&"; "&amp;") | gsub("<"; "&lt;") | gsub(">"; "&gt;")
+        | gsub("\""; "&quot;") | gsub("'"'"'"; "&#39;");
       def row: {
-        name, description, execution_result,
+        name: (.name | esc),
+        description: (.description | esc),
+        execution_result: (.execution_result | esc),
         cpu_units, memory_units,
         cpu_fmt: (.cpu_units | commafy),
         mem_fmt: (.memory_units | commafy)
@@ -413,15 +421,15 @@ generate_submission_detail_pages() {
       | ($evals | map(select(.included_in_aggregates))       | map(row)) as $measurements
       | ($evals | map(select(.included_in_aggregates | not)) | map(row)) as $checks
       | {
-          benchmark: $benchmark,
-          submission_dir: $submission_dir,
-          label: $label,
-          compiler: $compiler,
-          version: $version,
-          variant: $variant,
-          user: $user,
-          source_url: $source_url,
-          timestamp: $timestamp,
+          benchmark: ($benchmark | esc),
+          submission_dir: ($submission_dir | esc),
+          label: ($label | esc),
+          compiler: ($compiler | esc),
+          version: ($version | esc),
+          variant: ($variant | esc),
+          user: ($user | esc),
+          source_url: ($source_url | esc),
+          timestamp: ($timestamp | esc),
           measurements: $measurements,
           checks: $checks,
           measurements_count: ($measurements | length),

--- a/scripts/cape-subcommands/submission/submission-detail.html.tmpl
+++ b/scripts/cape-subcommands/submission/submission-detail.html.tmpl
@@ -1,0 +1,243 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>UPLC-CAPE — {{.benchmark}} — {{.label}}</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fontsource/iosevka@5/400.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fontsource/iosevka@5/700.css">
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            line-height: 1.6;
+            color: #333;
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 20px;
+            background-color: #f8f9fa;
+        }
+        .header {
+            margin-bottom: 40px;
+            padding: 20px 0;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 20px;
+        }
+        .header img { width: 150px; height: auto; flex-shrink: 0; }
+        .header-text { flex-grow: 0; }
+        .header h1 { color: #333; margin: 0 0 10px 0; }
+        .header p { color: #6c757d; margin: 5px 0; }
+
+        .breadcrumb { color: #6c757d; font-size: 0.9em; margin-top: 10px; }
+        .breadcrumb a { color: #667eea; text-decoration: none; }
+        .breadcrumb a:hover { text-decoration: underline; }
+        .breadcrumb-separator { margin: 0 8px; }
+
+        .benchmark-section {
+            background: white;
+            margin-bottom: 40px;
+            padding: 30px;
+            border-radius: 10px;
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+        }
+        .benchmark-title {
+            color: #667eea;
+            border-bottom: 3px solid #667eea;
+            padding-bottom: 10px;
+            margin-bottom: 8px;
+        }
+        .submission-meta {
+            color: #6c757d;
+            font-size: 0.9em;
+            margin-bottom: 4px;
+        }
+        .submission-meta a { color: #667eea; text-decoration: none; }
+        .submission-meta a:hover { text-decoration: underline; }
+
+        .section-lead {
+            color: #6c757d;
+            font-size: 0.9em;
+            margin: 24px 0 20px 0;
+        }
+
+        .eval-group { margin-top: 28px; }
+        .eval-group:first-of-type { margin-top: 12px; }
+        .eval-group h3 {
+            font-size: 1.05em;
+            margin: 0 0 4px 0;
+            display: flex;
+            align-items: baseline;
+            gap: 10px;
+        }
+        .eval-group .group-count {
+            font-size: 0.8em;
+            font-weight: 400;
+            color: #6c757d;
+        }
+        .eval-group .group-note {
+            color: #8a94a3;
+            font-size: 0.85em;
+            margin: 0 0 12px 0;
+        }
+        .badge {
+            display: inline-block;
+            font-size: 0.7em;
+            font-weight: 700;
+            text-transform: uppercase;
+            letter-spacing: 0.04em;
+            padding: 2px 8px;
+            border-radius: 10px;
+            vertical-align: middle;
+        }
+        .badge-included { background: #e6f4ea; color: #1e7e34; }
+        .badge-excluded { background: #f1f3f5; color: #6c757d; }
+
+        .eval-table {
+            width: 100%;
+            border-collapse: collapse;
+            font-size: 0.9em;
+        }
+        .eval-table th {
+            text-align: left;
+            padding: 8px 10px;
+            border-bottom: 2px solid #e9ecef;
+            color: #495057;
+            font-weight: 600;
+            font-size: 0.85em;
+        }
+        .eval-table th.num, .eval-table td.num {
+            text-align: right;
+            font-family: 'Iosevka', ui-monospace, SFMono-Regular, Menlo, monospace;
+            white-space: nowrap;
+        }
+        .eval-table td {
+            padding: 8px 10px;
+            border-bottom: 1px solid #f0f0f0;
+            vertical-align: top;
+        }
+        .eval-table tr:hover { background-color: #f8f9fa; }
+        .eval-name {
+            font-family: 'Iosevka', ui-monospace, SFMono-Regular, Menlo, monospace;
+            font-weight: 700;
+            color: #212529;
+        }
+        .eval-desc { color: #6c757d; font-size: 0.9em; }
+        .eval-result { font-size: 0.85em; color: #6c757d; white-space: nowrap; }
+        .eval-result.error { color: #b02a37; }
+        .eval-group.excluded .eval-name { color: #495057; font-weight: 400; }
+
+        .empty-note { color: #8a94a3; font-size: 0.9em; font-style: italic; }
+
+        .footer {
+            text-align: center;
+            margin-top: 50px;
+            padding: 20px;
+            color: #6c757d;
+            border-top: 1px solid #e9ecef;
+        }
+        .timestamp { font-style: italic; color: #6c757d; margin-bottom: 20px; }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <img src="../../uplc-cape-logo.png" alt="UPLC-CAPE Logo">
+        <div class="header-text">
+            <h1>UPLC-CAPE Performance Report</h1>
+            <p>Per-submission evaluation breakdown</p>
+            <div class="breadcrumb">
+                <a href="../../index.html">All benchmarks</a>
+                <span class="breadcrumb-separator">→</span>
+                <a href="../{{.benchmark}}.html">{{.benchmark}}</a>
+                <span class="breadcrumb-separator">→</span>
+                <span>{{.label}}</span>
+            </div>
+        </div>
+    </div>
+
+    <div class="benchmark-section">
+        <h2 class="benchmark-title">📊 {{.label}}</h2>
+        <div class="submission-meta">{{.benchmark}} benchmark · <code>{{.submission_dir}}</code></div>
+        <div class="submission-meta"><a href="{{.source_url}}" target="_blank" rel="noopener">View source on GitHub ↗</a></div>
+
+        <p class="section-lead">Every evaluation measured for this submission, with its stored CPU and memory units. Measurements feed the aggregate bars on the scenario page; checks (failure-path and pending evaluations) are measured but excluded from the aggregates.</p>
+
+        <div class="eval-group included">
+            <h3>Measurements <span class="badge badge-included">included in aggregates</span> <span class="group-count">{{.measurements_count}}</span></h3>
+            <p class="group-note">Expected on-chain evaluations that feed this submission's aggregate metrics.</p>
+            {{ if .measurements }}
+            <table class="eval-table">
+                <thead>
+                    <tr>
+                        <th>Evaluation</th>
+                        <th>Result</th>
+                        <th class="num">CPU units</th>
+                        <th class="num">Memory units</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {{ range .measurements }}
+                    <tr>
+                        <td>
+                            <div class="eval-name">{{.name}}</div>
+                            <div class="eval-desc">{{.description}}</div>
+                        </td>
+                        <td><span class="eval-result{{ if eq .execution_result "error" }} error{{ end }}">{{.execution_result}}</span></td>
+                        <td class="num">{{.cpu_fmt}}</td>
+                        <td class="num">{{.mem_fmt}}</td>
+                    </tr>
+                    {{ end }}
+                </tbody>
+            </table>
+            {{ else }}
+            <p class="empty-note">No measurements feed the aggregates for this submission.</p>
+            {{ end }}
+        </div>
+
+        <div class="eval-group excluded">
+            <h3>Checks <span class="badge badge-excluded">excluded from aggregates</span> <span class="group-count">{{.checks_count}}</span></h3>
+            <p class="group-note">Failure-path checks and any pending measurements. Their cost is recorded here but does not enter the aggregates.</p>
+            {{ if .checks }}
+            <table class="eval-table">
+                <thead>
+                    <tr>
+                        <th>Evaluation</th>
+                        <th>Result</th>
+                        <th class="num">CPU units</th>
+                        <th class="num">Memory units</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {{ range .checks }}
+                    <tr>
+                        <td>
+                            <div class="eval-name">{{.name}}</div>
+                            <div class="eval-desc">{{.description}}</div>
+                        </td>
+                        <td><span class="eval-result{{ if eq .execution_result "error" }} error{{ end }}">{{.execution_result}}</span></td>
+                        <td class="num">{{.cpu_fmt}}</td>
+                        <td class="num">{{.mem_fmt}}</td>
+                    </tr>
+                    {{ end }}
+                </tbody>
+            </table>
+            {{ else }}
+            <p class="empty-note">No excluded evaluations for this submission.</p>
+            {{ end }}
+        </div>
+    </div>
+
+    <div class="breadcrumb">
+        <a href="../../index.html">All benchmarks</a>
+        <span class="breadcrumb-separator">→</span>
+        <a href="../{{.benchmark}}.html">{{.benchmark}}</a>
+        <span class="breadcrumb-separator">→</span>
+        <span>{{.label}}</span>
+    </div>
+
+    <div class="footer">
+        <p>Generated by UPLC-CAPE • <a href="https://github.com/IntersectMBO/UPLC-CAPE">View on GitHub</a></p>
+        <p class="timestamp">Generated on: {{.timestamp}}</p>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
Closes #231.

## What

Each submission now has its own detail page at `report/benchmarks/<scenario>/<submission_dir>.html`, reachable from its row on the scenario page. The page lists every evaluation from that submission's `metrics.json`, split into two visually distinct sections — **Measurements** (`included_in_aggregates: true`) and **Checks** (excluded) — each row showing the evaluation name, description, execution result, and its stored `cpu_units` and `memory_units`. The number of excluded rows reconciles with the scenario page's footnote count.

The scenario (aggregate) page stays a light comparison view: it embeds no per-evaluation data and only links out to the detail pages, so its weight does not grow with the number of evaluations. The submission-row label — previously linking to the GitHub source — now opens the detail page; the "View source on GitHub" link moves onto the detail page, and the footnote now points readers at the breakdown ("click its label") instead of the raw `metrics.json`.

Detail pages are rendered server-side with `gomplate`, reading each submission's `evaluations[]` directly from `metrics.json`. The positional aggregate CSV that feeds the scenario page can't carry a variable-length evaluation list, so the detail generator reads `metrics.json` directly. No re-measuring and no new metric fields.

## Files

- `submission-detail.html.tmpl` — new per-submission detail template (server-rendered table, two sections).
- `report.sh` — new `generate_submission_detail_pages`, wired into both the `--all` and single-benchmark entry points.
- `benchmark.html.tmpl` — row label links to the detail page; GitHub source link and footnote wording updated; dead `REPO_MAIN` constant removed.
- `report.help.tmpl` — documents the new output.

## Drive-by fix

The single-benchmark path (`cape submission report <benchmark>`) aborted on bash 5.3 with `bad array subscript`: the unfiltered aggregate cache used an empty associative-array key, which bash 5.3 rejects outright. It is now folded to a non-empty sentinel key. Also localized the loop variable in `generate_index_report` so it no longer clobbers the caller's benchmark name in the final success messages.

## Verification

Rendered `report --all` and `report htlc`; opened the pages over a local HTTP server and confirmed: submission-row labels navigate to the detail pages, the detail page shows 4 measurements + 21 checks for `htlc/Plinth_1.65.0.0_Unisay` (21 matches `excluded_count` and the footnote), numbers are right-aligned and thousands-separated, empty sections degrade gracefully, and the two sections are clearly distinguished by badge colour. `shfmt` (via `treefmt`) reports no changes.

> Note: `report/` is gitignored and regenerated by CI, so this PR contains only pipeline and template changes.