### PR TITLE
ci: deploy PR preview for report-pipeline changes too

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -141,13 +141,17 @@ jobs:
           # the report pipeline itself (generator, aggregate, templates) change.
           # A pipeline-only PR produces no submission diff but can still change
           # every rendered page, so it must be previewable too.
+          # Fetch the base ref first: fetch-depth:0 does not guarantee a local
+          # origin/main, so the diff below would otherwise hit an ambiguous
+          # revision (same reason the `changed` job fetches it explicitly).
+          git fetch origin main --depth=1
           if git diff --name-only origin/main...HEAD | grep -qE \
             'submissions/.*(\.uplc|/metadata\.json)$|scripts/cape-subcommands/submission/(report|aggregate)\.sh$|scripts/cape-subcommands/submission/.*\.html\.tmpl$'; then
             echo "Report inputs or pipeline changed, proceeding with report generation"
-            echo "has_changes=true" >> $GITHUB_OUTPUT
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
           else
-            echo "No submission-data or report-pipeline changes detected (only docs/README), skipping deployment"
-            echo "has_changes=false" >> $GITHUB_OUTPUT
+            echo "No report-affecting changes detected, skipping preview deployment"
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Install Nix

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -134,15 +134,19 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Check if submission data changed
+      - name: Check if the preview needs rebuilding
         id: check_changes
         run: |
-          # Check if .uplc or metadata.json files changed compared to main
-          if git diff --name-only origin/main...HEAD | grep -qE 'submissions/.*\.(uplc|metadata\.json)$'; then
-            echo "Submission data files changed, proceeding with report generation"
+          # Deploy a preview when either the report inputs (submission data) or
+          # the report pipeline itself (generator, aggregate, templates) change.
+          # A pipeline-only PR produces no submission diff but can still change
+          # every rendered page, so it must be previewable too.
+          if git diff --name-only origin/main...HEAD | grep -qE \
+            'submissions/.*(\.uplc|/metadata\.json)$|scripts/cape-subcommands/submission/(report|aggregate)\.sh$|scripts/cape-subcommands/submission/.*\.html\.tmpl$'; then
+            echo "Report inputs or pipeline changed, proceeding with report generation"
             echo "has_changes=true" >> $GITHUB_OUTPUT
           else
-            echo "No submission data changes detected (only docs/README), skipping deployment"
+            echo "No submission-data or report-pipeline changes detected (only docs/README), skipping deployment"
             echo "has_changes=false" >> $GITHUB_OUTPUT
           fi
 


### PR DESCRIPTION
## Problem

The `Deploy PR Preview` job in `pr-ci.yml` rebuilds and deploys the report only when its `check_changes` step sees a submission-data diff. Its matcher was:

```
submissions/.*\.(uplc|metadata\.json)$
```

Two consequences:

1. A PR that touches only the **report pipeline** (the generator `report.sh`, the `aggregate.sh` step, or the `*.html.tmpl` templates) produces no submission diff, so `has_changes=false` and the whole build+deploy is skipped — no hosted preview. That is exactly the kind of change where a visual preview matters most. (Surfaced while reviewing #239, whose green CI produced a `404` at `pr-239/`.)
2. The pattern never actually matched `metadata.json`. `.*\.(…|metadata\.json)` requires a literal `.` immediately before `metadata`, but the file is preceded by `/` (`.../<dir>/metadata.json`), so a `metadata.json`-only change never triggered a preview either — contrary to the step's own comment ("`.uplc` or `metadata.json`").

## Change

Widen and correct the matcher:

```
submissions/.*(\.uplc|/metadata\.json)$|scripts/cape-subcommands/submission/(report|aggregate)\.sh$|scripts/cape-subcommands/submission/.*\.html\.tmpl$
```

- `metadata.json` now matches (regrouped so the alternation carries its own leading separator).
- Report-pipeline files now trigger a preview.
- Unchanged: `metrics.json` (regenerated by the measure step) and docs/README still do **not** trigger, so docs-only PRs stay cheap.

## Cost note

A report-pipeline PR now runs the full `measure --all` + `measure --preview` + `report --all` + deploy path, same as a submission-data PR. That is the intended tradeoff: a pipeline change that can alter every page should be previewable.

Verified the regex against representative paths (`.uplc`, `metadata.json`, `metrics.json`, `report.sh`, `aggregate.sh`, `*.html.tmpl`, `measure.sh`, `README.md`) and confirmed prettier (via `treefmt`) reports no formatting changes.