### PR TITLE
submissions(two_party_escrow): re-pin asData variant to c663b17 (name-only)

### DIFF
--- a/submissions/two_party_escrow/Plinth_1.65.0.0_Unisay_asdata/metadata.json
+++ b/submissions/two_party_escrow/Plinth_1.65.0.0_Unisay_asdata/metadata.json
@@ -16,10 +16,10 @@
     }
   ],
   "submission": {
-    "date": "2026-07-06T17:43:54Z",
+    "date": "2026-07-10T09:10:38Z",
     "source_available": true,
     "source_repository": "https://github.com/Unisay/plinth-cape-submissions",
-    "source_commit_hash": "4b3215042c1ccd481b5f62ad192d23b0e1f96758",
-    "implementation_notes": "Two-party escrow validator compiled with Plinth 1.65.0.0 (production line; no BuiltinCasing). Source: lib/TwoPartyEscrow/AsData.hs in plinth-cape-submissions @ 4b3215042c1ccd481b5f62ad192d23b0e1f96758."
+    "source_commit_hash": "c663b170bb2148a20072d8400b8679c03c11de4c",
+    "implementation_notes": "Two-party escrow validator compiled with Plinth 1.65.0.0 (production line; no BuiltinCasing). Source: lib/TwoPartyEscrow/AsData.hs in plinth-cape-submissions @ c663b170bb2148a20072d8400b8679c03c11de4c. The by-name decoder layout is now derived from the type; the datum type was renamed to bare Datum, which changes only pretty-printed instance-binder names in the UPLC (serialized program, metrics, and evaluation outcomes are unchanged)."
   }
 }

--- a/submissions/two_party_escrow/Plinth_1.65.0.0_Unisay_asdata/source/README.md
+++ b/submissions/two_party_escrow/Plinth_1.65.0.0_Unisay_asdata/source/README.md
@@ -4,7 +4,7 @@
 
 **Branch**: `main`
 
-**Commit**: `4b3215042c1ccd481b5f62ad192d23b0e1f96758`
+**Commit**: `c663b170bb2148a20072d8400b8679c03c11de4c`
 
 **Path**: `lib/TwoPartyEscrow/AsData.hs`
 
@@ -17,7 +17,7 @@ Production line with Plinth 1.65.0.0 (no BuiltinCasing). Plugin pragmas live in 
 ```bash
 git clone https://github.com/Unisay/plinth-cape-submissions
 cd plinth-cape-submissions
-git checkout 4b3215042c1ccd481b5f62ad192d23b0e1f96758
+git checkout c663b170bb2148a20072d8400b8679c03c11de4c
 ```
 
 `CAPE_REPO` must point at the sibling UPLC-CAPE checkout; the build aborts if the variable is unset. The recommended place is `.envrc.local` (gitignored), e.g.:

--- a/submissions/two_party_escrow/Plinth_1.65.0.0_Unisay_asdata/two_party_escrow.uplc
+++ b/submissions/two_party_escrow/Plinth_1.65.0.0_Unisay_asdata/two_party_escrow.uplc
@@ -98,7 +98,7 @@
                                                                                                                 txInfoValidRange-30
                                                                                                                 [
                                                                                                                   (lam
-                                                                                                                    `$fUnsafeFromDataEscrowDatum_$cunsafeFromBuiltinData`-31
+                                                                                                                    `$fUnsafeFromDataDatum_$cunsafeFromBuiltinData`-31
                                                                                                                     [
                                                                                                                       (lam
                                                                                                                         scriptContextTxInfo-32
@@ -316,7 +316,7 @@
                                                                                                                                                                                                               nt-40
                                                                                                                                                                                                               (case
                                                                                                                                                                                                                 [
-                                                                                                                                                                                                                  `$fUnsafeFromDataEscrowDatum_$cunsafeFromBuiltinData`-31
+                                                                                                                                                                                                                  `$fUnsafeFromDataDatum_$cunsafeFromBuiltinData`-31
                                                                                                                                                                                                                   [
                                                                                                                                                                                                                     forced-5
                                                                                                                                                                                                                     [
@@ -1407,7 +1407,7 @@
                                                                                                                                                       (lam
                                                                                                                                                         datum-92
                                                                                                                                                         [
-                                                                                                                                                          `$fUnsafeFromDataEscrowDatum_$cunsafeFromBuiltinData`-31
+                                                                                                                                                          `$fUnsafeFromDataDatum_$cunsafeFromBuiltinData`-31
                                                                                                                                                           datum-92
                                                                                                                                                         ]
                                                                                                                                                       )


### PR DESCRIPTION
Refreshes `submissions/two_party_escrow/Plinth_1.65.0.0_Unisay_asdata` from `plinth-cape-submissions` `c663b17`, which merged the "derive the by-name decoder layout from the type" change. That commit swaps the hand-written `Decoder.Named` `FieldAt` tag types for a Template Haskell deriver and renames the escrow datum type to a bare `Datum`.

For this submission the effect is text only. The datum rename survives into one instance-binder name in the pretty-printed UPLC, `$fUnsafeFromDataEscrowDatum_$cunsafeFromBuiltinData` becomes `$fUnsafeFromDataDatum_$cunsafeFromBuiltinData`, on three lines. The serialized program is name-independent, so script size, fee, CPU, memory, and every evaluation outcome stay exactly the same. `metrics.json` is therefore left untouched.

## Verification

I rebuilt the artifact independently from `c663b17` (`cabal run plinth-submissions`, the documented default) rather than copying it:

- Rebuilt `.uplc` md5 `b3d22af3eb39db4d9cea8d3f8986b4ae` (was `a12c552da685e54a0e0412da50dc21d6`).
- Diff against the committed artifact is exactly three lines, all the binder rename above.
- `cape submission measure` on the mainnet changPV evaluator reproduces the committed metrics unchanged: fee 311093 lovelace, script size 2558 bytes, term size 2188, 47/47 evaluations pass.
- As a toolchain cross-check, the same build reproduces the committed mainnet `two_party_escrow`, `htlc`, and `linear_vesting` artifacts byte for byte.

## Changes

- `two_party_escrow.uplc`: three instance-binder name lines.
- `metadata.json`: `source_commit_hash` `4b321504` to `c663b17`, with a note on the name-only nature of the change.
- `source/README.md`: commit reference and checkout command bumped to `c663b17`.
- `metrics.json`: unchanged.
